### PR TITLE
lrc: add settings panel for separator

### DIFF
--- a/lrc/README.md
+++ b/lrc/README.md
@@ -22,6 +22,13 @@ Enable `shin/lrc` in Settings → Plugins, then add the **LRC** bar widget. It d
 
 The widget checks MPD first, then falls back to Spotify.
 
+## Settings
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `show_separator` | bool | `true` | Prepend a separator before the lyric text. |
+| `separator` | string | `"\| "` | Text shown before the current lyric line. |
+
 ## Spawned processes
 
 - `playerctl` — enumerates MPRIS players and queries playback status and metadata.

--- a/lrc/plugin.toml
+++ b/lrc/plugin.toml
@@ -1,6 +1,6 @@
 id = "shin/lrc"
 name = "LRC"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 3
 author = "shin"
 license = "MIT"
@@ -9,6 +9,20 @@ deprecated = false
 description = "Displays current song lyrics via lrc_tty."
 tags = ["bar", "music"]
 dependencies = ["lrc_tty", "playerctl"]
+
+[[setting]]
+key = "show_separator"
+type = "bool"
+label_key = "settings.show_separator.label"
+description_key = "settings.show_separator.description"
+default = true
+
+[[setting]]
+key = "separator"
+type = "string"
+label_key = "settings.separator.label"
+description_key = "settings.separator.description"
+default = "| "
 
 [[widget]]
 id = "lrc"

--- a/lrc/translations/en.json
+++ b/lrc/translations/en.json
@@ -1,6 +1,12 @@
 {
-  "settings.show_separator.label": "Show separator",
-  "settings.show_separator.description": "Prepend a separator before the lyric text.",
-  "settings.separator.label": "Separator",
-  "settings.separator.description": "Text shown before the current lyric line."
+  "settings": {
+    "show_separator": {
+      "label": "Show separator",
+      "description": "Prepend a separator before the lyric text."
+    },
+    "separator": {
+      "label": "Separator",
+      "description": "Text shown before the current lyric line."
+    }
+  }
 }

--- a/lrc/translations/en.json
+++ b/lrc/translations/en.json
@@ -1,1 +1,6 @@
-{}
+{
+  "settings.show_separator.label": "Show separator",
+  "settings.show_separator.description": "Prepend a separator before the lyric text.",
+  "settings.separator.label": "Separator",
+  "settings.separator.description": "Text shown before the current lyric line."
+}

--- a/lrc/widget.luau
+++ b/lrc/widget.luau
@@ -2,6 +2,8 @@ noctalia.setUpdateInterval(300)
 
 local fetching = false
 local mpdPlayer = "mpd"
+local showSeparator = noctalia.getConfig("show_separator") ~= false
+local separator = noctalia.getConfig("separator") or "| "
 
 noctalia.runAsync("playerctl -l 2>/dev/null", function(r)
   if r.exitCode == 0 then
@@ -47,7 +49,11 @@ function fetchLyrics(player)
     if r.exitCode == 0 then
       local text = r.stdout:gsub("%s+$", "")
       if #text > 0 and text ~= "(no lyrics)" then
-        barWidget.setText("| " .. text)
+        local prefix = ""
+        if showSeparator then
+          prefix = separator
+        end
+        barWidget.setText(prefix .. text)
         return
       end
     end


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `shin/lrc`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a plugin-level settings panel to the **LRC** bar widget. Users can now toggle the lyric separator on/off and customize its text from Settings → Plugins, instead of it being hardcoded to `"| "`. Version bumped to `1.1.0`.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

No new dependencies.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** 3 <!-- must match plugin_api in plugin.toml -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
