### PR TITLE
Update nightwatch75/file-search to 0.0.10 — recheck settings fingerprint after launcher index build (#26 follow-up)

### DIFF
--- a/file-search/launcher.luau
+++ b/file-search/launcher.luau
@@ -155,7 +155,15 @@ local function buildIndex(query)
         local queued = pendingQuery
         pendingQuery = nil
         if result.exitCode == 0 and not result.timedOut then
-            runQuery(queued or query)
+            if indexKey() ~= key then
+                -- Settings changed while the walk was running: the cache
+                -- holds paths relative to the old root, and activation
+                -- would join them to the new one. Rebuild instead of
+                -- searching stale records (mirrors the panel).
+                buildIndex(queued or query)
+            else
+                runQuery(queued or query)
+            end
         else
             launcher.setResults(queued or query, { noopRow("err_index") })
         end

--- a/file-search/plugin.toml
+++ b/file-search/plugin.toml
@@ -6,7 +6,7 @@
 
 id = "nightwatch75/file-search"
 name = "File Search"
-version = "0.0.9"
+version = "0.0.10"
 plugin_api = 3
 author = "nightwatch75"
 license = "MIT"


### PR DESCRIPTION
## What it is

Maintenance update of `nightwatch75/file-search` from 0.0.9 to **0.0.10**, addressing the non-blocking note left on #26 at merge time.

## The fix

The launcher's `buildIndex` captured the root+exclusions fingerprint at build start, but its completion callback ran the query without confirming the settings still matched — during the up-to-180 s walk they may have changed, so the launcher could search relative paths from the old root while activation joined them to the current one, potentially opening an unrelated same-named entry.

The completion callback now mirrors the post-build fingerprint check the panel already had: if `indexKey()` no longer matches the captured key, the index is rebuilt against the new settings (re-showing the *Indexing…* row) instead of searching stale records.

## Scope

- `launcher.luau`: post-build fingerprint recheck (the queued query is carried into the rebuild).
- `plugin.toml`: version bump to 0.0.10.
- No other changes: spawned commands, dependencies, filesystem/network behavior, README and settings are identical to the merged 0.0.9.
