### PR TITLE
Update Battery widget plugin

### DIFF
--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -23,7 +23,7 @@ Add it to your desktop/lockscreen widgets using the widget editor. You can confi
 | `hide_plugged` | `bool` | `false` | Hide the battery widget when connected to AC power. |
 | `hide_full` | `bool` | `false` | Hide the battery widget when fully charged. |
 | `color` | `color` | `on_surface` | Color role for this widget's icon and label; fixed hex colors are also supported. |
-| `warning_color` | `color` | `error` | Color applied when charge is at or below 20%. |
+| `warning_color` | `color` | `error` | Color applied when charge is at or below warning threshold. |
 | `charging_color` | `color` | `on_surface` | Color applied when connected to AC power. |
 | `battery` | `select` | `auto` | Detect the battery automatically or set a custom name. |
 | `battery_name` | `string` | `BAT0` | Set a custom name for the battery. |
@@ -32,3 +32,4 @@ Add it to your desktop/lockscreen widgets using the widget editor. You can confi
 ## Notes
 
 `hide_full` and `hide_plugged` do not hide the background due to plugin limitations.
+The warning threshold is pulled from noctalia's settings.

--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -11,7 +11,7 @@ Desktop/lockscreen widget that displays the current battery level and charging s
 
 ## Usage
 
-Add it to your desktop/lockscreen widgets.
+Add it to your desktop/lockscreen widgets using the widget editor. You can configure it in the widget settings.
 
 ## Settings
 

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/battery-widget"
 name = "Battery Widget"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 19
 author = "yocraft"
 license = "MIT"

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -14,96 +14,96 @@ dependencies = []
 id = "widget"
 entry = "widget.luau"
 
-[[setting]]
-key = "layout"
-type = "select"
-label_key = "settings.layout.label"
-description_key = "settings.layout.description"
-default = "horizontal"
-options = [
-    { value = "horizontal", label_key = "settings.layout.horizontal" },
-    { value = "vertical", label_key = "settings.layout.vertical" },
-]
+    [[desktop_widget.setting]]
+    key = "layout"
+    type = "select"
+    label_key = "settings.layout.label"
+    description_key = "settings.layout.description"
+    default = "horizontal"
+    options = [
+        { value = "horizontal", label_key = "settings.layout.horizontal" },
+        { value = "vertical", label_key = "settings.layout.vertical" },
+    ]
 
-[[setting]]
-key = "show_glyph"
-type = "bool"
-label_key = "settings.show_glyph.label"
-description_key = "settings.show_glyph.description"
-default = true
+    [[desktop_widget.setting]]
+    key = "show_glyph"
+    type = "bool"
+    label_key = "settings.show_glyph.label"
+    description_key = "settings.show_glyph.description"
+    default = true
 
-[[setting]]
-key = "show_label"
-type = "bool"
-label_key = "settings.show_label.label"
-description_key = "settings.show_label.description"
-default = true
+    [[desktop_widget.setting]]
+    key = "show_label"
+    type = "bool"
+    label_key = "settings.show_label.label"
+    description_key = "settings.show_label.description"
+    default = true
 
-[[setting]]
-key = "hide_plugged"
-type = "bool"
-label_key = "settings.hide_plugged.label"
-description_key = "settings.hide_plugged.description"
-default = false
+    [[desktop_widget.setting]]
+    key = "hide_plugged"
+    type = "bool"
+    label_key = "settings.hide_plugged.label"
+    description_key = "settings.hide_plugged.description"
+    default = false
 
-[[setting]]
-key = "hide_full"
-type = "bool"
-label_key = "settings.hide_full.label"
-description_key = "settings.hide_full.description"
-default = false
-
-
-[[setting]]
-key = "color"
-type = "color"
-label_key = "settings.color.label"
-description_key = "settings.color.description"
-default = "on_surface"
-advanced = true
-
-[[setting]]
-key = "warning_color"
-type = "color"
-label_key = "settings.warning_color.label"
-description_key = "settings.warning_color.description"
-default = "error"
-advanced = true
-
-[[setting]]
-key = "charging_color"
-type = "color"
-label_key = "settings.charging_color.label"
-description_key = "settings.charging_color.description"
-default = "on_surface"
-advanced = true
+    [[desktop_widget.setting]]
+    key = "hide_full"
+    type = "bool"
+    label_key = "settings.hide_full.label"
+    description_key = "settings.hide_full.description"
+    default = false
 
 
-[[setting]]
-key = "battery"
-type = "select"
-label_key = "settings.battery.label"
-description_key = "settings.battery.description"
-default = "auto"
-options = [
-    { value = "auto", label_key = "settings.battery.auto" },
-    { value = "bat0", label_key = "settings.battery.bat0" },
-    { value = "custom", label_key = "settings.battery.custom" },
-]
+    [[desktop_widget.setting]]
+    key = "color"
+    type = "color"
+    label_key = "settings.color.label"
+    description_key = "settings.color.description"
+    default = "on_surface"
+    advanced = true
 
-[[setting]]
-key = "battery_name"
-type = "string"
-label_key = "settings.battery_name.label"
-description_key = "settings.battery_name.description"
-default = "BAT0"
-visible_when = { key = "battery", values = ["custom"] }
+    [[desktop_widget.setting]]
+    key = "warning_color"
+    type = "color"
+    label_key = "settings.warning_color.label"
+    description_key = "settings.warning_color.description"
+    default = "error"
+    advanced = true
 
-[[setting]]
-key = "refresh_interval"
-type = "int"
-label_key = "settings.refresh_interval.label"
-description_key = "settings.refresh_interval.description"
-default = 60
-min = 1
-max = 600
+    [[desktop_widget.setting]]
+    key = "charging_color"
+    type = "color"
+    label_key = "settings.charging_color.label"
+    description_key = "settings.charging_color.description"
+    default = "on_surface"
+    advanced = true
+
+
+    [[desktop_widget.setting]]
+    key = "battery"
+    type = "select"
+    label_key = "settings.battery.label"
+    description_key = "settings.battery.description"
+    default = "auto"
+    options = [
+        { value = "auto", label_key = "settings.battery.auto" },
+        { value = "bat0", label_key = "settings.battery.bat0" },
+        { value = "custom", label_key = "settings.battery.custom" },
+    ]
+
+    [[desktop_widget.setting]]
+    key = "battery_name"
+    type = "string"
+    label_key = "settings.battery_name.label"
+    description_key = "settings.battery_name.description"
+    default = "BAT0"
+    visible_when = { key = "battery", values = ["custom"] }
+
+    [[desktop_widget.setting]]
+    key = "refresh_interval"
+    type = "int"
+    label_key = "settings.refresh_interval.label"
+    description_key = "settings.refresh_interval.description"
+    default = 60
+    min = 1
+    max = 600

--- a/battery-widget/translations/en.json
+++ b/battery-widget/translations/en.json
@@ -46,7 +46,7 @@
       "label": "Show Label"
     },
     "warning_color": {
-      "description": "Color applied when charge is at or below 20%.",
+      "description": "Color applied when charge is at or below noctalia's warning threshold.",
       "label": "Warning Color"
     }
   }

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -1,5 +1,3 @@
-noctalia.setUpdateInterval(noctalia.getConfig("refresh_interval") * 1000)
-
 local glyph
 local color
 local percent
@@ -115,5 +113,6 @@ if not batName then
 end
 
 function update()
+    noctalia.setUpdateInterval(noctalia.getConfig("refresh_interval") * 1000)
     refreshBattery()
 end

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -75,11 +75,16 @@ local function render()
     desktopWidget.render(layout({ gap = 4, align = "center" }, content))
 end
 
+local function shellEscape(raw)
+    return "'" .. raw:gsub("'", "'\\''") .. "'"
+end
+
 local function refreshBattery()
     noctalia.runAsync(
         "cat "
-        .. path .. batName .. "/capacity "
-        .. path .. batName .. "/status",
+        .. shellEscape(path .. batName .. "/capacity")
+        .. " "
+        .. shellEscape(path .. batName .. "/status"),
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to read battery: " .. result.stderr)

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -70,9 +70,16 @@ local function render()
         table.insert(content, ui.label({ text = percent .. "%", color = color }))
     end
 
-    local layout = noctalia.getConfig("layout") == "vertical" and ui.column or ui.row
+    local vertical = noctalia.getConfig("layout") == "vertical"
 
-    desktopWidget.render(layout({ gap = 4, align = "center" }, content))
+    local layout = vertical and ui.column or ui.row
+
+    desktopWidget.render(
+        layout({
+            gap = vertical and 0 or 4,
+            align = "center"
+        }, content)
+    )
 end
 
 local function shellEscape(raw)

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -3,6 +3,8 @@ local color
 local percent
 local status
 
+local warning_threshold = 20
+
 local path = "/sys/class/power_supply/"
 local batName
 
@@ -43,8 +45,29 @@ local function getGlyph()
     end
 end
 
+local function getWarningThreshold()
+    noctalia.runAsync(
+        "grep warning_threshold ~/.local/state/noctalia/settings.toml | awk '{print $3}'",
+        function(result)
+            if result.exitCode ~= 0 then
+                noctalia.log("battery-widget: failed to get warning_threshold: " .. result.stderr)
+                return
+            end
+
+            local res = result.stdout
+
+            if not warning_threshold then
+                noctalia.log("battery-widget: invalid warning_threshold: " .. res)
+                return
+            end
+            
+            warning_threshold = tonumber(noctalia.string.trim(res))
+        end
+    )
+end
+
 local function getColor()
-    if status ~= "Charging" and percent <= 20 then
+    if status ~= "Charging" and percent <= warning_threshold then
         color = noctalia.getConfig("warning_color")
         return
     end
@@ -123,6 +146,8 @@ if not batName then
     noctalia.log("battery-widget: battery not found")
     return
 end
+
+getWarningThreshold()
 
 function update()
     noctalia.setUpdateInterval(noctalia.getConfig("refresh_interval") * 1000)


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/battery-widget`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Desktop/lockscreen widget that displays the current battery level and charging status.
<!-- A short description, and what a user gets out of it. -->

## External dependencies

None.
<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 19

## Screenshots / Videos

<img width="276" height="84" alt="image" src="https://github.com/user-attachments/assets/1d92b11d-08a9-41de-af6c-47d4667bbc73" />
<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
