### PR TITLE
Home Assistant v2.0.1

### DIFF
--- a/hassio/panel.luau
+++ b/hassio/panel.luau
@@ -595,7 +595,7 @@ function render()
 
         panel.render(ui.column({ flexGrow = 1, gap = 16 }, {
             ui.row({ align = "center", gap = 8 }, {
-                ui.glyph({ glyph = "smart-home", color = "primary" }),
+                ui.glyph({ name = "smart-home", size = 20, color = "primary" }),
                 ui.label({ text = noctalia.tr("shortcut.title"), fontSize = 16, fontWeight = "bold", color = "primary", flexGrow = 1 }),
                 ui.label({ text = getStatusText(), color = status == "connected" and "primary" or "on_surface_variant" }),
                 ui.button({ glyph = "list-search", onClick = "onOpenBrowser" }),

--- a/hassio/panel.luau
+++ b/hassio/panel.luau
@@ -595,6 +595,7 @@ function render()
 
         panel.render(ui.column({ flexGrow = 1, gap = 16 }, {
             ui.row({ align = "center", gap = 8 }, {
+                ui.glyph({ glyph = "smart-home", color = "primary" }),
                 ui.label({ text = noctalia.tr("shortcut.title"), fontSize = 16, fontWeight = "bold", color = "primary", flexGrow = 1 }),
                 ui.label({ text = getStatusText(), color = status == "connected" and "primary" or "on_surface_variant" }),
                 ui.button({ glyph = "list-search", onClick = "onOpenBrowser" }),

--- a/hassio/panel.luau
+++ b/hassio/panel.luau
@@ -1,6 +1,6 @@
 --!nonstrict
 
-local haUrl = noctalia.getConfig("ha_url")
+local haUrlRaw = noctalia.getConfig("ha_url")
 local haToken = noctalia.getConfig("ha_token")
 
 local entityStates = {}
@@ -22,6 +22,11 @@ local browserLoading = false
 local searchText = ""
 local monitoredEntities = {} -- current monitored list (owned here, saved to file)
 local panelOpenCount = 0
+
+local function getCleanUrl()
+  if type(haUrlRaw) ~= "string" then return "" end
+  return (haUrlRaw:gsub("/$", ""))
+end
 
 local function tr(key, subst)
       return noctalia.tr("panel." .. key, subst)
@@ -47,13 +52,14 @@ local function getCleanToken()
 end
 
 local function haPost(path, body)
-    if not haUrl or haUrl == "" then return end
+    local url = getCleanUrl()
+    if not url or url == "" then return end
     local cleanToken = getCleanToken()
     if cleanToken == "" then return end
     local encodedBody = noctalia.json.encode(body)
 
     noctalia.http({
-        url = haUrl .. path,
+        url = url .. path,
         method = "POST",
         headers = {
             "Authorization: Bearer " .. cleanToken,
@@ -132,7 +138,8 @@ end
 local function fetchAllEntities()
     if browserLoading then return end
     local cleanToken = getCleanToken()
-    if not haUrl or haUrl == "" or cleanToken == "" then
+    local url = getCleanUrl()
+    if not url or url == "" or cleanToken == "" then
         allEntities = {}
         browserLoading = false
         render()
@@ -143,7 +150,7 @@ local function fetchAllEntities()
     render()
 
     noctalia.http({
-        url = haUrl .. "/api/states",
+        url = url .. "/api/states",
         headers = {
             "Authorization: Bearer " .. cleanToken,
         }
@@ -500,7 +507,7 @@ local function getOrderedIds()
 end
 
 local function buildListBody(ids)
-    if not haUrl or haUrl == "" or getCleanToken() == "" then
+    if not getCleanUrl() or getCleanUrl() == "" or getCleanToken() == "" then
         return ui.label({ text = tr("not_configured"), color = "on_surface_variant" })
     end
     if status == "auth_failed" then

--- a/hassio/plugin.toml
+++ b/hassio/plugin.toml
@@ -1,6 +1,6 @@
 id = "pozzoo/hassio"
 name = "Home Assistant"
-version = "2.0.0"
+version = "2.0.1"
 plugin_api = 4
 author = "Pozzoo"
 license = "MIT"

--- a/hassio/service_sse.luau
+++ b/hassio/service_sse.luau
@@ -1,9 +1,14 @@
 --!nonstrict
 
-local haUrl = noctalia.getConfig("ha_url")
+local haUrlRaw = noctalia.getConfig("ha_url")
 local haToken = noctalia.getConfig("ha_token")
 
 local MANAGED_ENTITIES_FILE = "managed_entities.json"
+
+local function getCleanUrl()
+  if type(haUrlRaw) ~= "string" then return "" end
+  return (haUrlRaw:gsub("/$", ""))
+end
 
 local function loadManagedEntities()
   local dataDir, dirErr = noctalia.pluginDataDir()
@@ -49,13 +54,14 @@ local function syncUpdateInterval()
 end
 
 local function isConfigured()
-  return haUrl and haUrl ~= "" and getCleanToken() ~= ""
+  local url = getCleanUrl()
+  return url and url ~= "" and getCleanToken() ~= ""
 end
 
 local function haRequest(endpoint, method, body, callback)
   if not isConfigured() then return false end
 
-  local url = haUrl .. endpoint
+  local url = getCleanUrl() .. endpoint
   local cleanToken = getCleanToken()
 
   local jsonBody
@@ -296,7 +302,7 @@ function startSSEStream()
     return false
   end
 
-  local url = haUrl .. "/api/stream?restrict=state_changed"
+  local url = getCleanUrl() .. "/api/stream?restrict=state_changed"
 
   noctalia.log("Starting SSE stream")
   currentEvent = { data = "", event = "" }

--- a/hassio/widget.luau
+++ b/hassio/widget.luau
@@ -1,12 +1,17 @@
 --!nonstrict
 
-local haUrl = noctalia.getConfig("ha_url")
+local haUrlRaw = noctalia.getConfig("ha_url")
 local showEntityCount = noctalia.getConfig("show_entity_count")
 
 local status = "unconfigured"
 local entityCount = 0
 
 local render
+
+local function getCleanUrl()
+  if type(haUrlRaw) ~= "string" then return "" end
+  return (haUrlRaw:gsub("/$", ""))
+end
 
 local function tr(key, subst)
   return noctalia.tr("widget." .. key, subst)
@@ -83,8 +88,9 @@ function onClick()
 end
 
 function onRightClick()
-  if haUrl and haUrl ~= "" then
-    noctalia.runAsync("xdg-open " .. ("'" .. haUrl:gsub("'", "'\\''") .. "'"))
+  local url = getCleanUrl()
+  if url and url ~= "" then
+    noctalia.runAsync("xdg-open " .. ("'" .. url:gsub("'", "'\\''") .. "'"))
   end
 end
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `pozzoo/hassio`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Added a function to remove trailing slashes on HA URL, and added a HA icon on the panel.

## External dependencies

`xdg-open` - used to open the Home Assistant URL in your browser.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 4

## Screenshots / Videos

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
