### PR TITLE
feat(nix-monitor): update version 1.3.0

### DIFF
--- a/nix-monitor/nix_monitor_service.luau
+++ b/nix-monitor/nix_monitor_service.luau
@@ -168,15 +168,21 @@ function checkGenerations()
 end
 
 -- System stats check
-function checkSystemStats()
+function checkSystemStats(force)
 	if getState("isSystemStatsCheckRunning") then
 		return
 	end
 
-	if cfg("system_stats_check_mode") == "on_start" and getState("systemStatsCheckHasBeenPerformed") then
+	if cfg("system_stats_check_mode") == "off" then
 		return
 	end
 
+	if cfg("system_stats_check_mode") == "on_start" and getState("systemStatsCheckHasBeenPerformed") and not force then
+		return
+	end
+
+	setState("storeSize", "•••")
+	setState("closureSize", "•••")
 	setState("systemStatsCheckHasBeenPerformed", true)
 	setState("isSystemStatsCheckRunning", true)
 	setState("lastSystemStatsCheckRunTime", os.time())
@@ -236,7 +242,7 @@ watchState("command", function(command)
 		cancelRemoteCheck()
 		checkRemoteHash()
 		checkGenerations()
-		checkSystemStats()
+		checkSystemStats(true)
 	end
 
 	if command == "cancel" then

--- a/nix-monitor/nix_monitor_service.luau
+++ b/nix-monitor/nix_monitor_service.luau
@@ -68,6 +68,7 @@ setState("isRemoteCheckRunning", false)
 setState("isUpdateAvailable", false)
 setState("lastGenerationsCheckTime", 0)
 setState("isSystemStatsCheckRunning", false)
+setState("systemStatsCheckHasBeenPerformed", false)
 setState("lastSystemStatsCheckTime", os.time())
 setState("lastSystemStatsCheckRunTime", os.time())
 setState("hasHomeManager", noctalia.commandExists("home-manager"))
@@ -172,6 +173,11 @@ function checkSystemStats()
 		return
 	end
 
+	if cfg("system_stats_check_mode") == "on_start" and getState("systemStatsCheckHasBeenPerformed") then
+		return
+	end
+
+	setState("systemStatsCheckHasBeenPerformed", true)
 	setState("isSystemStatsCheckRunning", true)
 	setState("lastSystemStatsCheckRunTime", os.time())
 
@@ -216,7 +222,12 @@ end
 -- Init
 checkLocalHash()
 checkRemoteHash(10)
-checkSystemStats()
+if cfg("system_stats_check_mode") ~= "off" then
+	checkSystemStats()
+else
+	setState("storeSize", "n/a")
+	setState("closureSize", "n/a")
+end
 
 -- Command watcher
 watchState("command", function(command)

--- a/nix-monitor/panel.luau
+++ b/nix-monitor/panel.luau
@@ -263,13 +263,7 @@ function onUpdateClicked()
 		noctalia.notifyError(tr("notification.update_command_is_empty"))
 		return
 	end
-
-	if cfg("close_on_enter") then
-		command = `{command} && echo && read -p "{tr("terminal.press_enter_to_exit")}"`
-	end
-
-	panel.close()
-	noctalia.runInTerminal(command)
+	runCommandInTerminal(command)
 end
 
 function onCleanClicked()
@@ -278,13 +272,7 @@ function onCleanClicked()
 		noctalia.notifyError(tr("notification.clean_command_is_empty"))
 		return
 	end
-
-	if cfg("close_on_enter") then
-		command = `{command} && echo && read -p "{tr("terminal.press_enter_to_exit")}"`
-	end
-
-	panel.close()
-	noctalia.runInTerminal(command)
+	runCommandInTerminal(command)
 end
 
 function onOptimizeClicked()
@@ -293,11 +281,15 @@ function onOptimizeClicked()
 		noctalia.notifyError(tr("notification.optimize_command_is_empty"))
 		return
 	end
+	runCommandInTerminal(command)
+end
 
+function runCommandInTerminal(command)
 	if cfg("close_on_enter") then
 		command = `{command} && echo && read -p "{tr("terminal.press_enter_to_exit")}"`
 	end
 
+	command = `{command} || (echo && read -p "{tr("terminal.command_exits_non_zero")}")`
 	panel.close()
 	noctalia.runInTerminal(command)
 end

--- a/nix-monitor/plugin.toml
+++ b/nix-monitor/plugin.toml
@@ -1,6 +1,6 @@
 id              = "avivbintangaringga/nix-monitor"
 name            = "Nix Monitor"
-version         = "1.2.0"
+version         = "1.3.0"
 plugin_api      = 3
 icon            = "package"
 author          = "avivbintangaringga"
@@ -129,11 +129,23 @@ min             = 1
 max             = 30
 
 [[setting]]
+key             = "system_stats_check_mode"
+type            = "select"
+label_key       = "setting.system_stats_check_mode.label"
+description_key = "setting.system_stats_check_mode.description"
+options         = [
+    { value = "off", label_key="setting.option.system_stats_check_mode.off" },
+    { value = "on_interval", label_key="setting.option.system_stats_check_mode.on_interval" },
+    { value = "on_start", label_key="setting.option.system_stats_check_mode.on_start" },
+]
+default         = "on_interval"
+
+[[setting]]
 key             = "system_stats_check_interval"
 type            = "int"
 label_key       = "setting.system_stats_check_interval.label"
 description_key = "setting.system_stats_check_interval.description"
-default         = 10
+default         = 60
 min             = 5
 
 [[setting]]
@@ -141,9 +153,8 @@ key             = "system_stats_check_duration_threshold"
 type            = "int"
 label_key       = "setting.system_stats_check_duration_threshold.label"
 description_key = "setting.system_stats_check_duration_threshold.description"
-default         = 5
+default         = 15
 min             = 1
-max             = 30
 
 [[setting]]
 key             = "panel_card_color"

--- a/nix-monitor/translations/en.json
+++ b/nix-monitor/translations/en.json
@@ -160,6 +160,7 @@
     }
   },
   "terminal": {
-    "press_enter_to_exit": "Press enter to exit..."
+    "press_enter_to_exit": "Press enter to exit...",
+    "command_exits_non_zero": "WARNING: Command exits in a non-zero status!\nPress enter to exit..."
   }
 }

--- a/nix-monitor/translations/en.json
+++ b/nix-monitor/translations/en.json
@@ -75,6 +75,11 @@
         "nixos_26_05_small": "NixOS 26.05 Small",
         "nixos_unstable": "NixOS Unstable",
         "nixos_unstable_small": "NixOS Unstable Small"
+      },
+      "system_stats_check_mode": {
+        "off": "Off",
+        "on_interval": "On interval",
+        "on_start": "On start"
       }
     },
     "show_update_available_notification": {
@@ -88,6 +93,10 @@
     "system_stats_check_duration_threshold": {
       "description": "Cancel system stats check if it took too long (in minutes)",
       "label": "System stats check duration threshold"
+    },
+    "system_stats_check_mode": {
+      "description": "Select how system stats checking is performed (off, on interval, on start)",
+      "label": "System stats check mode"
     },
     "system_stats_check_interval": {
       "description": "How often to check for system stats (in minutes)",


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `avivbintangaringga/nix-monitor`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Checks Nixpkgs update by comparing local and remote nixpkgs hash

## External dependencies

 - `nixos-version` -> checks local nix hash
 - `nixos-rebuild` -> checks nixos generations
 - `nix-store` -> optimize nix store
 - `git` -> checks remote nixpkgs hash
 - `pkill` & `kill` -> cancel running job
 - `home-manager` -> check home manager generations (optional)
 - `du` -> check nix store size
 - `nix` -> check closure size
 - `cat`, `echo`, `cut`, `tail`, `grep`, `awk` -> string manipulation stuff
 - `read` -> add "Press enter to exit"

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against: 5.0.0**
- **Plugin API level: 3** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<img width="738" height="417" alt="Screenshot_2026-07-18_14-12-36" src="https://github.com/user-attachments/assets/d4d0086f-043c-4d25-8e79-5fcb6721d339" />

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
