### PR TITLE
ci(workflow): notifying plugin authors in PRs

### DIFF
--- a/.github/workflows/pr-notify-plugin-authors.py
+++ b/.github/workflows/pr-notify-plugin-authors.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+from github import Auth, Github
+
+PR_ID_LABEL = "- **Id:**"
+
+token = os.environ["GITHUB_TOKEN"]
+repo_name = os.environ["REPOSITORY"]
+pull_request_number = os.environ["PULL_REQUEST_NUMBER"]
+
+auth = Auth.Token(token)
+gh = Github(auth=auth)
+repo = gh.get_repo(repo_name)
+
+
+if pull_request_number.isdigit():
+    pull_request_number = int(pull_request_number)
+else:
+    print("Pull Request number is not numeric!")
+    sys.exit(1)
+
+pr = repo.get_pull(pull_request_number)
+body = pr.body
+lines = body.splitlines()
+
+pr_author = pr.user.login
+
+for i in range(len(lines)):
+    line = lines[i]
+    if PR_ID_LABEL in line:
+        id_line = line
+        break
+else:
+    print(f"Pull Request '{pull_request_number}' had no id label. Not a plugin PR probably.")
+    sys.exit(0)
+
+plugin = id_line.replace(PR_ID_LABEL, "").replace("`", "").strip()
+plugin_split = plugin.split("/")
+
+if len(plugin_split) != 2:
+    print(f"Unknown format of plugin name, got {plugin}")
+    sys.exit(1)
+
+author_name = plugin_split[0]
+plugin_name = plugin_split[1]
+
+def is_same_author(author: str):
+    if author == pr_author:
+        print("The author and maintainer of the plugin are the same!")
+        sys.exit(0)
+
+is_same_author(author_name)
+
+manifest_file = f"{plugin_name}/plugin.toml"
+
+if os.path.exists(manifest_file):
+    file_commits = repo.get_commits(path=manifest_file).reversed
+    author = file_commits[0].author.login
+else:
+    print(f"Plugin manifest doesn't exist, {manifest_file}")
+    sys.exit(1)
+
+is_same_author(author)
+
+if author:
+    pr.create_issue_comment(f"CC @{author}")
+else:
+    print("Could not get the author.")
+    sys.exit(1)
+
+

--- a/.github/workflows/pr-notify-plugin-authors.yml
+++ b/.github/workflows/pr-notify-plugin-authors.yml
@@ -1,0 +1,28 @@
+name: Notify Plugin Authors for Pull Requests
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  notify-plugin-authors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.14
+
+      - name: Install dependencies
+        run: pip install PyGithub
+
+      - name: Notify Authors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 .github/workflows/pr-notify-plugin-authors.py


### PR DESCRIPTION
Another workflow add to notify the plugin author, but this time for the pull requests instead of the issues