### PR TITLE
fix(eyecare): reflect configurable break duration in notification message

### DIFF
--- a/eyecare/plugin.toml
+++ b/eyecare/plugin.toml
@@ -1,6 +1,6 @@
 id = "apex077/eyecare"
 name = "Eye-Care Reminders"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 3
 author = "Apex077"
 license = "MIT"

--- a/eyecare/service.luau
+++ b/eyecare/service.luau
@@ -24,6 +24,7 @@ local settings = getSettings()
 function onConfigChanged()
     settings = getSettings()
     noctalia.log("eyecare: settings updated")
+    updateState()
 end
 
 -- Play a notification sound using system players
@@ -119,7 +120,7 @@ function update()
                 if settings.enable_notifications then
                     noctalia.notify(
                         noctalia.tr("notifications.eyecare-break-title"),
-                        noctalia.tr("notifications.eyecare-break-body")
+                        noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds })
                     )
                 end
                 if settings.enable_sound then
@@ -142,7 +143,7 @@ local function triggerBreak()
     if settings.enable_notifications then
         noctalia.notify(
             noctalia.tr("notifications.eyecare-break-title"),
-            noctalia.tr("notifications.eyecare-break-body")
+            noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds })
         )
     end
     if settings.enable_sound then

--- a/eyecare/translations/en.json
+++ b/eyecare/translations/en.json
@@ -1,6 +1,6 @@
 {
   "notifications": {
-    "eyecare-break-body": "Focus on an object 20 feet away for 20 seconds.",
+    "eyecare-break-body": "Focus on an object 20 feet away for {seconds} seconds.",
     "eyecare-break-finished-body": "Your eyes are rested. You can return to your screen.",
     "eyecare-break-finished-title": "Break finished",
     "eyecare-break-title": "Time for a break"


### PR DESCRIPTION
Fixes #63

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `apex077/eyecare`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Reflects the configured `break_duration_seconds` setting in the break notification message.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
No new dependencies. All original dependencies as mentioned in `plugin.toml`.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `noctalia v5.0.0 (v5.0.0-beta.3-42-g8b5b1381d5a2)`
- **Plugin API level:** 3<!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
<img width="1920" height="193" alt="image" src="https://github.com/user-attachments/assets/e0a9eb7b-c501-4165-907f-7d78b74c9d23" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
