### PR TITLE
fix(hassio): Perpetual connecting

### DIFF
--- a/hassio/plugin.toml
+++ b/hassio/plugin.toml
@@ -1,6 +1,6 @@
 id = "pozzoo/hassio"
 name = "Home Assistant"
-version = "2.0.1"
+version = "2.0.2"
 plugin_api = 4
 author = "Pozzoo"
 license = "MIT"

--- a/hassio/service_sse.luau
+++ b/hassio/service_sse.luau
@@ -39,6 +39,7 @@ local retryCount = 0
 local maxRetriesNotified = false
 local suspended = false
 local connectionRequestInFlight = false
+local connectingSince = nil
 
 local function getCleanToken()
   if type(haToken) ~= "string" then return "" end
@@ -214,8 +215,10 @@ end
 local function fetchInitialStates()
   if not isConfigured() or suspended or connectionRequestInFlight then return end
   connectionRequestInFlight = true
+  connectingSince = os.clock()
   local launched = haRequest("/api/states", "GET", nil, function(res)
     connectionRequestInFlight = false
+    connectingSince = nil
 
     if not res.body or res.body == "" then
       noctalia.log("Empty response body from /api/states")
@@ -287,6 +290,7 @@ local function fetchInitialStates()
 
   if not launched then
     connectionRequestInFlight = false
+    connectingSince = nil
     status = "disconnected"
     noctalia.state.set("connection_status", status)
     syncUpdateInterval()
@@ -394,6 +398,14 @@ function update()
 
   if suspended then
     return
+  end
+
+  if status == "connecting" and connectingSince and (os.clock() - connectingSince) > 15 then
+    connectionRequestInFlight = false
+    connectingSince = nil
+    status = "disconnected"
+    noctalia.state.set("connection_status", status)
+    syncUpdateInterval()
   end
 
   if status == "disconnected" then

--- a/hassio/shortcut.luau
+++ b/hassio/shortcut.luau
@@ -14,6 +14,11 @@ local pendingTimerSeq = 0
 local PENDING_TIMEOUT_SECONDS = 8
 local render
 
+local function getCleanUrl()
+    if type(haUrl) ~= "string" then return "" end
+    return (haUrl:gsub("/$", ""))
+end
+
 local function getCleanToken()
     if type(haToken) ~= "string" then return "" end
     return haToken:gsub("^%s+", ""):gsub("%s+$", "")
@@ -116,7 +121,7 @@ function onClick()
 
     local entity = getEntity()
     local cleanToken = getCleanToken()
-    if not entity or not haUrl or haUrl == "" or cleanToken == "" then return end
+    if not entity or getCleanUrl() == "" or cleanToken == "" then return end
 
     local eid = entity.entity_id
     if pendingToggle[eid] then return end
@@ -128,7 +133,7 @@ function onClick()
     local encoded = noctalia.json.encode({ entity_id = eid })
 
     noctalia.http({
-        url = haUrl .. "/api/services/" .. entity.domain .. "/toggle",
+        url = getCleanUrl() .. "/api/services/" .. entity.domain .. "/toggle",
         method = "POST",
         headers = {
             "Authorization: Bearer " .. cleanToken,

--- a/hassio/shortcut_2.luau
+++ b/hassio/shortcut_2.luau
@@ -14,6 +14,11 @@ local pendingTimerSeq = 0
 local PENDING_TIMEOUT_SECONDS = 8
 local render
 
+local function getCleanUrl()
+    if type(haUrl) ~= "string" then return "" end
+    return (haUrl:gsub("/$", ""))
+end
+
 local function getCleanToken()
     if type(haToken) ~= "string" then return "" end
     return haToken:gsub("^%s+", ""):gsub("%s+$", "")
@@ -116,7 +121,7 @@ function onClick()
 
     local entity = getEntity()
     local cleanToken = getCleanToken()
-    if not entity or not haUrl or haUrl == "" or cleanToken == "" then return end
+    if not entity or getCleanUrl() == "" or cleanToken == "" then return end
 
     local eid = entity.entity_id
     if pendingToggle[eid] then return end
@@ -128,7 +133,7 @@ function onClick()
     local encoded = noctalia.json.encode({ entity_id = eid })
 
     noctalia.http({
-        url = haUrl .. "/api/services/" .. entity.domain .. "/toggle",
+        url = getCleanUrl() .. "/api/services/" .. entity.domain .. "/toggle",
         method = "POST",
         headers = {
             "Authorization: Bearer " .. cleanToken,

--- a/hassio/shortcut_3.luau
+++ b/hassio/shortcut_3.luau
@@ -14,6 +14,11 @@ local pendingTimerSeq = 0
 local PENDING_TIMEOUT_SECONDS = 8
 local render
 
+local function getCleanUrl()
+    if type(haUrl) ~= "string" then return "" end
+    return (haUrl:gsub("/$", ""))
+end
+
 local function getCleanToken()
     if type(haToken) ~= "string" then return "" end
     return haToken:gsub("^%s+", ""):gsub("%s+$", "")
@@ -116,7 +121,7 @@ function onClick()
 
     local entity = getEntity()
     local cleanToken = getCleanToken()
-    if not entity or not haUrl or haUrl == "" or cleanToken == "" then return end
+    if not entity or getCleanUrl() == "" or cleanToken == "" then return end
 
     local eid = entity.entity_id
     if pendingToggle[eid] then return end
@@ -128,7 +133,7 @@ function onClick()
     local encoded = noctalia.json.encode({ entity_id = eid })
 
     noctalia.http({
-        url = haUrl .. "/api/services/" .. entity.domain .. "/toggle",
+        url = getCleanUrl() .. "/api/services/" .. entity.domain .. "/toggle",
         method = "POST",
         headers = {
             "Authorization: Bearer " .. cleanToken,

--- a/hassio/shortcut_4.luau
+++ b/hassio/shortcut_4.luau
@@ -14,6 +14,11 @@ local pendingTimerSeq = 0
 local PENDING_TIMEOUT_SECONDS = 8
 local render
 
+local function getCleanUrl()
+    if type(haUrl) ~= "string" then return "" end
+    return (haUrl:gsub("/$", ""))
+end
+
 local function getCleanToken()
     if type(haToken) ~= "string" then return "" end
     return haToken:gsub("^%s+", ""):gsub("%s+$", "")
@@ -116,7 +121,7 @@ function onClick()
 
     local entity = getEntity()
     local cleanToken = getCleanToken()
-    if not entity or not haUrl or haUrl == "" or cleanToken == "" then return end
+    if not entity or getCleanUrl() == "" or cleanToken == "" then return end
 
     local eid = entity.entity_id
     if pendingToggle[eid] then return end
@@ -128,7 +133,7 @@ function onClick()
     local encoded = noctalia.json.encode({ entity_id = eid })
 
     noctalia.http({
-        url = haUrl .. "/api/services/" .. entity.domain .. "/toggle",
+        url = getCleanUrl() .. "/api/services/" .. entity.domain .. "/toggle",
         method = "POST",
         headers = {
             "Authorization: Bearer " .. cleanToken,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `<author>/<plugin>`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixed panel perpetually showing "connecting", fixed missing clean URL uses on shortcuts.

## External dependencies

`xdg-open` - used to open the Home Assistant URL in your browser.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:*5.0.0-beta.3*
- **Plugin API level:** 4

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
