### PR TITLE
fix(ideapad-conservation-mode): use bind action in udev rule instead of add|change to avoid boot race

### DIFF
--- a/ideapad-conservation-mode/conservation_mode.luau
+++ b/ideapad-conservation-mode/conservation_mode.luau
@@ -62,7 +62,7 @@ local function readState()
 end
 
 local function render(on, enabled)
-  shortcut.setLabel(noctalia.tr(if on then "shortcut.on" else "shortcut.off"))
+  shortcut.setLabel(noctalia.tr("shortcut.label"))
   shortcut.setIcon("battery-charging", "battery")
   shortcut.setActive(on)
   shortcut.setEnabled(enabled)

--- a/ideapad-conservation-mode/plugin.toml
+++ b/ideapad-conservation-mode/plugin.toml
@@ -1,6 +1,6 @@
 id           = "lux/ideapad-conservation-mode"
 name         = "IdeaPad Conservation Mode"
-version      = "0.3.0"
+version      = "0.3.1"
 plugin_api = 3
 author       = "lux"
 license      = "MIT"

--- a/ideapad-conservation-mode/scripts/setup-permissions.sh
+++ b/ideapad-conservation-mode/scripts/setup-permissions.sh
@@ -41,11 +41,11 @@ usermod -aG "$GROUP_NAME" "$TARGET_USER"
 
 echo "Writing $RULE_FILE..."
 cat >"$RULE_FILE" <<EOF
-ACTION=="add|change", SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", RUN+="$CHGRP_BIN $GROUP_NAME /sys%p/conservation_mode", RUN+="$CHMOD_BIN 664 /sys%p/conservation_mode"
+ACTION=="bind", SUBSYSTEM=="platform", DRIVER=="ideapad_acpi", RUN+="$CHGRP_BIN $GROUP_NAME /sys%p/conservation_mode", RUN+="$CHMOD_BIN 664 /sys%p/conservation_mode"
 EOF
 
 echo "Reloading udev rules..."
 udevadm control --reload-rules
-udevadm trigger --subsystem-match=platform
+udevadm trigger --action=bind --subsystem-match=platform
 
 echo "Done."

--- a/ideapad-conservation-mode/translations/en.json
+++ b/ideapad-conservation-mode/translations/en.json
@@ -12,8 +12,7 @@
   },
   "shortcut": {
     "na": "Conservation N/A",
-    "off": "Conservation",
-    "on": "Conservation"
+    "label": "Conservation"
   },
   "title": "Conservation mode"
 }


### PR DESCRIPTION
## Plugin

- **Id:** `lux/ideapad-conservation-mode`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

The udev rule that grants the `lenovoctl` group write access to`conservation_mode` doesn't reliably survive a reboot. After every reboot, I have to perform the setup request again. To fix this, I have changed `ACTION=="add|change"` to `ACTION=="bind"` in the udev rule since the problem is likely caused by a race condition ("add" event fires before the driver is probed).
I also changed the shortcut button label to remove a redundancy.