### PR TITLE
i18n(plugins): added german translations for some plugins

### DIFF
--- a/nextboot-selector/plugin.toml
+++ b/nextboot-selector/plugin.toml
@@ -1,6 +1,6 @@
 id              = "avivbintangaringga/nextboot-selector"
 name            = "Next Boot Selector"
-version         = "1.0.1"
+version         = "1.0.2"
 plugin_api      = 9
 icon            = "refresh-dot"
 author          = "avivbintangaringga"

--- a/nextboot-selector/translations/de.json
+++ b/nextboot-selector/translations/de.json
@@ -1,0 +1,32 @@
+{
+  "notification": {
+    "failed_to_set_next_boot": "Der nächste Systemstart konnte nicht festgelegt werden",
+    "timed_out": "Zeitüberschreitung"
+  },
+  "panel": {
+    "reset": "Zurücksetzen",
+    "title": "Auswahl für den nächsten Startvorgang"
+  },
+  "settings" :{
+    "close_on_select": {
+      "description": "Ob das Fenster nach der Auswahl eines Eintrags geschlossen werden soll",
+      "label": "Schließen, wenn ausgewählt"
+    },
+    "excluded_keywords": {
+      "description": "Schlüsselwörter zum Ausschluss von Einträgen (Groß-/Kleinschreibung wird nicht berücksichtigt)",
+      "label": "Ausgeschlossene Schlüsselwörter"
+    },
+    "privilege_command": {
+      "description": "Befehl zum Erhöhen der Berechtigungen des efibootmgr Befehls",
+      "label": "Privilege-Befehl"
+    },
+    "reboot_command": {
+      "description": "Befehl, der ausgeführt werden soll, wenn „Neustart bei Auswahl“ aktiviert ist",
+      "label": "Befehl zum Neustart"
+    },
+    "reboot_on_select": {
+      "description": "Ob nach der Auswahl eines Eintrags automatisch ein Neustart erfolgen soll",
+      "label": "Neustart bei Auswahl"
+    }
+  }
+}

--- a/noctwhspr/plugin.toml
+++ b/noctwhspr/plugin.toml
@@ -1,6 +1,6 @@
 id           = "goodroot/noctwhspr"
 name         = "noctwhspr"
-version      = "1.0.0"
+version      = "1.0.1"
 plugin_api   = 3
 author       = "goodroot"
 license      = "MIT"

--- a/noctwhspr/translations/de.json
+++ b/noctwhspr/translations/de.json
@@ -1,0 +1,9 @@
+{
+  "settings": {
+    "root": {
+      "description": "Verzeichnis, in dem hyprwhspr installiert ist. Behalte die Standardeinstellung bei, es sei denn, hyprwhspr befindet sich unter einem nicht standardmäßigen Präfix.",
+      "label": "hyprwhspr Installationsverzeichnis"
+    }
+  },
+  "title": "noctwhspr"
+}

--- a/portctl/plugin.toml
+++ b/portctl/plugin.toml
@@ -2,7 +2,7 @@
 
 id           = "rxtsel/portctl"
 name         = "Portctl"
-version      = "0.2.2"
+version      = "0.2.3"
 plugin_api = 9
 author       = "Cristhian Melo"
 license      = "MIT"

--- a/portctl/translations/de.json
+++ b/portctl/translations/de.json
@@ -1,0 +1,54 @@
+{
+  "categories": {
+    "cloud": "Cloud",
+    "containers": "Containers",
+    "databases": "Datenbanken",
+    "development": "Entwicklung",
+    "other": "Andere",
+    "servers": "Server"
+  },
+  "panel": {
+    "cancel": "Abbrechen",
+    "kill": "Töten",
+    "kill_confirm": "{name} töten?",
+    "killing": "{name} wird getötet…",
+    "no_ports": "Keine lauschenden Ports",
+    "no_results": "Keine Ergebnisse für \"{query}\"",
+    "pid_copied": "PID {pid} kopiert",
+    "search_placeholder": "Suche Port, Prozess, PID…",
+    "tcp": "TCP",
+    "udp": "UDP"
+  },
+  "service": {
+    "kill_failed": "PID {pid} konnte nicht getötet werden",
+    "ss_not_found": "ss (iproute2) nicht gefunden — Installiere das Paket iproute2",
+    "terminated": "Prozess {pid} wurde beendet"
+  },
+  "settings": {
+    "glyph": {
+      "description": "In der Leiste angezeigtes Symbol",
+      "label": "Symbol"
+    },
+    "hide_system_ports": {
+      "description": "Ports unterhalb von 1024 ausblenden (privilegierte/Root-Ports)",
+      "label": "System Ports ausblenden"
+    },
+    "hide_unknown_ports": {
+      "description": "Ports ausblenden, auf deren Prozessinformationen nicht zugegriffen werden kann (z. B. rootlessport, root-eigene Prozesse ohne sudo)",
+      "label": "Unbekannte Ports ausblenden"
+    },
+    "ignore_list": {
+      "description": "Durch Kommas getrennte Teilzeichenfolgen von Prozessnamen, die ausgeblendet werden sollen (z. B. discord,chrome,steam)",
+      "label": "Prozesse ignorieren"
+    },
+    "ignore_ports": {
+      "description": "Durch Kommas getrennte Portnummern, die ausgeblendet werden sollen (z. B. 37700,6463)",
+      "label": "Ports ignorieren"
+    },
+    "refresh_interval": {
+      "description": "Sekunden zwischen den Port-Scans",
+      "label": "Aktualisierungsintervall"
+    }
+  },
+  "title": "Portctl"
+}

--- a/prismlauncher-instances/plugin.toml
+++ b/prismlauncher-instances/plugin.toml
@@ -1,6 +1,6 @@
 id = "radimous/prismlauncher-instances"
 name = "PrismLauncher Instances"
-version = "1.0.1"
+version = "1.0.2"
 plugin_api = 3
 author = "radimous"
 license = "MIT"

--- a/prismlauncher-instances/translations/de.json
+++ b/prismlauncher-instances/translations/de.json
@@ -1,0 +1,16 @@
+{
+  "no_instances": {
+    "subtitle": "Filter: ",
+    "title": "Keine Instanzen gefunden"
+  },
+  "settings": {
+    "launcher_exec_command": {
+      "description": "Starte Prismlauncher oder einen Fork deiner Wahl",
+      "label": "Prism-Ausführungsdatei"
+    },
+    "prismlauncher_path": {
+      "description": "Pfad zu PrismLauncher",
+      "label": "PrismLauncher Pfad"
+    }
+  }
+}

--- a/proton-pass/plugin.toml
+++ b/proton-pass/plugin.toml
@@ -1,6 +1,6 @@
 id = "lucasoe/proton-pass"
 name = "Proton Pass"
-version = "0.1.0"
+version = "0.1.1"
 plugin_api = 3
 author = "LucasOe"
 license = "MIT"

--- a/proton-pass/translations/de.json
+++ b/proton-pass/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "copied-password": "Passwort in die Zwischenablage kopiert",
+  "failed-list-vaults": "Auflistung der Tresore fehlgeschlagen. Bist du bei pass-cli angemeldet?",
+  "item-not-found": "Eintrag nicht gefunden",
+  "loading-items": "Lade Einträge…",
+  "loading-vaults": "Tresore werden geladen…"
+}

--- a/sharednd/plugin.toml
+++ b/sharednd/plugin.toml
@@ -13,7 +13,7 @@
 
 id = "whyoolw/sharednd"
 name = "ShareDND"
-version = "1.1.1"
+version = "1.1.2"
 plugin_api = 3
 author = "whyoolw"
 license = "MIT"

--- a/sharednd/translations/de.json
+++ b/sharednd/translations/de.json
@@ -1,0 +1,17 @@
+{
+  "notify": {
+    "no_niri_body": "Das sieht nach einer niri-Sitzung aus (NIRI_SOCKET ist gesetzt), aber die niri-Binärdatei befindet sich nicht im PATH, sodass die Bildschirmfreigabe nicht erkannt werden kann.",
+    "no_niri_title": "ShareDND: niri nicht gefunden"
+  },
+  "settings": {
+    "always_off_after": {
+      "description": "Deaktiviere Nicht stören, wenn die Freigabe endet, auch wenn diese Funktion bereits vor Beginn der Freigabe aktiviert war. Im deaktivierten Zustand wird DND nur dann deaktiviert, wenn dieses Plugin es aktiviert hat.",
+      "label": "Immer DND nach dem Teilen deaktivieren"
+    },
+    "only_active": {
+      "description": "Es werden nur Screencasts gezählt, die aktiv gestreamt werden. Ist diese Funktion deaktiviert, bleibt Nicht stören bei jeder geöffneten Screencast-Sitzung aktiviert (auch wenn diese angehalten ist oder nichts anzeigt).",
+      "label": "Nur aktive Streams"
+    }
+  },
+  "title": "ShareDND"
+}

--- a/shelly/plugin.toml
+++ b/shelly/plugin.toml
@@ -1,7 +1,7 @@
 id           = "joshuaslate/shelly"
 name         = "Shelly"
 icon         = "package"
-version      = "2.0.0"
+version      = "2.0.1"
 plugin_api = 3
 license = "MIT"
 author       = "joshuaslate"

--- a/shelly/translations/de.json
+++ b/shelly/translations/de.json
@@ -1,0 +1,84 @@
+{
+  "bar": {
+    "click_handler": {
+      "error": {
+        "missing_cli": "Shelly CLI ist nicht installiert. Bitte installiere es, um diese Funktion nutzen zu können.",
+        "missing_gui": "Shelly GUI ist nicht installiert. Bitte installiere es, um diese Funktion nutzen zu können."
+      }
+    },
+    "text": {
+      "error": "?",
+      "updates": {
+        "one": "{count} Update",
+        "other": "{count} Updates"
+      }
+    },
+    "tooltip": {
+      "aur_title": "AUR",
+      "error": {
+        "decode_json": "Decodierung der Ausgabe von `shelly check-updates --json` fehlgeschlagen"
+      },
+      "flatpak_title": "Flatpak",
+      "no_updates": "System ist auf dem neuesten Stand",
+      "packages_title": "Pakete"
+    }
+  },
+  "notify": {
+    "new_updates": {
+      "description": "Für dein System sind {count} neue Updates verfügbar.",
+      "title": "Neue Updates verfügbar"
+    }
+  },
+  "settings": {
+    "bar_font_size": {
+      "description": "Die Schriftgröße des Balkentextes.",
+      "label": "Schriftgröße der Leiste"
+    },
+    "bar_label": {
+      "description": "Bezeichnung, die in der Leiste angezeigt werden soll.",
+      "label": "Leistenbezeichnung",
+      "options": {
+        "count_and_label": "Zählen und beschriften (z.B. 5 Aktualisierungen)",
+        "count_only": "Nur zählen (z.B. 5)"
+      }
+    },
+    "click_action": {
+      "description": "Was passiert, wenn man auf die Leiste klickt",
+      "label": "Klick Aktion",
+      "options": {
+        "none": "Nichts",
+        "open_gui": "Öffne Shelly GUI",
+        "open_updater": "Start Update in Terminal"
+      }
+    },
+    "color": {
+      "description": "Die Farbe des Textes in der Leiste",
+      "label": "Farbe"
+    },
+    "glyph": {
+      "description": "Das von dem Label angezeigte Symbol",
+      "label": "Symbol"
+    },
+    "glyph_color": {
+      "description": "Die Farbe des Symbols",
+      "label": "Symbol Farbe"
+    },
+    "glyph_size": {
+      "description": "Die Größe des Symbols.",
+      "label": "Symbol Größe"
+    },
+    "hide_when_up_to_date": {
+      "description": "Ob die Leiste ausgeblendet werden soll, wenn keine Aktualisierungen verfügbar sind",
+      "label": "Ausblenden wenn auf dem neuesten Stand"
+    },
+    "interval": {
+      "description": "Wie oft der Dienst im Hintergrund nach Updates sucht",
+      "label": "Aktualisierungsintervall in Sekunden"
+    },
+    "notify": {
+      "description": "Ob bei verfügbaren Updates eine Benachrichtigung angezeigt werden soll",
+      "label": "Benachrichtigen"
+    }
+  },
+  "title": "Shelly"
+}

--- a/todo/plugin.toml
+++ b/todo/plugin.toml
@@ -8,7 +8,7 @@
 
 id = "nightwatch75/todo"
 name = "To Do"
-version = "0.0.14"
+version = "0.0.15"
 plugin_api = 15
 author = "nightwatch75"
 license = "MIT"

--- a/todo/translations/de.json
+++ b/todo/translations/de.json
@@ -1,0 +1,37 @@
+{
+  "clear_done_confirm": "Alle erledigten Einträge löschen?",
+  "clear_done_no": "Abbrechen",
+  "clear_done_yes": "Löschen",
+  "empty": "Noch keine Aufgaben – mit + hinzufügen",
+  "placeholder": "Neue Aufgabe…",
+  "prio_important": "Wichtig",
+  "prio_low": "Niedrig",
+  "prio_medium": "Mittel",
+  "save_failed": "Das Speichern der Aufgabenliste ist fehlgeschlagen",
+  "settings": {
+    "glyph": {
+      "description": "Das Symbol, das für das To Do Widget in der Leiste angezeigt wird.",
+      "label": "Leisten-Symbol"
+    },
+    "todo_folder": {
+      "description": "Ordner, in dem die Aufgabenliste (todo.json) gespeichert ist. Standardmäßig ist dies ~/Dokumente/Todo",
+      "label": "To Do Ordner"
+    }
+  },
+  "sort_manual": "Manuell",
+  "sort_priority": "Priorität",
+  "tip_add": "Aufgabe hinzufügen",
+  "tip_clear_done": "Alle erledigten Aufgaben löschen",
+  "tip_close": "Schließen",
+  "tip_commit": "Speichern (Enter)",
+  "tip_delete": "Aufgabe löschen",
+  "tip_done": "Als erledigt markieren",
+  "tip_edit": "Bearbeiten",
+  "tip_grip": "Neu anordnen – zum Anheben dieser Zeile hier klicken",
+  "tip_grip_drop": "Klicke einen anderen Griff an, um hier abzusetzen, oder diesen hier, um den Vorgang abzubrechen",
+  "tip_settings": "Plugin Einstellungen",
+  "tip_sort": "Modus wechseln",
+  "tip_undone": "Als Aufgabe markieren",
+  "title": "To Do",
+  "tooltip": "To Do — {count} zu erledigen"
+}

--- a/um5606_fan_state/plugin.toml
+++ b/um5606_fan_state/plugin.toml
@@ -1,6 +1,6 @@
 id = "thatonecalculator/um5606_fan_state"
 name = "ASUS UM5606 Fan State"
-version = "1.0.6"
+version = "1.0.7"
 plugin_api = 3
 author = "ThatOneCalculator"
 license = "MIT"

--- a/um5606_fan_state/translations/de.json
+++ b/um5606_fan_state/translations/de.json
@@ -1,0 +1,12 @@
+{
+  "settings": {
+    "poll_interval": {
+      "description": "Abfrageintervall in ms",
+      "label": "Abfrageintervall"
+    },
+    "show_label": {
+      "label": "Label anzeigen"
+    }
+  },
+  "title": "ASUS UM5606 Fan State"
+}

--- a/upbeat/plugin.toml
+++ b/upbeat/plugin.toml
@@ -1,6 +1,6 @@
 id = "neuro/upbeat"
 name = "Upbeat"
-version = "1.0.1"
+version = "1.0.2"
 plugin_api = 3
 author = "neuro"
 license = "MIT"

--- a/upbeat/translations/de.json
+++ b/upbeat/translations/de.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "beat_display": {
+      "description": "Internet-Zeitformat umschalten (.beats)",
+      "label": ".beats anzeigen"
+    },
+    "show_centibeats": {
+      "description": "Anzeige der Subbeats ein-/ausschalten (.xx)",
+      "label": "Subbeats anzeigen"
+    },
+    "time_format_toggle": {
+      "description": "24-Stunden-Anzeige",
+      "label": "24-Stunden-Anzeige umschalten"
+    }
+  }
+}

--- a/web-launcher/plugin.toml
+++ b/web-launcher/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/web-launcher"
 name = "Web Launcher"
-version = "1.0.1"
+version = "1.0.2"
 plugin_api = 3
 author = "yocraft"
 license = "MIT"

--- a/web-launcher/translations/de.json
+++ b/web-launcher/translations/de.json
@@ -1,0 +1,27 @@
+{
+  "notify": {
+    "message": "Öffne {name}",
+    "title": "Websites"
+  },
+  "settings": {
+    "command": {
+      "description": "Befehl zum Starten der Website. Beispiel: \"firefox --new-window\"",
+      "label": "Befehl"
+    },
+    "icon_provider": {
+      "description": "Icon Downloadquelle",
+      "direct": "Website-eigenes favicon.ico",
+      "duckduckgo": "DuckDuckGo",
+      "google": "Google",
+      "label": "Icon Anbieter"
+    },
+    "links": {
+      "description": "Format: Name|https://url",
+      "label": "Links"
+    },
+    "notify": {
+      "description": "Beim öffnen des Links benachrichtigen",
+      "label": "Benachrichtigen"
+    }
+  }
+}

--- a/zed-provider/plugin.toml
+++ b/zed-provider/plugin.toml
@@ -1,6 +1,6 @@
 id = "cleboost/zed-provider"
 name = "Zed Provider"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 3
 author = "cleboost"
 license = "MIT"

--- a/zed-provider/translations/de.json
+++ b/zed-provider/translations/de.json
@@ -1,0 +1,17 @@
+{
+  "database-empty": "Die Zed-Datenbank ist leer oder wurde nicht gefunden",
+  "filter-empty": "Filter: \"{filter}\"",
+  "loading": "Wird geladen…",
+  "loading-subtitle": "Lese Zed-Projekte",
+  "no-projects-found": "Keine Projekte gefunden",
+  "settings": {
+    "db_path": {
+      "description": "Pfad zu Zed's db.sqlite Datei",
+      "label": "Zed-Datenbankpfad"
+    },
+    "max_results": {
+      "description": "Maximale Anzahl der anzuzeigenden Projekte",
+      "label": "Maximale Ergebnisse"
+    }
+  }
+}


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** Too many to list here, see the commit list :D
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

German translations for some plugins 

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [ ] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [ ] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [ ] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
