### PR TITLE
feat(audio-switcher): migrate to widget.actions and fix mute status logic

### DIFF
--- a/audio-switcher/README.md
+++ b/audio-switcher/README.md
@@ -60,7 +60,6 @@ Use the settings button in the panel header to open Noctalia's plugin settings.
 | Plugin | `show_percentage` | `bool` | `true` | Show the output volume beside the bar icon; disable it for an icon-only widget. |
 | Plugin | `show_notification_on_switch` | `bool` | `true` | Show a notification when switching device. |
 | Plugin | `show_actions_in_tooltip` | `bool` | `true` | Show actions in tooltip. |
-| Plugin | `scroll_step` | `int` | `5` | Volume points changed by each wheel step over the bar widget (1–25). |
 
 ## IPC and keybinds
 

--- a/audio-switcher/panel.luau
+++ b/audio-switcher/panel.luau
@@ -461,16 +461,7 @@ function onRefresh() sendCommand("refresh") end
 function onScanBluetooth() sendCommand("scan_bluetooth") end
 function onCycleOutput() sendCommand("cycle_output") end
 function onCycleInput() sendCommand("cycle_input") end
-function onOpenSettingsClicked()
-  local started = noctalia.runAsync("noctalia msg settings-open plugins", function(result)
-    if result.timedOut == true or tonumber(result.exitCode) ~= 0 then
-      noctalia.notifyError(tr("title"), tr("errors.command_start"))
-    end
-  end, 5000)
-  if not started then
-    noctalia.notifyError(tr("title"), tr("errors.command_start"))
-  end
-end
+function onOpenSettingsClicked() noctalia.openSettings() end
 
 function onShowOutputs()
   activeTab = "output"

--- a/audio-switcher/panel.luau
+++ b/audio-switcher/panel.luau
@@ -110,7 +110,7 @@ local function volumeCard(kind)
   local isOutput = kind == "output"
   local device = activeDevice(kind)
   local volume = tonumber(isOutput and snapshot.outputVolume or snapshot.inputVolume) or 0
-  local muted = isOutput and snapshot.outputMuted == true or snapshot.inputMuted == true
+  local muted = (isOutput and snapshot.outputMuted == true) or (not isOutput and snapshot.inputMuted == true)
   local icon = isOutput and (muted and "volume-off" or "volume") or (muted and "microphone-mute" or "microphone")
   return ui.column({ flexGrow = 1, gap = 8, padding = 12, radius = 12, fill = "surface_variant/0.45" }, {
     ui.row({ align = "center", gap = 8 }, {

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,7 +1,7 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
-version = "0.3.0"
-plugin_api = 9
+version = "0.4.0"
+plugin_api = 14
 author = "blackbartblues"
 license = "MIT"
 icon = "switch-horizontal"
@@ -30,19 +30,13 @@ label_key = "settings.show_actions_in_tooltip.label"
 description_key = "settings.show_actions_in_tooltip.description"
 default = true
 
-[[setting]]
-key = "scroll_step"
-type = "int"
-label_key = "settings.scroll_step.label"
-description_key = "settings.scroll_step.description"
-default = 5
-min = 1
-max = 25
-step = 1
-
 [[widget]]
 id = "widget"
 entry = "widget.luau"
+
+  [widget.actions]
+  scroll_up = "volume-up"
+  scroll_down = "volume-down"
 
 [[panel]]
 id = "audio-switcher"

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,7 +1,7 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
 version = "0.4.0"
-plugin_api = 14
+plugin_api = 15
 author = "blackbartblues"
 license = "MIT"
 icon = "switch-horizontal"

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -37,6 +37,9 @@ entry = "widget.luau"
   [widget.actions]
   scroll_up = "volume-up"
   scroll_down = "volume-down"
+  left = "panel-toggle blackbartblues/audio-switcher:audio-switcher"
+  right = "plugin blackbartblues/audio-switcher:service all cycle-output"
+  middle = "plugin blackbartblues/audio-switcher:service all cycle-input"
 
 [[panel]]
 id = "audio-switcher"

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -137,7 +137,6 @@
       }
     },
     "input": "Input",
-    "output": "Output",
-    "tooltip": "Output: {output} ({output_volume})\nInput: {input} ({input_volume})\nScroll: change output volume\nLeft click: open Audio Switcher\nRight click: cycle outputs\nMiddle click: cycle inputs"
+    "output": "Output"
   }
 }

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -95,10 +95,6 @@
     "visible_count": "Visible {count}"
   },
   "settings": {
-    "scroll_step": {
-      "description": "How many percentage points each mouse-wheel step changes volume on the bar widget.",
-      "label": "Scroll step"
-    },
     "show_actions_in_tooltip": {
       "description": "Show actions in tooltip.",
       "label": "Show actions in tooltip"

--- a/audio-switcher/widget.luau
+++ b/audio-switcher/widget.luau
@@ -1,8 +1,6 @@
 --!nonstrict
 
-local PANEL_ID = "blackbartblues/audio-switcher:audio-switcher"
 local SNAPSHOT_KEY = "audio_switcher_snapshot"
-local COMMAND_KEY = "audio_switcher_command"
 
 local snapshot = noctalia.state.get(SNAPSHOT_KEY) or {
   available = false,
@@ -13,7 +11,6 @@ local snapshot = noctalia.state.get(SNAPSHOT_KEY) or {
   inputVolume = 0,
   outputMuted = false,
 }
-local requestId = 0
 
 local function activeDevice(devices, fallback)
   for _, device in ipairs(type(devices) == "table" and devices or {}) do
@@ -61,14 +58,6 @@ local function render()
   barWidget.setTooltip(tooltipItems)
 end
 
-local function dispatch(action)
-  requestId += 1
-  noctalia.state.set(COMMAND_KEY, {
-    action = action,
-    requestId = "widget-" .. tostring(os.time()) .. "-" .. tostring(requestId),
-  })
-end
-
 noctalia.state.watch(SNAPSHOT_KEY, function(value)
   if type(value) == "table" then
     snapshot = value
@@ -76,25 +65,8 @@ noctalia.state.watch(SNAPSHOT_KEY, function(value)
   end
 end)
 
-function update()
-  render()
-end
-
 function onConfigChanged()
   render()
 end
 
-function onClick()
-  noctalia.togglePanel(PANEL_ID)
-end
-
-function onRightClick()
-  dispatch("cycle_output")
-end
-
-function onMiddleClick()
-  dispatch("cycle_input")
-end
-
-noctalia.setUpdateInterval(60000)
 render()

--- a/audio-switcher/widget.luau
+++ b/audio-switcher/widget.luau
@@ -3,7 +3,6 @@
 local PANEL_ID = "blackbartblues/audio-switcher:audio-switcher"
 local SNAPSHOT_KEY = "audio_switcher_snapshot"
 local COMMAND_KEY = "audio_switcher_command"
-local RESULT_KEY = "audio_switcher_result"
 
 local snapshot = noctalia.state.get(SNAPSHOT_KEY) or {
   available = false,
@@ -15,7 +14,6 @@ local snapshot = noctalia.state.get(SNAPSHOT_KEY) or {
   outputMuted = false,
 }
 local requestId = 0
-local outputVolumeDraft = nil
 
 local function activeDevice(devices, fallback)
   for _, device in ipairs(type(devices) == "table" and devices or {}) do
@@ -33,7 +31,7 @@ local function render()
   local inputDevice = activeDevice(snapshot.inputs)
   local outputName = outputDevice and tostring(outputDevice.name or "") or noctalia.tr("panel.no_output")
   local inputName = inputDevice and tostring(inputDevice.name or "") or noctalia.tr("panel.no_input")
-  local outputVolume = percent(outputVolumeDraft or snapshot.outputVolume)
+  local outputVolume = percent(snapshot.outputVolume)
   local inputVolume = percent(snapshot.inputVolume)
 
   local glyph = snapshot.outputMuted == true and "volume-off" or "volume"
@@ -73,18 +71,7 @@ end
 
 noctalia.state.watch(SNAPSHOT_KEY, function(value)
   if type(value) == "table" then
-    if outputVolumeDraft ~= nil and tonumber(value.outputVolume) == outputVolumeDraft then
-      outputVolumeDraft = nil
-    end
     snapshot = value
-    render()
-  end
-end)
-
-noctalia.state.watch(RESULT_KEY, function(result)
-  if type(result) ~= "table" or not tostring(result.requestId or ""):match("^widget%-scroll%-") then return end
-  if result.ok ~= true then
-    outputVolumeDraft = nil
     render()
   end
 end)
@@ -107,22 +94,6 @@ end
 
 function onMiddleClick()
   dispatch("cycle_input")
-end
-
-function onScroll(axis, steps)
-  if axis ~= "vertical" then return end
-  local detents = tonumber(steps) or 0
-  if detents == 0 then return end
-  local step = math.max(1, math.min(25, math.floor(tonumber(noctalia.getConfig("scroll_step")) or 5)))
-  local current = tonumber(outputVolumeDraft or snapshot.outputVolume) or 0
-  outputVolumeDraft = math.max(0, math.min(100, math.floor(current - detents * step + 0.5)))
-  render()
-  requestId += 1
-  noctalia.state.set(COMMAND_KEY, {
-    action = "set_output_volume",
-    value = outputVolumeDraft,
-    requestId = "widget-scroll-" .. tostring(os.time()) .. "-" .. tostring(requestId),
-  })
 end
 
 noctalia.setUpdateInterval(60000)


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `blackbartblues/audio-switcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

- Fixes a bug in the panel where both input and output are shown as muted when only input is muted.
- Uses the new openSettings to open the plugin-specific settings page.
- Migrates right, left, middle click, and scroll to the widget.actions entry.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

No dependencies added.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5, latest main (flake)
- **Plugin API level:** 15

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.