### PR TITLE
feat(lyrics): update to 1.4.3

### DIFF
--- a/lyrics/README.md
+++ b/lyrics/README.md
@@ -1,4 +1,4 @@
-# Noctalia Lyrics 1.4.2
+# Noctalia Lyrics 1.4.3
 
 Synchronized lyrics for the Noctalia bar, with multiple MPRIS players,
 translation and romanization layers, configurable sources, karaoke highlighting,

--- a/lyrics/lyrics.luau
+++ b/lyrics/lyrics.luau
@@ -4,6 +4,8 @@
 noctalia.setUpdateInterval(33)
 
 local glyph = noctalia.getConfig("glyph")
+local showGlyph = noctalia.getConfig("show_glyph")
+if showGlyph == nil then showGlyph = true end
 local showArtist = noctalia.getConfig("show_artist")
 local hideWhenPaused = noctalia.getConfig("hide_when_paused")
 local showCover = noctalia.getConfig("show_cover")
@@ -445,7 +447,7 @@ local function render()
       or coverShape == "square" and 0
       or math.min(coverRadius, coverSize / 2)
     prefix[#prefix + 1] = ui.image({ path = coverPath, width = coverSize, height = coverSize, radius = radius, fit = "cover" })
-  else
+  elseif showGlyph then
     prefix[#prefix + 1] = ui.glyph({
       name = glyph,
       size = 14,
@@ -578,6 +580,14 @@ function onRightClick()
       render()
     end
   end)
+end
+
+function onScroll(axis, steps)
+  if axis ~= "vertical" or playerInstance == "" then return end
+  local direction = tonumber(steps) or 0
+  if direction == 0 then return end
+  local action = direction < 0 and "next" or "previous"
+  noctalia.runAsync("playerctl --player " .. shellQuote(playerInstance) .. " " .. action, function() end)
 end
 
 function update()

--- a/lyrics/plugin.toml
+++ b/lyrics/plugin.toml
@@ -1,6 +1,6 @@
 id = "h465855hgg/lyrics"
 name = "Lyrics"
-version = "1.4.2"
+version = "1.4.3"
 plugin_api = 3
 author = "h465855hgg"
 license = "MIT"
@@ -461,11 +461,23 @@ entry = "lyrics_service.luau"
 id = "lyrics"
 entry = "lyrics.luau"
 
+[widget.settings."enable_scroll"]
+type = "boolean"
+default = true
+
+  [[widget.setting]]
+  key = "show_glyph"
+  type = "bool"
+  label_key = "settings.show_glyph.label"
+  description_key = "settings.show_glyph.description"
+  default = true
+
   [[widget.setting]]
   key = "glyph"
   type = "glyph"
   label_key = "settings.glyph.label"
   default = "music"
+  visible_when = { key = "show_glyph", values = ["true"] }
 
   [[widget.setting]]
   key = "show_artist"

--- a/lyrics/plugin.toml
+++ b/lyrics/plugin.toml
@@ -461,10 +461,6 @@ entry = "lyrics_service.luau"
 id = "lyrics"
 entry = "lyrics.luau"
 
-[widget.settings."enable_scroll"]
-type = "boolean"
-default = true
-
   [[widget.setting]]
   key = "show_glyph"
   type = "bool"

--- a/lyrics/translations/en.json
+++ b/lyrics/translations/en.json
@@ -129,6 +129,10 @@
     "glyph": {
       "label": "Glyph"
     },
+    "show_glyph": {
+      "label": "Show glyph",
+      "description": "Display the configured glyph when no album cover is available."
+    },
     "gradient": {
       "description": "Light up each character as the song progresses (karaoke style).",
       "label": "Per-character gradient"

--- a/lyrics/translations/zh-Hans.json
+++ b/lyrics/translations/zh-Hans.json
@@ -129,6 +129,10 @@
     "glyph": {
       "label": "图标"
     },
+    "show_glyph": {
+      "label": "显示图标",
+      "description": "没有专辑封面时显示设置的图标。"
+    },
     "gradient": {
       "description": "根据播放进度逐字点亮当前歌词。",
       "label": "逐字渐变"


### PR DESCRIPTION
## Summary
- add a setting to hide the fallback glyph when album artwork is unavailable
- hide the glyph picker when fallback glyph display is disabled
- add vertical mouse-wheel controls for next and previous track
- bump the plugin version to 1.4.3

## Validation
- JSON and TOML parsing checks
- plugin manifest validation

Closes #85