### PR TITLE
Fix Drive Health device name normalization

### DIFF
--- a/drive-health/collector.luau
+++ b/drive-health/collector.luau
@@ -118,6 +118,11 @@ local function smartDeviceFor(path)
   return controller ~= nil and "/dev/" .. controller or tostring(path)
 end
 
+local function deviceBasename(value)
+  local normalized = tostring(value or ""):gsub("/+$", "")
+  return normalized:match("([^/]+)$") or ""
+end
+
 local function listDirectory(path)
   local entries = noctalia.listDir(path)
   return type(entries) == "table" and entries or {}
@@ -765,8 +770,13 @@ local function normalizeRaw(raw, source)
 
   local disks = {}
   for _, block in ipairs(lsblk.blockdevices or {}) do
-    local device = tostring(block.path or ("/dev/" .. tostring(block.name or "")))
-    local name = tostring(block.name or "")
+    local device = tostring(block.path or "")
+    local name = deviceBasename(block.name)
+    if name == "" then name = deviceBasename(block.kname) end
+    if name == "" then name = deviceBasename(device) end
+    if not device:match("^/dev/") and name ~= "" then device = "/dev/" .. name end
+    local kernelName = deviceBasename(block.kname)
+    if kernelName == "" then kernelName = name end
     local virtual = name:match("^zram") or name:match("^loop") or name:match("^ram") or name:match("^sr")
     if block.type == "disk" and device:match("^/dev/") and not virtual then
       local smartDevice = smartDeviceFor(device)
@@ -789,7 +799,7 @@ local function normalizeRaw(raw, source)
       local model = noctalia.string.trim(tostring(block.model or ""))
       local namespace = name:match("^nvme%d+(n%d+)$")
       local id = serial ~= "" and serial .. (namespace ~= nil and ":" .. namespace or "")
-        or tostring(block.kname or device)
+        or (kernelName ~= "" and kernelName or device)
       local preferences = preferenceFor(id)
       local removable = block.rm == true or tonumber(block.rm) == 1 or block.hotplug == true or tonumber(block.hotplug) == 1
       local transport = tostring(block.tran or "unknown")

--- a/drive-health/plugin.toml
+++ b/drive-health/plugin.toml
@@ -1,6 +1,6 @@
 id = "gustav0ar/drive-health"
 name = "Drive Health"
-version = "1.2.0"
+version = "1.2.1"
 plugin_api = 3
 author = "Drive Health contributors"
 license = "MIT"

--- a/drive-health/scripts/collect_raw.sh
+++ b/drive-health/scripts/collect_raw.sh
@@ -59,7 +59,7 @@ lsblk --nodeps --noheadings --paths --output PATH,TYPE,ROTA >"$devices_tmp"
 {
   printf '{"schema":2,"collector_version":"%s","collection_id":"%s","generated_at_epoch":%s,"lsblk":' \
     "$collector_version" "$collection_id" "$generated_at_epoch"
-  lsblk --json --bytes --output \
+  lsblk --json --bytes --paths --output \
     NAME,KNAME,PATH,PKNAME,TYPE,TRAN,ROTA,RM,HOTPLUG,SIZE,LOG-SEC,PHY-SEC,MODEL,SERIAL,FSTYPE,FSSIZE,FSUSED,FSAVAIL,MOUNTPOINTS
   printf ',"smart":['
 

--- a/drive-health/tests/collector_harness.lua
+++ b/drive-health/tests/collector_harness.lua
@@ -392,10 +392,10 @@ local normalized, normalizeError = normalizeRaw({
   generated_at_epoch = 1700000000,
   lsblk = { blockdevices = {
     {
-      name = "nvme9n1", kname = "nvme9n1", path = "/dev/nvme9n1", type = "disk",
+      name = "/dev/nvme9n1", kname = "/dev/nvme9n1", path = "/dev/nvme9n1", type = "disk",
       tran = "nvme", rota = false, size = 2000000000, model = "Fixture NVMe", serial = "FIXTURE1",
       mountpoints = {}, children = {
-        { name = "nvme9n1p1", kname = "nvme9n1p1", path = "/dev/nvme9n1p1", type = "part",
+        { name = "/dev/nvme9n1p1", kname = "/dev/nvme9n1p1", path = "/dev/nvme9n1p1", type = "part",
           mountpoints = { "/mnt/work" }, fsused = 250, fsavail = 750 },
       },
     },
@@ -485,15 +485,17 @@ assert(sleeping.summary.sleeping_count == 1 and sleeping.summary.smart_unavailab
 local namespaces = assert(normalizeRaw({
   schema = 2, generated_at_epoch = 1700000000,
   lsblk = { blockdevices = {
-    { name = "nvme0n1", kname = "nvme0n1", path = "/dev/nvme0n1", type = "disk",
+    { name = "/dev/nvme0n1", kname = "/dev/nvme0n1", path = "/dev/nvme0n1", type = "disk",
       tran = "nvme", rota = false, serial = "SHARED", children = {} },
-    { name = "nvme0n2", kname = "nvme0n2", path = "/dev/nvme0n2", type = "disk",
+    { name = "/dev/nvme0n2", kname = "/dev/nvme0n2", path = "/dev/nvme0n2", type = "disk",
       tran = "nvme", rota = false, serial = "SHARED", children = {} },
+    { name = "/dev/zram0", kname = "/dev/zram0", path = "/dev/zram0", type = "disk",
+      rota = false, serial = "VIRTUAL", children = {} },
   } }, smart = {},
 }, "test"))
-assert(namespaces.disks[1].id ~= namespaces.disks[2].id
-    and namespaces.disks[1].id:match(":n%d+$") and namespaces.disks[2].id:match(":n%d+$"),
-  "NVMe namespaces sharing a controller serial did not receive unique IDs")
+assert(#namespaces.disks == 2, "absolute zram name was not excluded from physical drive inventory")
+assert(namespaces.disks[1].id == "SHARED:n1" and namespaces.disks[2].id == "SHARED:n2",
+  "absolute NVMe names did not receive stable namespace-qualified IDs")
 
 local empty = assert(normalizeRaw({
   schema = 2, collection_id = "   ", generated_at_epoch = 1700000000,

--- a/drive-health/tests/fixtures/bin/lsblk
+++ b/drive-health/tests/fixtures/bin/lsblk
@@ -3,12 +3,13 @@ set -eu
 
 case " $* " in
   *" --nodeps "*)
-    printf '%s\n' "/dev/sda disk 1" "/dev/nvme0n1 disk 0"
+    printf '%s\n' "/dev/sda disk 1" "/dev/nvme0n1 disk 0" "/dev/zram0 disk 0"
     ;;
   *" --json "*)
     printf '%s\n' '{"blockdevices":[' \
-      '{"name":"sda","kname":"sda","path":"/dev/sda","type":"disk","tran":"sata","rota":true,"size":1000000000,"model":"Fixture SATA","serial":"SATA1","mountpoints":[]},' \
-      '{"name":"nvme0n1","kname":"nvme0n1","path":"/dev/nvme0n1","type":"disk","tran":"nvme","rota":false,"size":2000000000,"model":"Fixture NVMe","serial":"NVME1","mountpoints":[]}' \
+      '{"name":"/dev/sda","kname":"/dev/sda","path":"/dev/sda","type":"disk","tran":"sata","rota":true,"size":1000000000,"model":"Fixture SATA","serial":"SATA1","mountpoints":[]},' \
+      '{"name":"/dev/nvme0n1","kname":"/dev/nvme0n1","path":"/dev/nvme0n1","type":"disk","tran":"nvme","rota":false,"size":2000000000,"model":"Fixture NVMe","serial":"NVME1","mountpoints":[]},' \
+      '{"name":"/dev/zram0","kname":"/dev/zram0","path":"/dev/zram0","type":"disk","rota":false,"size":4294967296,"mountpoints":[]}' \
       ']}'
     ;;
   *)

--- a/drive-health/tests/test_collect_raw.sh
+++ b/drive-health/tests/test_collect_raw.sh
@@ -9,7 +9,7 @@ printf '%s\n' "$payload" | jq -e '
   .schema == 2
   and .collector_version == "2.0.0"
   and (.collection_id | type == "string" and length > 0)
-  and (.lsblk.blockdevices | length) == 2
+  and ([.lsblk.blockdevices[].name] | sort) == ["/dev/nvme0n1", "/dev/sda", "/dev/zram0"]
   and (.smart | length) == 2
   and ([.smart[].requested_device] | sort) == ["/dev/nvme0", "/dev/sda"]
   and (.smart[] | select(.requested_device == "/dev/sda") | .payload.test_standby) == true


### PR DESCRIPTION
## Plugin

- **Id:** `gustav0ar/drive-health`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes Drive Health inventory normalization when `lsblk` returns absolute `NAME` and `KNAME` values such as `/dev/zram0` and `/dev/nvme0n1`.

The merged normalizer assumed those fields were bare kernel names. With absolute values, virtual-device filtering did not recognize zram/loop/ram/optical devices, and NVMe namespace extraction failed. Multiple namespaces sharing a controller serial could consequently receive the same ID, mixing preferences, history, and alerts.

This change:

- explicitly requests path-form JSON from `lsblk`, making the raw-input contract deterministic;
- normalizes `NAME` and `KNAME` to basenames at the collector boundary, with fallbacks through `KNAME` and `PATH`;
- uses the normalized kernel name for virtual-device checks, NVMe namespace suffixes, display fallbacks, and serial-less stable IDs;
- retains compatibility with bare-name caches from existing collector installations;
- updates the fixture to mirror real `lsblk --paths` output and adds regressions for zram exclusion and same-serial NVMe namespaces;
- bumps Drive Health from `1.2.0` to `1.2.1`.

This addresses the follow-up issue reported by @ItsLemmy on #58.

## External dependencies

No new dependencies. Drive Health continues to declare and document `lsblk`, `smartctl`, `sh`, `date`, `dirname`, `mkdir`, `mktemp`, `rm`, `sed`, `cat`, `chmod`, `mv`, `sudo`, `env`, `bash`, `install`, `systemctl`, `pkexec`, `id`, `tr`, `pacman`, `apt-get`, `dnf`, `zypper`, `apk`, `xbps-install`, and `emerge`.

The plugin makes no network calls and downloads or executes no remote code.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `v5.0.0-beta.3-117-g32c608f7db31-dirty`
- **Plugin API level:** 3

Validation performed:

- `make -C drive-health test` — all collector, alert, history, panel/widget, raw collector, packaging, translation, and Noctalia lint checks pass.
- `python3 .github/workflows/validate-plugins.py` — all 32 plugin manifests pass.
- A live raw collection confirmed every JSON `NAME` is absolute while zram remains excluded from SMART probing.
- Regression fixtures confirm `/dev/zram0` is excluded from normalized physical inventory and `/dev/nvme0n1` plus `/dev/nvme0n2` with serial `SHARED` become `SHARED:n1` and `SHARED:n2`.
- ShellCheck passes for all shipped and test shell scripts.
- Gitleaks reports no secrets.
- `git diff --check` passes, and the PR changes only `drive-health/`.

## Screenshots / Videos

No visual changes. The Drive Health UI remains unchanged; this fixes the identity and filtering data supplied to it.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (only `en.json` is shipped).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is accounted for above and in `README.md`.
- [x] I have the right to publish this code under the MIT license declared in `plugin.toml`.
