### PR TITLE
Web launcher plugin update

### DIFF
--- a/web-launcher/README.md
+++ b/web-launcher/README.md
@@ -12,7 +12,7 @@ Quickly open your favorite websites from the launcher. Favicons are downloaded a
 
 ## Requirements
 
-A browser and `xdg-utils`.
+A browser and `xdg-utils` (optional with advanced command setting).
 
 ## Usage
 
@@ -27,6 +27,7 @@ You can customize the list and order of websites in settings.
 | `links` | `string_list` | `see below` | Websites list and order. |
 | `notify` | `bool` | `true` | Toggle notification when launching website. |
 | `icon_provider` | `select` | `google` | Icon download source. |
+| `command` | `string` | `xdg-open` | Command that launches the website. |
 
 Default links:
 ```

--- a/web-launcher/launcher.luau
+++ b/web-launcher/launcher.luau
@@ -72,8 +72,7 @@ local function downloadFavicon(domain, onDone)
     end)
 end
 
-function onQuery(query)
-    local text = noctalia.string.trim(query)
+local function makeResults(text, query)
     local results = {}
 
     for _, link in ipairs(links) do
@@ -85,7 +84,9 @@ function onQuery(query)
         local iconValue = hasIcon and iconPath or nil
 
         if not hasIcon then
-            downloadFavicon(domain, function() end)
+            downloadFavicon(domain, function()
+                launcher.setResults(query, makeResults(text, query))
+            end)
         end
 
         if text == "" then
@@ -107,7 +108,12 @@ function onQuery(query)
         end
     end
 
-    launcher.setResults(query, results)
+    return results
+end
+
+function onQuery(query)
+    local text = noctalia.string.trim(query)
+    launcher.setResults(query, makeResults(text, query))
 end
 
 local function shellEscape(raw)

--- a/web-launcher/launcher.luau
+++ b/web-launcher/launcher.luau
@@ -122,6 +122,9 @@ end
 
 function onActivate(id)
     local command = noctalia.getConfig("command")
+    if not command or command == "" then
+        command = "xdg-open"
+    end
     noctalia.runAsync(command .. " " .. shellEscape(id))
 
     if noctalia.getConfig("notify") then

--- a/web-launcher/launcher.luau
+++ b/web-launcher/launcher.luau
@@ -121,7 +121,8 @@ local function shellEscape(raw)
 end
 
 function onActivate(id)
-    noctalia.runAsync("xdg-open " .. shellEscape(id))
+    local command = noctalia.getConfig("command")
+    noctalia.runAsync(command .. " " .. shellEscape(id))
 
     if noctalia.getConfig("notify") then
         noctalia.notify(

--- a/web-launcher/plugin.toml
+++ b/web-launcher/plugin.toml
@@ -32,6 +32,14 @@ default = [
 ]
 
 [[setting]]
+key = "command"
+type = "string"
+label_key = "settings.command.label"
+description_key = "settings.command.description"
+default = "xdg-open"
+advanced = true
+
+[[setting]]
 key = "notify"
 type = "bool"
 label_key = "settings.notify.label"

--- a/web-launcher/plugin.toml
+++ b/web-launcher/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/web-launcher"
 name = "Web Launcher"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 3
 author = "yocraft"
 license = "MIT"

--- a/web-launcher/translations/en.json
+++ b/web-launcher/translations/en.json
@@ -4,6 +4,10 @@
             "label": "Links",
             "description": "Format: Name|https://url"
         },
+        "command": {
+            "label": "Command",
+            "description": "Command that launches the website. Example: \"firefox --new-window\""
+        },
         "notify": {
             "label": "Notify",
             "description": "Notify when opening link."


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Web Launcher

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/web-launcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Quickly open your favorite websites from the launcher. Favicons are downloaded automatically.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** 3<!-- must match plugin_api in plugin.toml -->

## Screenshots

<img width="893" height="569" alt="image" src="https://github.com/user-attachments/assets/d06a9e19-9ffc-44f8-9615-7c19266c5ea3" />

**Browser directly is faster than xdg-open:**
<img width="390" height="242" alt="image" src="https://github.com/user-attachments/assets/9b9cf090-f62a-49e2-a407-5aa4ce937926" />

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
