### PR TITLE
fix(game-launcher): use cc from PATH instead of /usr/bin/cc for NixOS…

### DIFF
--- a/game-launcher/.gitignore
+++ b/game-launcher/.gitignore
@@ -1,0 +1,1 @@
+gamelauncher

--- a/game-launcher/panel.luau
+++ b/game-launcher/panel.luau
@@ -362,7 +362,7 @@ local function buildBinary()
   loading = true
   errorMsg = ""
   render()
-  local ok = noctalia.runAsync("/usr/bin/cc -o " .. binary .. " " .. cSource .. " -lsqlite3", function(res)
+  local ok = noctalia.runAsync("cc -o " .. binary .. " " .. cSource .. " -lsqlite3", function(res)
     building = false
     if res.exitCode == 0 then
       loading = false

--- a/game-launcher/plugin.toml
+++ b/game-launcher/plugin.toml
@@ -1,6 +1,6 @@
 id = "alexander/game-launcher"
 name = "Game Launcher"
-version = "1.1.1"
+version = "1.1.2"
 plugin_api = 13
 author = "Alexander"
 license = "MIT"

--- a/game-launcher/search.luau
+++ b/game-launcher/search.luau
@@ -36,7 +36,7 @@ local function ensureGames(cb)
     return
   end
   if not noctalia.fileExists(binary) then
-    local ok = noctalia.runAsync("/usr/bin/cc -o " .. binary .. " " .. cSource .. " -lsqlite3", function(res)
+    local ok = noctalia.runAsync("cc -o " .. binary .. " " .. cSource .. " -lsqlite3", function(res)
       if res.exitCode == 0 then
         runScan()
       else


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `alexander/game-launcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Fixes the remaining part of #73: the scanner was compiled with a hardcoded `/usr/bin/cc`, which does not exist on NixOS. Now builds `gamelauncher` with `cc` from `PATH`. No change on other distros.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

`cc` (compiles `gamelauncher.c`), `libsqlite3-dev`, `xdg-utils` — all already declared in `plugin.toml`.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

Scanner builds and detects Steam games on NixOS (`~/.local/share/Steam`); reporter `@dinhokusanagi` confirmed with a manual `cc` build.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: NixOS (Niri)
- **Noctalia version tested against:**
- **Plugin API level:** 13

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

No visual change — build-path fix only.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR (`1.1.1` → `1.1.2`); `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
