### PR TITLE
feat(workflow): Added the workflow for notifying plugin authors in PR's

### DIFF
--- a/.github/workflows/pr-notify-plugin-authors.yml
+++ b/.github/workflows/pr-notify-plugin-authors.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   notify-plugin-authors:

--- a/.github/workflows/pr-notify-plugin-authors.yml
+++ b/.github/workflows/pr-notify-plugin-authors.yml
@@ -1,0 +1,42 @@
+name: Notify Plugin Authors for Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+    paths-ignore:
+      - catalog.toml
+      - '.**'
+      - README.md
+      - README_TEMPLATE.md
+  workflow_dispatch:
+    inputs:
+      pull-request-number:
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify-plugin-authors:
+    runs-on: ubuntu-latest
+    if: github.repository == 'noctalia-dev/community-plugins'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            .github/workflows/scripts/PyGithub-requirement.txt
+
+      - name: Install dependencies
+        run: pip install -r .github/workflows/scripts/PyGithub-requirement.txt
+
+      - name: Notify Authors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pull-request-number || github.event.pull_request.number }}
+        run: python3 .github/workflows/scripts/pr-notify-plugin-authors.py

--- a/.github/workflows/scripts/issues-check-for-correct-plugin.py
+++ b/.github/workflows/scripts/issues-check-for-correct-plugin.py
@@ -37,4 +37,4 @@ plugin = lines[i].strip()
 
 if "--- SELECT ---" in plugin:
     issue.create_comment("Specify which plugin this issue is about!")
-    issue.edit(state='closed', state_reason='null')
+    issue.edit(state='closed')

--- a/.github/workflows/scripts/pr-notify-plugin-authors.py
+++ b/.github/workflows/scripts/pr-notify-plugin-authors.py
@@ -1,0 +1,70 @@
+import os
+import sys
+
+from github import Auth, Github
+
+token = os.environ["GITHUB_TOKEN"]
+repo_name = os.environ["REPOSITORY"]
+pull_request_number = os.environ["PULL_REQUEST_NUMBER"]
+
+auth = Auth.Token(token)
+gh = Github(auth=auth)
+repo = gh.get_repo(repo_name)
+
+if pull_request_number.isdigit():
+    pull_request_number = int(pull_request_number)
+else:
+    print("Pull Request number is not numeric!")
+    sys.exit(1)
+
+pull_request = repo.get_pull(pull_request_number)
+
+plugin_dirs = set()
+hidden_dirs = set()
+root_files = set()
+
+for file in pull_request.get_files():
+    file_split = file.filename.split("/")
+    if len(file_split) > 1:
+        root_dir = file_split[0]
+        if root_dir.startswith('.'):
+            hidden_dirs.add(root_dir)
+        else:
+            plugin_dirs.add(root_dir)
+    else:
+        root_files.add(file)
+
+if len(plugin_dirs) > 1:
+    print("Multiple plugin changes in one PR!")
+    pull_request.create_issue_comment("This pull request was automatically closed because it contains changes for two or more plugins in one PR!")
+    pull_request.edit(state='closed')
+    sys.exit(0)
+elif len(plugin_dirs) == 1:
+    plugin_dir = plugin_dirs.pop()
+
+    manifest_file = f"{plugin_dir}/plugin.toml"
+
+    if os.path.exists(manifest_file):
+        file_commits = repo.get_commits(path=manifest_file).reversed
+        author = file_commits[0].author
+
+        if author is not None:
+            author = author.login
+        else:
+            print("Author name is null, returning!")
+            sys.exit(1)
+    else:
+        print(f"Plugin manifest doesn't exist, {manifest_file}")
+        sys.exit(0)
+else:
+    print("This is a non-plugin change, returning!")
+    sys.exit(0)
+
+
+pr_author = pull_request.user.login
+
+if pr_author == author:
+    print("The author and maintainer of the plugin are the same!")
+    sys.exit(0)
+else:
+    pull_request.create_issue_comment(f"CC @{author}")


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `test/test`
- [x] New plugin
- [ ] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does
asdasdasd
<!-- A short description, and what a user gets out of it. -->

## External dependencies
asdasdasdasd
<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing
asdasdasdasd
<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [x] Tested on Sway
- [x] Tested on another compositor:
- **Noctalia version tested against:** asdasdasd
- **Plugin API level:** asdasdasdasd <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos
asdasdasdasdasd
<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
