### PR TITLE
Feature: Added support for PrismLauncher forks, notably FreesmLauncher

### DIFF
--- a/prismlauncher-instances/plugin.toml
+++ b/prismlauncher-instances/plugin.toml
@@ -1,13 +1,13 @@
 id = "radimous/prismlauncher-instances"
 name = "PrismLauncher Instances"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 3
 author = "radimous"
 license = "MIT"
 dependencies = ["prismlauncher"]
 icon = "nut"
 deprecated = false
-description = "A launcher provider that adds PrismLauncher instances to the noctalia launcher."
+description = "A launcher provider that adds PrismLauncher and PrismLauncher fork instances to the noctalia launcher."
 tags = ["gaming", "launcher"]
 
 [[launcher_provider]]
@@ -24,3 +24,10 @@ type = "string"
 label_key = "settings.prismlauncher_path.label"
 description_key = "settings.prismlauncher_path.description"
 default = "~/.local/share/PrismLauncher"
+
+[[setting]]
+key = "launcher_exec_command"
+type = "string"
+label_key = "settings.launcher_exec_command.label"
+description_key = "settings.launcher_exec_command.description"
+default = "prismlauncher"

--- a/prismlauncher-instances/prismlauncher-instances.luau
+++ b/prismlauncher-instances/prismlauncher-instances.luau
@@ -5,10 +5,15 @@ local function getPrismPath()
     return noctalia.expandPath(prismPath)
 end
 
+local function getLauncherCommand()
+    local launcherCommand = noctalia.getConfig("launcher_exec_command")
+    return noctalia.expandPath(launcherCommand)
+end
+
 local function getInstancesDir()
     local prismPath = getPrismPath()
 
-    local configuredInstanceDir = getCfgValue(prismPath .. "/prismlauncher.cfg", "InstanceDir")
+    local configuredInstanceDir = getCfgValue(prismPath .. "/*.cfg", "InstanceDir")
 
     local instances
     if configuredInstanceDir == nil then -- default path
@@ -91,8 +96,10 @@ local function shellQuote(s)
 end
 
 function onActivate(id)
+  local launcherCommand = getLauncherCommand()
+
   if id == "" then return end
-  noctalia.runAsync(string.format("prismlauncher --launch %s &>/dev/null", shellQuote(id)))
+  noctalia.runAsync(string.format(launcherCommand .. " --launch %s &>/dev/null", shellQuote(id)))
 end
 
 -- doesn't handle icons that were changed to different default icon, rest is fine

--- a/prismlauncher-instances/translations/en.json
+++ b/prismlauncher-instances/translations/en.json
@@ -3,6 +3,10 @@
     "prismlauncher_path": {
       "label": "PrismLauncher path",
       "description": "Path to PrismLauncher"
+    },
+    "launcher_exec_command": {
+      "label": "Prism Executable",
+      "description": "Start Prismlauncher or fork of choice"
     }
   },
   "no_instances": {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `radimous/prismlauncher-instances` @radimous 
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Adds support for PrismLauncher forks, assumes that the fork of choice provides a .cfg file in the provided path (for example: ~/.local/share/FreesmLauncher has a freesmlauncher.cfg)
User can provide an executable argument in plugin settings, this allows `prismlauncher` to be set as the default to keep functionality for existing plugin users

## External dependencies
prismlauncher fork of choice (e.g. freesmlauncher)
<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 
3

Tested on FreesmLauncher by 2 people

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
<img width="573" height="513" alt="image" src="https://github.com/user-attachments/assets/d76b81f4-fbcf-4c3b-8f57-9a54cc902043" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
