### PR TITLE
feat(lyrics): Add setting to hide when no lyrics available

### DIFF
--- a/lyrics/README.md
+++ b/lyrics/README.md
@@ -1,4 +1,4 @@
-# Noctalia Lyrics 1.4.4
+# Noctalia Lyrics 1.4.5
 
 Synchronized lyrics for the Noctalia bar, with multiple MPRIS players,
 translation and romanization layers, configurable sources, karaoke highlighting,
@@ -62,7 +62,7 @@ noctalia msg config-reload
 Run validation after every change:
 
 ```sh
-python3 .github/workflows/validate-plugins.py
+python3 .github/workflows/scripts/validate-plugins.py
 noctalia plugins lint lyrics
 sh lyrics/scripts/setup-deps.sh --check
 cd lyrics
@@ -136,10 +136,11 @@ milliseconds, double-line translation and romanization, karaoke highlighting,
 marquee behavior, transitions, fonts, spacing, and side padding.
 
 Per-widget settings control the fallback glyph, artist visibility, paused-state
-visibility, album-cover shape and size, and primary, inactive, and secondary
-lyric colors. Credential and source-specific fields are shown only when their
-matching source is selected; source order, credentials, polling, marquee
-metrics, player filters, and fine layout controls are under Advanced settings.
+visibility, visibility when no lyrics are available, album-cover shape and size,
+and primary, inactive, and secondary lyric colors. Credential and source-specific
+fields are shown only when their matching source is selected; source order,
+credentials, polling, marquee metrics, player filters, and fine layout controls
+are under Advanced settings.
 
 ## Feature test checklist
 

--- a/lyrics/lyrics.luau
+++ b/lyrics/lyrics.luau
@@ -8,6 +8,7 @@ local showGlyph = noctalia.getConfig("show_glyph")
 if showGlyph == nil then showGlyph = true end
 local showArtist = noctalia.getConfig("show_artist")
 local hideWhenPaused = noctalia.getConfig("hide_when_paused")
+local hideWhenNoLyrics = noctalia.getConfig("hide_when_no_lyrics")
 local showCover = noctalia.getConfig("show_cover")
 if showCover == nil then showCover = true end
 local coverShape = noctalia.getConfig("cover_shape") or "circle"
@@ -142,8 +143,12 @@ local function getProgressMs()
   return baselinePosition / 1000 + elapsed
 end
 
+local function hasLyrics()
+  return lyrics and #lyrics > 0 and track
+end
+
 local function getLineInfo()
-  if not lyrics or #lyrics == 0 or not track then return nil end
+  if not hasLyrics() then return nil end
 
   local position = getProgressMs()
   local synced = lyrics[1].time >= 0
@@ -442,7 +447,7 @@ local function currentTransitionLine(info)
 end
 
 local function render()
-  if hideWhenPaused and not playing then
+  if hideWhenPaused and not playing or hideWhenNoLyrics and not hasLyrics() then
     barWidget.setVisible(false)
     return
   end

--- a/lyrics/lyrics.luau
+++ b/lyrics/lyrics.luau
@@ -447,7 +447,8 @@ local function currentTransitionLine(info)
 end
 
 local function render()
-  if hideWhenPaused and not playing or hideWhenNoLyrics and not hasLyrics() then
+  local showingTrack = displayMode == "track" or showMode == "track"
+  if hideWhenPaused and not playing or hideWhenNoLyrics and not showingTrack and not hasLyrics() then
     barWidget.setVisible(false)
     return
   end

--- a/lyrics/plugin.toml
+++ b/lyrics/plugin.toml
@@ -502,6 +502,12 @@ entry = "lyrics.luau"
   default = false
 
   [[widget.setting]]
+  key = "hide_when_no_lyrics"
+  type = "bool"
+  label_key = "settings.hide_when_no_lyrics.label"
+  default = false
+
+  [[widget.setting]]
   key = "show_cover"
   type = "bool"
   label_key = "settings.show_cover.label"

--- a/lyrics/plugin.toml
+++ b/lyrics/plugin.toml
@@ -1,6 +1,6 @@
 id = "h465855hgg/lyrics"
 name = "Lyrics"
-version = "1.4.4"
+version = "1.4.5"
 plugin_api = 3
 author = "h465855hgg"
 license = "MIT"

--- a/lyrics/translations/en.json
+++ b/lyrics/translations/en.json
@@ -148,6 +148,9 @@
     "hide_when_paused": {
       "label": "Hide when paused"
     },
+    "hide_when_no_lyrics": {
+      "label": "Hide when no lyrics"
+    },
     "inactive_color": {
       "description": "Color used for upcoming lyrics, paused playback, and secondary lines.",
       "label": "Inactive lyric color"

--- a/lyrics/translations/zh-Hans.json
+++ b/lyrics/translations/zh-Hans.json
@@ -148,6 +148,9 @@
     "hide_when_paused": {
       "label": "暂停时隐藏"
     },
+    "hide_when_no_lyrics": {
+      "label": "无歌词时隐藏"
+    },
     "inactive_color": {
       "description": "设置未唱歌词、暂停状态和次要歌词行的颜色。",
       "label": "未唱歌词颜色"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `h465855hgg/lyrics`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

An update allowing hiding the widget when no lyrics are available.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [ ] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [ ] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [ ] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [ ] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [ ] I did not edit `catalog.toml`; CI generates it.
- [ ] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [ ] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
