### PR TITLE
fix(drive-health): preserve collector boot trigger

### DIFF
--- a/drive-health/packaging/set-collector-interval.sh
+++ b/drive-health/packaging/set-collector-interval.sh
@@ -18,7 +18,9 @@ dropin_path="$dropin_dir/interval.conf"
 temporary=$(mktemp)
 trap 'rm -f -- "$temporary"' EXIT
 
-printf '[Timer]\nOnUnitActiveSec=\nOnUnitActiveSec=%smin\n' "$interval_minutes" >"$temporary"
+# Resetting a monotonic timer also removes OnBootSec inherited from the base
+# unit, so the drop-in must restore both triggers.
+printf '[Timer]\nOnUnitActiveSec=\nOnBootSec=20s\nOnUnitActiveSec=%smin\n' "$interval_minutes" >"$temporary"
 install -d -m0755 "$dropin_dir"
 install -m0644 "$temporary" "$dropin_path"
 

--- a/drive-health/packaging/uninstall-system-collector.sh
+++ b/drive-health/packaging/uninstall-system-collector.sh
@@ -15,6 +15,7 @@ rm -f \
   "/etc/systemd/system/$service_name.service" \
   "/etc/systemd/system/$service_name.timer"
 rm -rf \
+  "/etc/systemd/system/$service_name.timer.d" \
   "/usr/local/libexec/$service_name" \
   "/run/$service_name"
 

--- a/drive-health/plugin.toml
+++ b/drive-health/plugin.toml
@@ -1,6 +1,6 @@
 id = "gustav0ar/drive-health"
 name = "Drive Health"
-version = "1.2.3"
+version = "1.2.4"
 plugin_api = 9
 author = "Drive Health contributors"
 license = "MIT"

--- a/drive-health/tests/test_packaging.sh
+++ b/drive-health/tests/test_packaging.sh
@@ -20,8 +20,11 @@ grep -q '^OnUnitActiveSec=15min$' "$fixture/noctalia-drive-health.timer"
 
 bash -n "$interval_script"
 bash -n "$manage_script"
+grep -Fq "OnUnitActiveSec=\\nOnBootSec=20s\\nOnUnitActiveSec=%smin" "$interval_script"
 grep -q 'packaging/manage-collector.sh' "$project_dir/packaging/install-system-collector.sh"
 grep -q 'packaging/uninstall-system-collector.sh' "$project_dir/packaging/install-system-collector.sh"
+grep -Fq '"/etc/systemd/system/$service_name.timer.d"' \
+  "$project_dir/packaging/uninstall-system-collector.sh"
 
 if grep -R -q 'noctalia-smart-monito[r]' "$project_dir"; then
   echo "generic legacy collector namespace must not be read, modified, or removed" >&2


### PR DESCRIPTION
## Plugin

- **Id:** `gustav0ar/drive-health`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Restores `OnBootSec=20s` when changing the SMART interval. The interval reset previously removed all monotonic triggers, so collection started only after manual activation. Explicit collector removal now also deletes the timer drop-in.

## External dependencies

No new dependencies.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0-beta.6
- **Plugin API level:** 9
- `sh drive-health/tests/test_packaging.sh`
- Plugin manifest validator and its 44 tests

## Screenshots / Videos

Not applicable; no visual changes.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` documents every entry and dependency.
- [x] The existing `thumbnail.webp` is unchanged.
- [x] `version` follows semver and is bumped; `plugin_api` remains the oldest required level.
- [x] No non-English translations are changed.
- [x] I did not edit `catalog.toml`.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every filesystem write and spawned process is documented.
- [x] I have the right to publish this code under the declared license.
