### PR TITLE
Update nightwatch75/topgrade-wrapper to 0.0.4 — settings shortcut in the panel header

### DIFF
--- a/topgrade-wrapper/README.md
+++ b/topgrade-wrapper/README.md
@@ -15,8 +15,9 @@ count at a glance without giving up the interactive upgrade.
 
 ## Requirements
 
-Noctalia with plugin API 9 or newer (the panel wires its callbacks as closures),
-and `topgrade` on `PATH`. A terminal emulator is needed for the update run:
+Noctalia v5.0.0-beta.6 or newer — the first tagged release that accepts
+`plugin_api = 15`, which the panel's settings shortcut
+(`noctalia.openSettings()`) needs — and `topgrade` on `PATH`. A terminal emulator is needed for the update run:
 the plugin uses Noctalia's own detection (`$TERMINAL`, then `ghostty`, `kitty`,
 `alacritty`, `wezterm`, `foot`, `konsole`, `gnome-terminal`, `ptyxis`, `xterm`),
 or the one named in the **Terminal** setting.
@@ -67,6 +68,14 @@ noctalia msg panel-toggle nightwatch75/topgrade-wrapper:panel
 | **Update** (panel)                | Run topgrade in a terminal window                           |
 | **Dismiss** (panel)               | Keep the numbers but return the bar glyph to its resting colour |
 | ↻ refresh (panel header)          | Same as **Check Updates**                                   |
+| ⚙ settings (panel header)         | Open this plugin's page in *Settings → Plugins*             |
+
+That settings page also opens from the command line, so it can be bound in your
+compositor too:
+
+```sh
+noctalia msg settings-open-plugin nightwatch75/topgrade-wrapper
+```
 
 The glyph turns to the accent colour with the pending count next to it once a
 check finds something, stays neutral while everything is up to date or after

--- a/topgrade-wrapper/panel.luau
+++ b/topgrade-wrapper/panel.luau
@@ -349,6 +349,17 @@ render = function()
                     request("check")
                 end,
             }),
+            -- Opens the settings window on this plugin's own page (the host
+            -- supplies the plugin id, so a plugin can only ever open its own).
+            -- The panel closes on the way; the engine keeps running.
+            ui.button({
+                glyph = "settings",
+                variant = "ghost",
+                tooltip = tr("tip_settings"),
+                onClick = function()
+                    noctalia.openSettings()
+                end,
+            }),
             ui.button({
                 glyph = "close",
                 variant = "ghost",

--- a/topgrade-wrapper/plugin.toml
+++ b/topgrade-wrapper/plugin.toml
@@ -11,8 +11,8 @@
 
 id = "nightwatch75/topgrade-wrapper"
 name = "Topgrade Wrapper"
-version = "0.0.2"
-plugin_api = 9
+version = "0.0.4"
+plugin_api = 15
 author = "nightwatch75"
 license = "MIT"
 dependencies = ["topgrade"]

--- a/topgrade-wrapper/translations/en.json
+++ b/topgrade-wrapper/translations/en.json
@@ -103,6 +103,7 @@
   "step_planning": "topgrade steps",
   "step_unnamed": "topgrade",
   "tip_check": "Check for updates now",
+  "tip_settings": "Plugin settings",
   "tip_close": "Close",
   "tip_update": "Run topgrade in a terminal window",
   "title": "Topgrade Wrapper",


### PR DESCRIPTION
## Plugin

- **Id:** `nightwatch75/topgrade-wrapper`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`: 0.0.2 → 0.0.4)

## What it does

Updates Topgrade Wrapper from 0.0.2 to 0.0.4. This is a small update — one
feature, plus documentation.

**Settings shortcut in the panel header (plugin API 15).** A ⚙ button, between
the ↻ refresh and the close ✕, opens this plugin's own page in
*Settings → Plugins* via `noctalia.openSettings()`. This plugin has ten
settings — the topgrade config file, the exclusion mode and step list, the
auto-check interval, the terminal, `assume_yes`, `sudo_loop`,
`keep_terminal_open` — so reaching them without leaving the panel is worth more
here than in a plugin with one or two. The same page is reachable from the
command line with `noctalia msg settings-open-plugin
nightwatch75/topgrade-wrapper`, so it can be bound in a compositor.

The panel diff against 0.0.2 is exactly this one button; the check pipeline,
the per-manager expansion, the version display and the terminal launch are
untouched.

**Documentation.** The README now names the release a user can act on
(v5.0.0-beta.6) instead of an API level they cannot map to one, and documents
the settings IPC command above.

**Requires noctalia ≥ v5.0.0-beta.6** (plugin API 15) — the first tagged release
that accepts `plugin_api = 15`, which `noctalia.openSettings()` needs. On older
releases the manifest is correctly rejected as incompatible, and the catalog's
release rows keep serving 0.0.2 to those hosts.

## External dependencies

Unchanged from 0.0.2: `topgrade` on `PATH`, declared in `dependencies` and
listed in the README's *Requirements*.

The check runs `topgrade --dry-run --no-self-update` and then one read-only
listing query per package manager it reports (`checkupdates`, `flatpak
remote-ls --updates`, and so on) — each of those tools is optional and only
affects the count, never the upgrade. The upgrade itself is never run in the
background: it opens a terminal window, using Noctalia's own terminal discovery
unless the *Terminal* setting names one, so package managers can prompt and
sudo can ask for the password on the tty.

No network access of its own (the package managers make their own). No
filesystem writes outside the plugin's own data directory.

## Testing

- [x] Tested on Niri
- **Noctalia version tested against:** v5.0.0-beta.6
- **Plugin API level:** 15

Exercised: panel opened from the bar glyph and via
`noctalia msg panel-toggle nightwatch75/topgrade-wrapper:panel`; **Check
Updates** run against a real Arch system with pacman and flatpak pending;
manager rows expanded and collapsed; package hover detail line; **Dismiss** and
the bar glyph returning to its resting colour; **Update** launching the terminal
and the panel tracking the run; the service IPC actions
(`check`, `update`, `dismiss`); the ⚙ header button and
`noctalia msg settings-open-plugin nightwatch75/topgrade-wrapper`.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the README template, documents every entry id and dependency, and includes the exact panel and service IPC commands.
- [x] I created `thumbnail.webp` with the thumbnail generator.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires (15, for `noctalia.openSettings()`).
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core (this PR ships English only).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml` (MIT).

## Screenshot
<img width="512" height="633" alt="shot-20260728-120747" src="https://github.com/user-attachments/assets/78e56e90-c4f7-4a5d-be0d-fe82a68f9d5f" />

