### PR TITLE
fix(audio-switcher): fix an error printed to logs and change widget color to default

### DIFF
--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,6 +1,6 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
-version = "0.2.0"
+version = "0.2.1"
 plugin_api = 9
 author = "blackbartblues"
 license = "MIT"

--- a/audio-switcher/service.luau
+++ b/audio-switcher/service.luau
@@ -503,12 +503,11 @@ local function loadCurrentVolume(kind, callback)
   local target = kind == "output" and "@DEFAULT_SINK@" or "@DEFAULT_SOURCE@"
   local volumeCommand = kind == "output" and "get-sink-volume" or "get-source-volume"
   local muteCommand = kind == "output" and "get-sink-mute" or "get-source-mute"
-  runPactl({ "-f", "json", volumeCommand, target }, function(volumeResult)
-    if volumeResult.exitCode ~= 0 then
+  runPactl({ "-f", "json", volumeCommand, target }, function(volumeData)
+    if volumeData.exitCode ~= 0 then
       callback(false)
       return
     end
-    local volumeData = decodeJson(volumeResult.stdout)
     if volumeData == nil or type(volumeData.volume) ~= "table" then
       callback(false)
       return

--- a/audio-switcher/service.luau
+++ b/audio-switcher/service.luau
@@ -97,7 +97,7 @@ local function runCommand(args, callback, timeoutMs)
 end
 
 local function runPactl(args, callback, timeoutMs)
-  local command = { "pactl" }
+  local command = { "env", "LC_ALL=C", "pactl" }
   for _, value in ipairs(args) do table.insert(command, value) end
   return runCommand(command, callback, timeoutMs)
 end
@@ -203,6 +203,25 @@ local function firstVolumePercent(volume)
     end
   end
   return 0
+end
+
+local function parseCurrentVolume(output)
+  local decoded = noctalia.json.decode(tostring(output or ""))
+  if type(decoded) == "table" and type(decoded.volume) == "table" then
+    return firstVolumePercent(decoded.volume)
+  end
+  return tonumber(tostring(output or ""):match("(%d+)%%"))
+end
+
+local function parseCurrentMute(output)
+  local decoded = noctalia.json.decode(tostring(output or ""))
+  if type(decoded) == "table" and type(decoded.mute) == "boolean" then
+    return decoded.mute
+  end
+  local value = tostring(output or ""):match("Mute:%s*(%a+)")
+  if value == "yes" then return true end
+  if value == "no" then return false end
+  return nil
 end
 
 local function propertiesOf(item)
@@ -503,27 +522,27 @@ local function loadCurrentVolume(kind, callback)
   local target = kind == "output" and "@DEFAULT_SINK@" or "@DEFAULT_SOURCE@"
   local volumeCommand = kind == "output" and "get-sink-volume" or "get-source-volume"
   local muteCommand = kind == "output" and "get-sink-mute" or "get-source-mute"
-  runPactl({ "-f", "json", volumeCommand, target }, function(volumeData)
-    if volumeData.exitCode ~= 0 then
+  runPactl({ "-f", "json", volumeCommand, target }, function(volumeResult)
+    if volumeResult.exitCode ~= 0 then
       callback(false)
       return
     end
-    if volumeData == nil or type(volumeData.volume) ~= "table" then
+    local volume = parseCurrentVolume(volumeResult.stdout)
+    if volume == nil then
       callback(false)
       return
     end
-    local volume = firstVolumePercent(volumeData.volume)
     runPactl({ "-f", "json", muteCommand, target }, function(muteResult)
       if muteResult.exitCode ~= 0 then
         callback(false)
         return
       end
-      local muteData = decodeJson(muteResult.stdout)
-      if muteData == nil then
+      local muted = parseCurrentMute(muteResult.stdout)
+      if muted == nil then
         callback(false)
         return
       end
-      callback(true, volume, muteData.mute == true)
+      callback(true, volume, muted)
     end)
   end)
 end

--- a/audio-switcher/widget.luau
+++ b/audio-switcher/widget.luau
@@ -45,7 +45,7 @@ local function render()
   if snapshot.busy == true then
     barWidget.setGlyphColor("secondary")
   elseif snapshot.available == true then
-    barWidget.setGlyphColor("primary")
+    barWidget.setGlyphColor("default")
   else
     barWidget.setGlyphColor("error")
   end


### PR DESCRIPTION
## Plugin

- **Id:** `blackbartblues/audio-switcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

1. Removes a JSON decode error that was logged every time the volume changed: `audio-switcher: JSON decode failed: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'V'`
2. Changes the default color of the widget to match other widgets default color.

## External dependencies

None

## Testing

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5, latest main (flake)
- **Plugin API level:** 9

## Screenshots / Videos

Before:
<img width="130" height="29" alt="image" src="https://github.com/user-attachments/assets/2150beaf-1b0a-40c1-865c-e64c85359b55" />
After:
<img width="129" height="31" alt="image" src="https://github.com/user-attachments/assets/44dd8af2-aa3e-4971-96b9-6ce58d5991ec" />

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
