### PR TITLE
fix(topgrade-wrapper): force LC_ALL=C for background queries

### DIFF
--- a/topgrade-wrapper/service.luau
+++ b/topgrade-wrapper/service.luau
@@ -86,7 +86,7 @@ local COUNTERS = {
     {
         key = "apt",
         requires = "apt-get",
-        signals = { "apt%-get[^\n]*upgrade", "apt[^\n]*full%-upgrade", "nala[^\n]*upgrade" },
+        signals = { "apt%-get[^\n]*upgrade", "apt[^\n]*full%-upgrade", "apt[^\n]*dist%-upgrade", "nala[^\n]*upgrade" },
         cmd = [[apt-get -s -o Debug::NoLocking=1 upgrade 2>/dev/null | awk '/^Inst /{gsub(/[][]/,"",$3); gsub(/[()]/,"",$4); print $2"\t"$3"\t"$4}']],
     },
     {
@@ -451,7 +451,7 @@ pumpQueue = function()
     local counter = table.remove(queue, 1)
     step = tr("count." .. counter.key)
     publish()
-    local started = noctalia.runAsync(counter.cmd, function(result)
+    local started = noctalia.runAsync("export LC_ALL=C; " .. counter.cmd, function(result)
         -- A query that timed out or reported an error is recorded as unknown
         -- rather than zero: saying "up to date" because a mirror was down would
         -- be a lie. Note that most of these commands end in a filter, so their
@@ -512,7 +512,7 @@ startCheck = function()
     step = tr("step_planning")
     publish()
 
-    local started = noctalia.runAsync(buildCommand(true), function(result)
+    local started = noctalia.runAsync("export LC_ALL=C; " .. buildCommand(true), function(result)
         if result.timedOut then
             failCheck(tr("err_dry_timeout"))
             return


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `nightwatch75/topgrade-wrapper`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Forces `LC_ALL=C` on background package manager queries (`apt`, `snap`, etc.) and the `topgrade --dry-run` to ensure predictable formatting and avoid locale-related parse failures (e.g., when the system language is set to French).

## External dependencies

None

## Testing

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** 15

## Screenshots / Videos

No visual changes.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
