### PR TITLE
Update nightwatch75/todo to 0.0.14 — settings shortcut, long task text no longer overruns the row buttons

### DIFF
--- a/todo/README.md
+++ b/todo/README.md
@@ -33,6 +33,14 @@ noctalia msg panel-toggle nightwatch75/todo:panel
 | **Enter**, or ✓ (row)         | Commit the edit — the row goes back to a static line |
 | ☐ / ☑ button (row)            | Toggle done/to-do (done tasks are struck through)   |
 | 🗑 button (row)                | Delete the task                                     |
+| ⚙ button (panel header)       | Open this plugin's page in *Settings → Plugins*     |
+
+That settings page also opens from the command line, so it can be bound in your
+compositor too:
+
+```sh
+noctalia msg settings-open-plugin nightwatch75/todo
+```
 
 ## Priorities
 
@@ -79,6 +87,10 @@ close.
 Tick a task (☐ → ☑) to complete it — its text is struck through until you
 un-tick it. The bar glyph's tooltip shows how many tasks are still to do.
 
+A task longer than the row wraps onto further lines and the row grows to fit,
+so the whole text stays readable and never runs under the buttons on the
+right.
+
 ## Storage
 
 Tasks live in one file, `todo.json`, inside the configured **To Do folder**
@@ -111,7 +123,9 @@ noctalia msg plugins enable nightwatch75/todo
 
 ## Requirements
 
-- noctalia with plugin API ≥ 5 (declarative drag-and-drop)
+- noctalia v5.0.0-beta.6 or newer — the first tagged release that accepts
+  `plugin_api = 15` (`noctalia.openSettings()`, the panel's ⚙ button;
+  declarative drag-and-drop needs 5)
 - No external dependencies
 
 ## License

--- a/todo/panel.luau
+++ b/todo/panel.luau
@@ -30,6 +30,38 @@
 -- The bar widget (todo.luau) lights its glyph while the panel is open via the
 -- shared "todo_open" state; it reads todo.json itself for the pending count.
 
+-- Row width budget. A Button constrains its label only when it has an explicit
+-- width (the host derives the label's max width from it); flexGrow alone lets a
+-- long task overrun the buttons to its right instead of shrinking. So the text
+-- button is given whatever the fixed parts of the row leave over.
+--
+-- The constrained label WRAPS, it does not ellipsize: Button sets the label's
+-- maxWidth and TextEllipsize::End but never a maxLines, and the text renderer
+-- only ellipsizes against an explicit line budget — with maxLines 0 Pango is
+-- given the full 500-line backstop and wraps freely. Wrapping is what we want
+-- here (the whole task stays readable), and the row grows to fit because
+-- Button pins only a minimum height.
+-- Every constant below mirrors one in noctalia's Style, named so the sum can be
+-- re-checked against the host rather than re-measured by eye.
+local PANEL_WIDTH = 400 -- keep in sync with [[panel]] width in plugin.toml
+local PANEL_PADDING = 14 -- Style::panelPadding, applied left and right
+local SCROLLBAR_GUTTER = 14 -- Style::scrollbarWidth (6) + Style::scrollbarGap (8)
+local ROW_GAP = 8 -- the task row's own gap
+local CHIP_W = 16 -- the priority chip
+local GRIP_W = 24 -- the ☰ drag grip, manual mode only
+local GLYPH_BTN_W = 30 -- ghost glyph button: 2 × Style::spaceSm + a 14px glyph
+local ROW_CONTENT_W = PANEL_WIDTH - (2 * PANEL_PADDING) - SCROLLBAR_GUTTER
+
+-- Width left for the task text once the chip, the optional grip and the
+-- `trailing` glyph buttons (each preceded by a gap) have taken their share.
+local function taskTextWidth(withGrip, trailing)
+    local width = ROW_CONTENT_W - CHIP_W - ROW_GAP - (trailing * (GLYPH_BTN_W + ROW_GAP))
+    if withGrip then
+        width -= GRIP_W + ROW_GAP
+    end
+    return width
+end
+
 local PRIORITIES = { "important", "medium", "low" }
 local RANK = { important = 1, medium = 2, low = 3 }
 local COLORS = { important = "#e06c75", medium = "#e5c07b", low = "#98c379" }
@@ -403,12 +435,14 @@ local function taskRow(item)
         }))
     else
         -- Static text; clicking it re-opens the editor ("press on the text").
+        -- The explicit width is what makes a long task wrap onto another line
+        -- instead of running under the three buttons that follow it.
         table.insert(children, ui.button({
             key = "view-" .. id,
             text = item.done and strike(item.text) or item.text,
             variant = "ghost",
             contentAlign = "start",
-            flexGrow = 1,
+            width = taskTextWidth(grip ~= nil, 3),
             onClick = function()
                 enterEdit(id)
             end,
@@ -510,6 +544,7 @@ render = function()
             onClick = "onClearDone",
         }),
         ui.button({ key = "header-add", glyph = "plus", variant = "primary", tooltip = tr("tip_add"), onClick = "onAdd" }),
+        ui.button({ key = "header-settings", glyph = "settings", variant = "ghost", tooltip = tr("tip_settings"), onClick = "onOpenSettings" }),
         ui.button({ key = "header-close", glyph = "close", variant = "ghost", tooltip = tr("tip_close"), onClick = "onClosePanel" }),
     })
 
@@ -648,6 +683,13 @@ end
 function onClearDoneCancel()
     confirmingClear = false
     render()
+end
+
+-- Opens the settings window on this plugin's own page (the host supplies the
+-- plugin id, so a plugin can only ever open its own). It closes the panel on
+-- the way, so onClose flushes any pending edit first.
+function onOpenSettings()
+    noctalia.openSettings()
 end
 
 function onClosePanel()

--- a/todo/plugin.toml
+++ b/todo/plugin.toml
@@ -8,8 +8,8 @@
 
 id = "nightwatch75/todo"
 name = "To Do"
-version = "0.0.10"
-plugin_api = 9
+version = "0.0.14"
+plugin_api = 15
 author = "nightwatch75"
 license = "MIT"
 dependencies = []

--- a/todo/translations/en.json
+++ b/todo/translations/en.json
@@ -30,6 +30,7 @@
   "tip_grip": "Drag to reorder",
   "tip_grip_drop": "Click another grip to drop here, or this one to cancel",
   "tip_sort": "Switch ordering mode",
+  "tip_settings": "Plugin settings",
   "tip_undone": "Mark as to do",
   "title": "To Do",
   "tooltip": "To Do — {count} to do"


### PR DESCRIPTION
## Plugin

- **Id:** `nightwatch75/todo`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`: 0.0.10 → 0.0.14)

## What it does

Updates To Do from 0.0.10 to 0.0.14. Two improvements, no behaviour removed.

**Settings shortcut in the panel header (plugin API 15).** A ⚙ button, left of
the close ✕, opens this plugin's own page in *Settings → Plugins* via
`noctalia.openSettings()` — the quickest route to the *To Do folder* setting.
The same page is reachable from the command line with
`noctalia msg settings-open-plugin nightwatch75/todo`, so it can be bound in a
compositor.

**Long task text no longer runs under the row's buttons.** A task longer than
its row used to overrun the done, edit and delete buttons on the right. The
text control is now given an explicit width, so the task wraps within its own
column and the row grows to fit — the whole text stays readable and nothing
overlaps.

The width is computed rather than eyeballed: the panel width from the manifest
minus `Style::panelPadding` on both sides and the scrollbar gutter
(`scrollbarWidth` + `scrollbarGap`), then minus the priority chip, the trailing
glyph buttons with their gaps, and the ☰ grip when *Manual* mode shows one. Each
constant is named after the `Style` value it mirrors so the sum can be
re-checked against the host instead of re-measured. That yields 220 px for the
text in *Priority* mode and 188 px in *Manual*.

Worth noting for review: the constrained label **wraps, it does not ellipsize**.
`Button` sets the label's max width and `TextEllipsize::End` but never a
`maxLines`, and the text renderer only ellipsizes against an explicit line
budget. Wrapping is the wanted behaviour here — the whole task stays readable —
and the README documents it as such.

**Requires noctalia ≥ v5.0.0-beta.6** (plugin API 15) — the first tagged release
that accepts `plugin_api = 15`, which `noctalia.openSettings()` needs. On older
releases the manifest is correctly rejected as incompatible, and the catalog's
release rows keep serving 0.0.10 to those hosts. Declarative drag-and-drop
still needs only API 5, as before.

## External dependencies

None — unchanged. The task list is a single JSON file (`todo.json` in the
configured folder) and the plugin runs no external commands. No network access;
that one file is the only filesystem write.

## Testing

- [x] Tested on Niri
- **Noctalia version tested against:** v5.0.0-beta.6
- **Plugin API level:** 15

Exercised: panel opened from the bar glyph and via
`noctalia msg panel-toggle nightwatch75/todo:panel`; tasks added, edited,
committed with Enter and with the ✓ button, ticked done and un-ticked, deleted;
priority cycled through important/medium/low from the chip; ordering switched
between *Priority* and *Manual* repeatedly to confirm the manual order survives;
rows reordered by dragging the ☰ grip onto the insertion zones; clear-done
confirm/cancel strip; idle autosave and save on close; the ⚙ header button and
`noctalia msg settings-open-plugin nightwatch75/todo`. Wrapping checked with
tasks well past the row width in both ordering modes, with and without the grip
column.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the README template, documents every entry id, and includes the exact panel IPC command.
- [x] I created `thumbnail.webp` with the thumbnail generator.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires (15, for `noctalia.openSettings()`).
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core (this PR ships English only).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for (no network, no spawned processes; the only write is `todo.json`).
- [x] I have the right to publish this code under the `license` declared in `plugin.toml` (MIT).

## Screenshot
<img width="501" height="582" alt="shot-20260728-120433" src="https://github.com/user-attachments/assets/68a200c4-6b4a-4cdc-920c-46adfed34354" />



