### PR TITLE
Fix/battery threshold setup

### DIFF
--- a/battery-threshold/README.md
+++ b/battery-threshold/README.md
@@ -58,4 +58,4 @@ noctalia msg plugin damian-ds7/battery-threshold:service all setup
 - **Manual Setup Fallback**: If Polkit is not available, run
   `sudo ./setup_rules.sh` manually from the plugin directory.
 - **Persistence**: Threshold settings are stored in `threshold.txt` in plugin
-  directory and restored across reboots.
+  data directory and restored across reboots.

--- a/battery-threshold/README.md
+++ b/battery-threshold/README.md
@@ -13,12 +13,10 @@ while plugged in, reducing battery wear and heat.
 
 ## Requirements
 
-- `polkit` - required for interactive setup
 - Laptop hardware supporting battery charge threshold control in sysfs
   (`/sys/class/power_supply/*/charge_control_end_threshold`).
-- The following external programs must be available on `PATH`: `test`, `pkexec`,
-  `bash`, `cat`, `getent`, `groupadd`, `usermod`, `udevadm`, `chgrp`, and
-  `chmod`.
+- The following external programs must be available on `PATH`: `test`, `sudo`,
+  `bash`, `readlink`, `cat`, `getent`, `groupadd`, `usermod`, `udevadm`, `chgrp`, and `chmod`.
 
 ## Usage
 

--- a/battery-threshold/plugin.toml
+++ b/battery-threshold/plugin.toml
@@ -7,7 +7,7 @@ description  = "Set the battery threshold for laptop batteries to extend battery
 license      = "MIT"
 icon         = "battery-eco"
 tags         = ["hardware", "system", "utility", "bar", "panel"]
-dependencies = ["test", "pkexec", "bash", "cat", "getent", "groupadd", "usermod", "udevadm", "chgrp", "chmod"]
+dependencies = ["test", "sudo", "bash", "readlink", "cat", "getent", "groupadd", "usermod", "udevadm", "chgrp", "chmod"]
 
 [[service]]
 id    = "service"

--- a/battery-threshold/plugin.toml
+++ b/battery-threshold/plugin.toml
@@ -1,6 +1,6 @@
 id           = "damian-ds7/battery-threshold"
 name         = "Battery Threshold Control"
-version      = "1.0.0"
+version      = "1.0.1"
 plugin_api   = 3
 author       = "Damian D'Souza"
 description  = "Set the battery threshold for laptop batteries to extend battery lifespan"

--- a/battery-threshold/service.luau
+++ b/battery-threshold/service.luau
@@ -171,26 +171,20 @@ local function run_setup()
     local rules_script = plugin_dir .. "/setup_rules.sh"
 
     local cmd =
-        string.format("pkexec bash %s %s", shell_quote(rules_script), shell_quote(user))
+        string.format("bash %s %s", shell_quote(rules_script), shell_quote(user))
 
-    noctalia.log("Running setup script via pkexec: " .. cmd)
-    noctalia.runAsync(cmd, function(result)
-        if result.exitCode == 0 then
-            noctalia.log("Setup completed successfully")
-            noctalia.notify(
-                noctalia.tr("notification.setup-title"),
-                noctalia.tr("notification.setup-success")
-            )
-            check_status()
-        else
-            noctalia.log("Setup failed with exit code " .. tostring(result.exitCode))
-            noctalia.notifyError(
-                noctalia.tr("notification.setup-title"),
-                noctalia.tr("notification.setup-fail")
-            )
-        end
-        noctalia.state.set("run_setup_request", false)
-    end)
+    noctalia.log("Launching setup script in terminal: " .. cmd)
+    local launched = noctalia.runInTerminal(cmd)
+    if launched then
+        noctalia.log("Setup script launched in terminal")
+    else
+        noctalia.log("Failed to launch terminal for setup script")
+        noctalia.notifyError(
+            noctalia.tr("notification.setup-title"),
+            noctalia.tr("notification.setup-fail")
+        )
+    end
+    noctalia.state.set("run_setup_request", false)
 end
 
 noctalia.state.watch("run_setup_request", function(val)

--- a/battery-threshold/setup_rules.sh
+++ b/battery-threshold/setup_rules.sh
@@ -8,22 +8,64 @@
 # It creates a group 'battery_ctl' and adds the target user to this group.
 #
 # Usage:
-#  $ sudo ./setup_rules.sh        # uses SUDO_USER (with sudo)
-#  $ ./setup_rules.sh username    # use provided username (if ran as root)
+#  $ ./setup_rules.sh [username] [--non-interactive|-y]
 # ------------------------------
 set -e
 
-# Check if running as root
-if [ "$EUID" -ne 0 ]; then
-  echo "Error: This script must be run as root (use sudo)"
-  exit 1
+SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+
+TARGET_USER=""
+SKIP_PROMPT=false
+
+for arg in "$@"; do
+  case "$arg" in
+  -y | --non-interactive)
+    SKIP_PROMPT=true
+    ;;
+  -*)
+    ;;
+  *)
+    if [ -z "$TARGET_USER" ]; then
+      TARGET_USER="$arg"
+    fi
+    ;;
+  esac
+done
+
+TARGET_USER="${TARGET_USER:-${SUDO_USER:-$USER}}"
+
+if [ "$SKIP_PROMPT" = false ]; then
+  echo "===================================================="
+  echo " Battery Threshold Udev Setup"
+  echo "===================================================="
+  echo "Script location: $SCRIPT_PATH"
+  echo "Target user:     $TARGET_USER"
+  echo ""
+  echo "Please examine the script location and contents above before proceeding."
+  echo ""
+
+  read -rp "Do you want to proceed with setup? (y/N): " CONFIRM
+  case "$CONFIRM" in
+  [yY][eE][sS] | [yY])
+    ;;
+  *)
+    echo "Setup cancelled by user."
+    read -rp "Press Enter to exit..."
+    exit 1
+    ;;
+  esac
 fi
 
-# Determine target user
-TARGET_USER=${SUDO_USER:-$1}
+# Escalate privileges via sudo only after user confirmation
+if [ "$EUID" -ne 0 ]; then
+  echo ""
+  echo "Escalating privileges via sudo..."
+  exec sudo bash "$SCRIPT_PATH" "$TARGET_USER" --non-interactive
+fi
 
 if [ -z "$TARGET_USER" ]; then
   echo "Error: No target user specified." >&2
+  read -rp "Press Enter to exit..."
   exit 1
 fi
 
@@ -50,5 +92,8 @@ echo "Reloading rules..."
 
 udevadm control --reload-rules && udevadm trigger
 
-echo "You may need a reboot for the plugin's write access to take effect"
+echo ""
+echo "You may need a reboot for the plugin's write access to take effect."
 echo "Done!"
+echo ""
+read -rp "Press Enter to exit..."


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `damian-ds7/battery-threshold`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Minor tweak to setup process, now script will be run initially without sudo in terminal, it will give target user for new rule setup. script location and tell user to examine the script first before confirmation. After getting it, it reruns the script with sudo.

## External dependencies

replaces pkexec with sudo, also readlink required for getting script path in info print.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0~beta.6
- **Plugin API level:** 3

## Screenshots / Videos

Nothing new compared to #7 

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
