### PR TITLE
[shelly](fix): support shelly v3

### DIFF
--- a/shelly/README.md
+++ b/shelly/README.md
@@ -4,36 +4,41 @@ Shelly is a plugin that uses the [Shelly Arch Package Manager](https://github.co
 
 ## Plugin
 
-| Field   | Value                                   |
-| ------- | --------------------------------------- |
-| ID      | `joshuaslate/shelly`                    |
+| Field   | Value                                          |
+| ------- | ---------------------------------------------- |
+| ID      | `joshuaslate/shelly`                           |
 | Entries | Service: `update_poller`; bar widget: `shelly` |
 
 ## Requirements
 
-Install the Shelly Arch Package Manager from the [AUR](https://aur.archlinux.org/packages/shelly). The `shelly`
+Install the Shelly Arch Package Manager (>= v3.0.0) from the [AUR](https://aur.archlinux.org/packages/shelly). The `shelly`
 command must be available on `PATH`.
 
-Test that it works by running `shelly check-updates` in a terminal. If it returns a list of packages, then it is working correctly.
+Verify the correct version is installed by running `shelly --version` in a terminal. It should return a version number >= 3.0.0.
+
+Test that it works by running `shelly list updates all` in a terminal. If it returns a list of packages, then it is working correctly.
 
 ## Usage
 
 Add the `shelly` widget from Noctalia's widget picker. It periodically checks
 for available Arch package updates and shows their count and names in the bar
 tooltip. Click behavior is configurable: open Shelly's graphical interface,
-run `shelly upgrade-all` in a terminal, or do nothing.
+run `shelly upgrade all` in a terminal, or do nothing.
 
 The `update_poller` service owns the periodic checks and can notify you when
 new updates become available.
 
 ## Settings
 
-| Setting                | Type     | Default      | Description                                                                                        |
-| ---------------------- | -------- | ------------ | -------------------------------------------------------------------------------------------------- |
-| `interval`             | `int`    | `300`        | The interval (in seconds) between update checks                                                    |
-| `notify`               | `bool`   | `false`      | Whether or not you want to receive notifications when there are new package updates available      |
-| `color`                | `color`  | `on_surface` | The text color for the bar widget                                                                  |
-| `glyph_color`          | `color`  | `on_surface` | The color of the glyph on the bar widget                                                           |
-| `glyph`                | `glyph`  | `package`    | Bar widget icon.                                                                                   |
-| `click_action`         | `select` | `open_gui`   | The action to perform when the bar widget is clicked. Options: `open_gui`, `open_updater`, `none`. |
-| `hide_when_up_to_date` | `bool`   | `false`      | Whether or not to hide the bar widget when there are no package updates available                  |
+| Setting                | Type     | Default           | Description                                                                                              |
+| ---------------------- | -------- | ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `interval`             | `int`    | `300`             | The interval (in seconds) between update checks                                                          |
+| `notify`               | `bool`   | `false`           | Whether or not you want to receive notifications when there are new package updates available            |
+| `color`                | `color`  | `on_surface`      | The text color for the bar widget                                                                        |
+| `bar_label`            | `select` | `count_and_label` | The label to display in the bar widget when there are updates. Options: `count_only`, `count_and_label`. |
+| `bar_font_size`        | `int`    | `14`              | The size of the font displayed in the bar widget                                                         |
+| `glyph_color`          | `color`  | `on_surface`      | The color of the glyph on the bar widget                                                                 |
+| `glyph`                | `glyph`  | `package`         | Bar widget icon                                                                                          |
+| `glyph_size`           | `int`    | `14`              | The size of the glyph in the bar widget                                                                  |
+| `click_action`         | `select` | `open_gui`        | The action to perform when the bar widget is clicked. Options: `open_gui`, `open_updater`, `none`.       |
+| `hide_when_up_to_date` | `bool`   | `false`           | Whether or not to hide the bar widget when there are no package updates available                        |

--- a/shelly/plugin.toml
+++ b/shelly/plugin.toml
@@ -48,6 +48,24 @@ entry = "widget.luau"
   default = "on_surface"
 
   [[widget.setting]]
+  key = "bar_label"
+  type = "select"
+  label_key = "settings.bar_label.label"
+  description_key = "settings.bar_label.description"
+  default = "open_gui"
+  options = [
+    { value = "count_and_label", label_key = "settings.bar_label.options.count_and_label" },
+    { value = "count_only", label_key = "settings.bar_label.options.count_only" }
+  ]
+
+  [[widget.setting]]
+  key = "bar_font_size"
+  type = "int"
+  label_key = "settings.bar_font_size.label"
+  description_key = "settings.bar_font_size.description"
+  default = 14
+
+  [[widget.setting]]
   key = "glyph"
   type = "glyph"
   label_key = "settings.glyph.label"
@@ -60,6 +78,13 @@ entry = "widget.luau"
   label_key = "settings.glyph_color.label"
   description_key = "settings.glyph_color.description"
   default = "on_surface"
+
+  [[widget.setting]]
+  key = "glyph_size"
+  type = "int"
+  label_key = "settings.glyph_size.label"
+  description_key = "settings.glyph_size.description"
+  default = 14
 
   [[widget.setting]]
   key = "click_action"

--- a/shelly/plugin.toml
+++ b/shelly/plugin.toml
@@ -1,7 +1,7 @@
 id           = "joshuaslate/shelly"
 name         = "Shelly"
 icon         = "package"
-version      = "1.0.1"
+version      = "2.0.0"
 plugin_api = 3
 license = "MIT"
 author       = "joshuaslate"

--- a/shelly/plugin.toml
+++ b/shelly/plugin.toml
@@ -52,7 +52,7 @@ entry = "widget.luau"
   type = "select"
   label_key = "settings.bar_label.label"
   description_key = "settings.bar_label.description"
-  default = "open_gui"
+  default = "count_and_label"
   options = [
     { value = "count_and_label", label_key = "settings.bar_label.options.count_and_label" },
     { value = "count_only", label_key = "settings.bar_label.options.count_only" }

--- a/shelly/poller.luau
+++ b/shelly/poller.luau
@@ -18,7 +18,7 @@ noctalia.setUpdateInterval(updateInterval)
 function refresh()
   isPolling = true
 
-  noctalia.runAsync("shelly check-updates --json", function(result)
+  noctalia.runAsync("shelly list-updates all --json", function(result)
     isPolling = false
 
     if result.exitCode ~= 0 then
@@ -28,7 +28,14 @@ function refresh()
         return
     end
 
-    local decoded = noctalia.json.decode(result.stdout)
+    local stdout = result.stdout
+
+    -- Shelly's JSON output may leak stderr into stdout. Remove stderr value to ensure valid JSON.
+    if result.stderr ~= "" then
+        stdout = stdout:gsub(result.stderr, "")
+    end
+
+    local decoded = noctalia.json.decode(stdout)
     if type(decoded) ~= "table" then
         updateError = noctalia.tr("bar.tooltip.error.decode_json")
         noctalia.state.set("update_error", updateError)

--- a/shelly/translations/en.json
+++ b/shelly/translations/en.json
@@ -16,7 +16,7 @@
     "tooltip": {
       "aur_title": "AUR",
       "error": {
-        "decode_json": "Failed to decode output from `shelly check-updates --json`"
+        "decode_json": "Failed to decode output from `shelly list-updates all --json`"
       },
       "flatpak_title": "Flatpak",
       "no_updates": "System is up to date",
@@ -30,6 +30,18 @@
     }
   },
   "settings": {
+    "bar_font_size": {
+      "description": "The font size of the bar text.",
+      "label": "Bar Font Size"
+    },
+    "bar_label": {
+      "description": "Label to display in the bar.",
+      "label": "Bar Label",
+      "options": {
+        "count_only": "Count Only (e.g., 5)",
+        "count_and_label": "Count and Label (e.g., 5 Updates)"
+      }
+    },
     "click_action": {
       "description": "What happens when you click on the bar.",
       "label": "Click Action",
@@ -50,6 +62,10 @@
     "glyph_color": {
       "description": "The color of the glyph.",
       "label": "Glyph Color"
+    },
+    "glyph_size": {
+      "description": "The size of the glyph.",
+      "label": "Glyph Size"
     },
     "hide_when_up_to_date": {
       "description": "Whether to hide the bar when there are no updates available.",

--- a/shelly/widget.luau
+++ b/shelly/widget.luau
@@ -2,10 +2,13 @@
 local glyph = noctalia.getConfig("glyph")
 local color = noctalia.getConfig("color") or "on_surface"
 local glyphColor = noctalia.getConfig("glyph_color") or color
+local glyphSize = noctalia.getConfig("glyph_size") or 14
 local updateError = noctalia.state.get("update_error")
 local notifyOnNewUpdates = noctalia.getConfig("notify")
 local hideWhenUpToDate = noctalia.getConfig("hide_when_up_to_date")
 local click_action = noctalia.getConfig("click_action") or "open_gui"
+local barLabelType = noctalia.getConfig("bar_label") or "count_and_label"
+local barFontSize = noctalia.getConfig("bar_font_size") or 14
 local updates = noctalia.state.get("updates") or { Packages = {}, Aur = {}, Flatpak = {} }
 
 local function countUpdates(scopedUpdates)
@@ -71,8 +74,8 @@ local function render()
   local count = countUpdates(updates)
 
   barWidget.render(container({ gap = 6, align = "center", visible = not hideWhenUpToDate or count > 0 }, {
-    ui.glyph({ name = glyph, size = 14, color = glyphColor, visible = glyph ~= "" }),
-    ui.label({ text = noctalia.trp("bar.text.updates", count), color = color }),
+    ui.glyph({ name = glyph, size = glyphSize, color = glyphColor, visible = glyph ~= "" }),
+    ui.label({ text = barLabelType == "count_only" and string.format("%d", count) or noctalia.trp("bar.text.updates", count), color = color, fontSize = barFontSize }),
   }))
 
   updateTooltip(count)
@@ -109,7 +112,7 @@ function onClick()
       return
     end
 
-    noctalia.runInTerminal(cmd .. " upgrade-all")
+    noctalia.runInTerminal(cmd .. " upgrade all")
   end
 end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `joshuaslate/shelly`
- [ ] New plugin
- [X] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
A new major of Shelly was released (v3), which broke this plugin (see #181). This fixes the issues there and adds the requested features:
- Ability to show just the count in the widget (e.g., "5" instead of "5 Updates")
- Ability to change font size in the widget

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
Waited for package updates, saw the count increase, saw the updates available in the tooltip, then clicked through to upgrade all dependencies.

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** noctalia v5.0.0 (v5.0.0-beta.7-8-ga7d2cad44217)
- **Plugin API level:** 3

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
<img width="189" height="80" alt="image" src="https://github.com/user-attachments/assets/e61a011a-8c4a-4d73-9f9f-e57d611af496" />

I didn't grab a screenshot before updating... but the count was > 0, and it showed properly.

## Checklist

- [X] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [X] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [X] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [X] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [X] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [X] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [X] I did not edit `catalog.toml`; CI generates it.
- [X] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [X] The code is readable and not obfuscated, minified, or generated.
- [X] It does not download and execute remote code. ** Not without explicit user interaction. The whole point of this plugin is to update dependencies via Shelly. This plugin only opens shelly and the user handles downloading & updating their packages from there. **
- [X] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [X] I have the right to publish this code under the `license` declared in `plugin.toml`.
