### PR TITLE
fix(drive-health): missing daemon WantedBy= (#142)

### DIFF
--- a/drive-health/packaging/noctalia-drive-health.service.in
+++ b/drive-health/packaging/noctalia-drive-health.service.in
@@ -34,3 +34,6 @@ LockPersonality=true
 MemoryDenyWriteExecute=true
 CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SYS_ADMIN CAP_SYS_RAWIO
 ReadWritePaths=/run/noctalia-drive-health
+
+[Install]
+WantedBy=multi-user.target

--- a/drive-health/plugin.toml
+++ b/drive-health/plugin.toml
@@ -1,6 +1,6 @@
 id = "gustav0ar/drive-health"
 name = "Drive Health"
-version = "1.2.5"
+version = "1.2.6"
 plugin_api = 17
 author = "Drive Health contributors"
 license = "MIT"


### PR DESCRIPTION
Without a `WantedBy=` option set in `noctalia-drive-health-service.in`, the service cannot be started, which results in an error.

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** gustav0ar/drive-health
- [ ] New plugin
- [X] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Fix to #142. It allows the `noctalia-drive-health.service` daemon to be ran by setting `WantedBy=multi-user.target`.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
```
"lsblk", "smartctl", "sh", "date", "dirname", "mkdir", "mktemp", "rm", "sed", "cat",
"chmod", "mv", "env", "bash", "install", "systemctl", "pkexec", "id", "tr", "pacman",
"apt-get", "dnf", "zypper", "apk", "xbps-install", "emerge"
```

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** noctalia v5.0.0 (v5.0.0-beta.4-34-g128e48bcfeff)
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 17

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [X] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [X] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [X] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [X] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [X] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [X] I did not edit `catalog.toml`; CI generates it.
- [X] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [X] The code is readable and not obfuscated, minified, or generated.
- [X] It does not download and execute remote code.
- [X] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [X] I have the right to publish this code under the `license` declared in `plugin.toml`.
