### PR TITLE
Update nightwatch75/topgrade-wrapper to 0.0.6 — version bump for the #204 LC_ALL fix, version shown in the panel header

### DIFF
--- a/topgrade-wrapper/panel.luau
+++ b/topgrade-wrapper/panel.luau
@@ -12,6 +12,18 @@
 local STATE_KEY = "topgrade_state"
 local REQUEST_KEY = "topgrade_request"
 
+-- Read out of the plugin's own manifest (readFile resolves a relative path
+-- against the plugin directory), so the header cannot drift from the version
+-- the store shows. Empty when unreadable — a missing version is not worth an
+-- error line in the panel.
+local pluginVersion = (function()
+    local text = noctalia.readFile("plugin.toml")
+    if type(text) ~= "string" then
+        return ""
+    end
+    return ("\n" .. text):match('\nversion%s*=%s*"([^"]+)"') or ""
+end)()
+
 local snapshot = nil
 local expanded = {} -- manager key -> the package list is open
 local hoverKey = nil -- package row currently under the pointer
@@ -331,14 +343,21 @@ render = function()
     local hasUpdates = totalOf() > 0 and (phase == "ready" or phase == "running")
 
     local children = {
-        ui.row({ gap = 8, align = "center" }, {
+        -- Every child of the header carries a stable key, so the reconciler
+        -- matches roles instead of guessing by position and type.
+        ui.row({ key = "header", gap = 8, align = "center" }, {
             ui.label({
+                key = "title",
                 text = tr("title"),
                 fontSize = 16,
                 fontWeight = "bold",
                 color = "on_surface",
-                flexGrow = 1,
             }),
+            -- Version off the manifest, small and dimmed: it answers "which
+            -- build am I running" without competing with the title. The spacer
+            -- rather than a flexGrow title keeps the two together on the left.
+            ui.label({ key = "version", text = pluginVersion, fontSize = 10, color = "on_surface_variant" }),
+            ui.spacer({ key = "gap", flexGrow = 1 }),
             ui.button({
                 key = "header-check" .. (busy() and "-off" or ""),
                 glyph = "refresh",
@@ -353,6 +372,7 @@ render = function()
             -- supplies the plugin id, so a plugin can only ever open its own).
             -- The panel closes on the way; the engine keeps running.
             ui.button({
+                key = "settings",
                 glyph = "settings",
                 variant = "ghost",
                 tooltip = tr("tip_settings"),
@@ -361,6 +381,7 @@ render = function()
                 end,
             }),
             ui.button({
+                key = "close",
                 glyph = "close",
                 variant = "ghost",
                 tooltip = tr("tip_close"),

--- a/topgrade-wrapper/plugin.toml
+++ b/topgrade-wrapper/plugin.toml
@@ -11,7 +11,7 @@
 
 id = "nightwatch75/topgrade-wrapper"
 name = "Topgrade Wrapper"
-version = "0.0.4"
+version = "0.0.6"
 plugin_api = 15
 author = "nightwatch75"
 license = "MIT"

--- a/topgrade-wrapper/service.luau
+++ b/topgrade-wrapper/service.luau
@@ -48,6 +48,12 @@ local MAX_LISTED = 200
 --              `name<TAB>installed<TAB>available`. Either version may be empty
 --              when the tool does not report it.
 --
+-- Every query — and the dry run itself — is spawned with `export LC_ALL=C;` in
+-- front of it: these parsers key off English words and fixed column layouts
+-- (`^Inst `, the zypper table, the pip header), which a translated system turns
+-- into gibberish. Reported upstream from a French desktop (community-plugins
+-- #204). The interactive run is deliberately left in the user's own locale.
+--
 -- The count is simply how many lines came back, so the number on the bar and the
 -- list the panel expands are the same answer to the same question, asked once:
 -- no second round trip to a mirror, and no way for the two to disagree.


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `nightwatch75/topgrade-wrapper`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Two things, both small.

**1. Version bump for the `LC_ALL=C` fix (#204).**

**2. Plugin version in the panel header.** 

## External dependencies

None new. Unchanged: `topgrade`, plus the terminal emulator the user configures.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.7
- **Plugin API level:** 15

## Screenshots / Videos
Panel header with the version label:

<img width="500" height="130" alt="topgrade-0 0 6-header" src="https://github.com/user-attachments/assets/623cdf08-b9c7-4cc8-b236-c80a6b8b70f2" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
