### PR TITLE
feat: add toggle for notifications on device switch and toggle for keybinds in tooltip

### DIFF
--- a/audio-switcher/README.md
+++ b/audio-switcher/README.md
@@ -49,6 +49,7 @@ Use the settings button in the panel header to open Noctalia's plugin settings.
 | Entry | Setting | Type | Default | Description |
 | --- | --- | --- | --- | --- |
 | Plugin | `show_percentage` | `bool` | `true` | Show the output volume beside the bar icon; disable it for an icon-only widget. |
+| Plugin | `show_notification_on_switch` | `bool` | `true` | Show a notification when switching device. |
 | Plugin | `scroll_step` | `int` | `5` | Volume points changed by each wheel step over the bar widget (1–25). |
 
 ## IPC and keybinds

--- a/audio-switcher/README.md
+++ b/audio-switcher/README.md
@@ -50,6 +50,7 @@ Use the settings button in the panel header to open Noctalia's plugin settings.
 | --- | --- | --- | --- | --- |
 | Plugin | `show_percentage` | `bool` | `true` | Show the output volume beside the bar icon; disable it for an icon-only widget. |
 | Plugin | `show_notification_on_switch` | `bool` | `true` | Show a notification when switching device. |
+| Plugin | `show_actions_in_tooltip` | `bool` | `true` | Show actions in tooltip. |
 | Plugin | `scroll_step` | `int` | `5` | Volume points changed by each wheel step over the bar widget (1–25). |
 
 ## IPC and keybinds

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -17,6 +17,13 @@ description_key = "settings.show_percentage.description"
 default = true
 
 [[setting]]
+key = "show_notification_on_switch"
+type = "bool"
+label_key = "settings.show_notification_on_switch.label"
+description_key = "settings.show_notification_on_switch.description"
+default = true
+
+[[setting]]
 key = "scroll_step"
 type = "int"
 label_key = "settings.scroll_step.label"

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -24,6 +24,13 @@ description_key = "settings.show_notification_on_switch.description"
 default = true
 
 [[setting]]
+key = "show_actions_in_tooltip"
+type = "bool"
+label_key = "settings.show_actions_in_tooltip.label"
+description_key = "settings.show_actions_in_tooltip.description"
+default = true
+
+[[setting]]
 key = "scroll_step"
 type = "int"
 label_key = "settings.scroll_step.label"

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,6 +1,6 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
-version = "0.1.1"
+version = "0.2.0"
 plugin_api = 9
 author = "blackbartblues"
 license = "MIT"

--- a/audio-switcher/service.luau
+++ b/audio-switcher/service.luau
@@ -751,7 +751,7 @@ local function setDefaultTarget(command, kind, device)
     end
     moveStreams(kind, device.targetName, function()
       local messageKey = kind == "output" and "notifications.output_selected" or "notifications.input_selected"
-      finishAction(command, true, noctalia.tr(messageKey, { device = device.name }))
+      finishAction(command, true, noctalia.tr(messageKey, { device = device.name }), noctalia.getConfig("show_notification_on_switch"))
     end)
   end)
 end

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -88,6 +88,10 @@
     "show_percentage": {
       "description": "Show the current output volume percentage next to the bar icon. Disable it to show only the icon.",
       "label": "Show percentage"
+    },
+    "show_notification_on_switch": {
+      "description": "Show a notification when switching device.",
+      "label": "Show notification on switch"
     }
   },
   "tabs": {

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -92,6 +92,10 @@
     "show_notification_on_switch": {
       "description": "Show a notification when switching device.",
       "label": "Show notification on switch"
+    },
+    "show_actions_in_tooltip": {
+      "description": "Show actions in tooltip.",
+      "label": "Show actions in tooltip"
     }
   },
   "tabs": {
@@ -100,6 +104,23 @@
   },
   "title": "Audio Switcher",
   "widget": {
-    "tooltip": "Output: {output} ({output_volume})\nInput: {input} ({input_volume})\nScroll: change output volume\nLeft click: open Audio Switcher\nRight click: cycle outputs\nMiddle click: cycle inputs"
+    "action": {
+      "scroll": {
+        "key": "Scroll",
+        "description": "Change output volume"
+      },
+      "left_click": {
+        "key": "Left click",
+        "description": "Open Audio Switcher"
+      },
+      "right_click": {
+        "key": "Right click",
+        "description": "Cycle visible outputs"
+      },
+      "middle_click": {
+        "key": "Middle click",
+        "description": "Cycle visible inputs"
+      }
+    }
   }
 }

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -104,6 +104,8 @@
   },
   "title": "Audio Switcher",
   "widget": {
+    "input": "Input",
+    "output": "Output",
     "action": {
       "scroll": {
         "key": "Scroll",

--- a/audio-switcher/widget.luau
+++ b/audio-switcher/widget.luau
@@ -52,12 +52,15 @@ local function render()
 
   local showPercentage = noctalia.getConfig("show_percentage") ~= false
   barWidget.setText(showPercentage and not barWidget.isVertical() and outputVolume or "")
-  barWidget.setTooltip(noctalia.tr("widget.tooltip", {
-    output = outputName,
-    output_volume = outputVolume,
-    input = inputName,
-    input_volume = inputVolume,
-  }))
+  local tooltipItems = {{key = "Output", value = `{outputName} ({outputVolume})`},
+                        {key = "Input", value = `{inputName} ({inputVolume})`}}
+  if noctalia.getConfig("show_actions_in_tooltip") == true then
+    table.insert(tooltipItems, {key = noctalia.tr("widget.action.scroll.key"), value = noctalia.tr("widget.action.scroll.description")})
+    table.insert(tooltipItems, {key = noctalia.tr("widget.action.left_click.key"), value = noctalia.tr("widget.action.left_click.description")})
+    table.insert(tooltipItems, {key = noctalia.tr("widget.action.right_click.key"), value = noctalia.tr("widget.action.right_click.description")})
+    table.insert(tooltipItems, {key = noctalia.tr("widget.action.middle_click.key"), value = noctalia.tr("widget.action.middle_click.description")})
+  end
+  barWidget.setTooltip(tooltipItems)
 end
 
 local function dispatch(action)

--- a/audio-switcher/widget.luau
+++ b/audio-switcher/widget.luau
@@ -52,8 +52,8 @@ local function render()
 
   local showPercentage = noctalia.getConfig("show_percentage") ~= false
   barWidget.setText(showPercentage and not barWidget.isVertical() and outputVolume or "")
-  local tooltipItems = {{key = "Output", value = `{outputName} ({outputVolume})`},
-                        {key = "Input", value = `{inputName} ({inputVolume})`}}
+  local tooltipItems = {{key = noctalia.tr("widget.output"), value = `{outputName} ({outputVolume})`},
+                        {key = noctalia.tr("widget.input"), value = `{inputName} ({inputVolume})`}}
   if noctalia.getConfig("show_actions_in_tooltip") == true then
     table.insert(tooltipItems, {key = noctalia.tr("widget.action.scroll.key"), value = noctalia.tr("widget.action.scroll.description")})
     table.insert(tooltipItems, {key = noctalia.tr("widget.action.left_click.key"), value = noctalia.tr("widget.action.left_click.description")})


### PR DESCRIPTION
## Plugin

- **Id:** `blackbartblues/audio-switcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Added two new toggles to the settings and rewrote the tooltip to use TooltipRow.
1. The plugin sends a notification when switching audio devices. Added an option to disable these notifications for users who prefer using only the OSD/no notification at all.
2. Added an option to hide keybindings from the tooltip to reduce visual noise.
3. Switched to TooltipRow to more closely match the standard audio widget.

## External dependencies

No external dependencies added.

## Testing

I tested the added settings by toggling them and confirming that they work as expected.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5, latest `main` (flake)
- **Plugin API level:** 9

## Screenshots / Videos

Widget tooltip with `show_actions_in_tooltip` set to true
<img width="248" height="150" alt="image" src="https://github.com/user-attachments/assets/1460e5df-d75e-4a49-baed-31054b300262" />

Widget tooltip with `show_actions_in_tooltip` set to false
<img width="223" height="49" alt="image" src="https://github.com/user-attachments/assets/b8917bec-24fc-4d03-b106-defdfb84f0f2" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
