### PR TITLE
Add noctalia plugin for hyprland layout switching

### DIFF
--- a/hypr-layout-switcher/README.md
+++ b/hypr-layout-switcher/README.md
@@ -1,0 +1,116 @@
+# Hyprland Layout Switcher
+
+A [Noctalia](https://github.com/noctalia-dev/noctalia-shell) plugin that shows the tiled
+layout of the currently active Hyprland workspace in the bar, and lets you cycle through
+layouts with a click or a keybinding.
+
+**Hyprland only.** The plugin talks to `hyprctl` and relies on Hyprland's per-workspace
+`layout` rule, so it does nothing on other compositors (Sway, river, Niri, X11 WMs, …).
+
+## What it does
+
+- A bar widget shows the active workspace's tiled layout as an icon plus its name
+  (`Dwindle`, `Master`, `Monocle`, `Scrolling`).
+- A background service polls `hyprctl activeworkspace -j` once per second and publishes
+  the layout so the widget stays in sync when you switch workspaces or change the layout
+  from elsewhere.
+- Clicking the widget — or sending the plugin an IPC message — cycles to the next layout
+  in the list `dwindle → master → monocle → scrolling → dwindle`.
+- Switching is applied with a workspace rule scoped to the *current* workspace only, so
+  different workspaces can keep different layouts. Special workspaces (scratchpads) are
+  handled too, matched by name instead of id.
+
+Note that `monocle` and `scrolling` come from Hyprland layout plugins; if you don't have
+those installed, cycling onto them will be a no-op on Hyprland's side.
+
+They look like this:
+
+```lua
+-- See https://wiki.hypr.land/Configuring/Layouts/Dwindle-Layout/ for more
+hl.config({
+    dwindle = {
+        preserve_split = true, -- You probably want this
+    },
+})
+
+-- See https://wiki.hypr.land/Configuring/Layouts/Master-Layout/ for more
+hl.config({
+    master = {
+        new_status = "master",
+    },
+})
+
+-- See https://wiki.hypr.land/Configuring/Layouts/Scrolling-Layout/ for more
+hl.config({
+    scrolling = {
+        fullscreen_on_one_column = true,
+    },
+})
+
+```
+
+## Requirements
+
+- Hyprland with `hyprctl` on your `PATH`
+- Noctalia `5.0.0-beta.1` or newer (plugin API 3)
+
+## Installation
+
+Register this repository as a plugin source, then enable the plugin:
+
+```sh
+noctalia msg plugins enable maddingo/hypr-layout-switcher
+```
+
+Finally, add the widget to a bar section in the Noctalia settings — it is listed as
+**Hyprland Layout Switcher → toggle**.
+
+## Key bindings
+
+The plugin exposes a `cycle` IPC command on its `poller` service:
+
+```sh
+noctalia msg plugin maddingo/hypr-layout-switcher:poller all cycle
+```
+
+The signature is `plugin <author/plugin:entry> <target[:bar-name]> <event>`. `poller` is a
+service entry with no visible output, so the target must be `all`.
+
+Bind that in `~/.config/hypr/hyprland.lua`:
+
+```lua
+-- Cycle the active workspace's tiled layout
+bind("SUPER, Tab, exec, "
+  .. "noctalia msg plugin maddingo/hypr-layout-switcher:poller all cycle")
+```
+
+Reload with `hyprctl reload`. The bar widget updates immediately, whether you cycle via
+the keybinding or by clicking it.
+
+If you would rather jump straight to a specific layout instead of cycling, bind
+`hyprctl` directly — the widget picks the change up on its next poll:
+
+```lua
+bind("SUPER, D, exec, hyprctl keyword general:layout dwindle")
+bind("SUPER, M, exec, hyprctl keyword general:layout master")
+```
+
+Note that `general:layout` changes the global default, whereas the plugin's `cycle`
+only affects the active workspace.
+
+## Configuration
+
+There are no settings; to change behaviour, edit the source (fork the repo and add your
+fork as the plugin source). The layout list lives at the top of `service.luau`, and the
+icons at the top of `widget.luau`:
+
+```lua
+local layouts = { "dwindle", "master", "monocle", "scrolling" }
+```
+
+Trim it to the layouts you actually have installed, and keep the `glyphs` table in
+`widget.luau` in sync. Reload the plugin afterwards.
+
+## License
+
+MIT

--- a/hypr-layout-switcher/plugin.toml
+++ b/hypr-layout-switcher/plugin.toml
@@ -1,0 +1,19 @@
+id = "maddingo/hypr-layout-switcher"
+name = "Hyprland Layout Switcher"
+description = "Shows and cycles the active workspace's layout"
+version = "0.1.0"
+min_noctalia = "5.0.0-beta.1"
+plugin_api = 3
+author = "maddingo"
+license = "MIT"
+icon = "layout-grid"
+tags = ["hyprland", "layout", "workspace"]
+dependencies = ["hyprland"]
+
+[[service]]
+id = "poller"
+entry = "service.luau"
+
+[[widget]]
+id = "toggle"
+entry = "widget.luau"

--- a/hypr-layout-switcher/service.luau
+++ b/hypr-layout-switcher/service.luau
@@ -1,0 +1,64 @@
+--!nonstrict
+
+local layouts = { "dwindle", "master", "monocle", "scrolling" }
+
+noctalia.setUpdateInterval(1000)
+
+local lastLayout = nil
+
+local function setLayoutCmd(layout)
+  local lua = string.format(
+    "local w = hl.get_active_special_workspace() or hl.get_active_workspace(); "
+      .. "if w then if w.special then hl.workspace_rule({workspace = tostring(w.name), layout = %q}) "
+      .. "else hl.workspace_rule({workspace = tostring(w.id), layout = %q}) end end",
+    layout, layout
+  )
+  return "hyprctl eval '" .. lua:gsub("'", "'\\''") .. "'"
+end
+
+local function poll()
+  if not noctalia.commandExists("hyprctl") then
+    return
+  end
+  noctalia.runAsync("hyprctl activeworkspace -j", function(result)
+    if result.exitCode ~= 0 then
+      return
+    end
+    local data = noctalia.json.decode(result.stdout)
+    if data == nil then
+      return
+    end
+    local layout = data.tiledLayout
+    if layout and layout ~= lastLayout then
+      lastLayout = layout
+      noctalia.state.set("layout", layout)
+    end
+  end)
+end
+
+local function cycle()
+  local idx = 1
+  for i, l in ipairs(layouts) do
+    if l == lastLayout then
+      idx = (i % #layouts) + 1
+      break
+    end
+  end
+  local nextLayout = layouts[idx]
+  noctalia.runAsync(setLayoutCmd(nextLayout))
+  lastLayout = nextLayout
+  noctalia.state.set("layout", nextLayout)
+end
+
+function onIpc(event)
+  if event == "cycle" then
+    cycle()
+  end
+end
+
+function update()
+  poll()
+end
+
+poll()
+

--- a/hypr-layout-switcher/widget.luau
+++ b/hypr-layout-switcher/widget.luau
@@ -1,0 +1,29 @@
+--!nonstrict
+
+local glyphs = {
+  dwindle   = "layout-grid",
+  master    = "layout-sidebar",
+  monocle   = "square",
+  scrolling = "arrows-horizontal",
+}
+
+local current = "dwindle"
+
+local function render()
+  barWidget.setGlyph(glyphs[current] or "layout-grid")
+  barWidget.setText(current:sub(1, 1):upper() .. current:sub(2))
+end
+
+noctalia.state.watch("layout", function(value)
+  if value then
+    current = value
+    render()
+  end
+end)
+
+function onClick()
+  noctalia.runAsync("noctalia msg plugin maddingo/hyprland-layout:poller all cycle")
+end
+
+render()
+


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `maddingo/hyp-layout-switcher`
- [x] New plugin
- [ ] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Has a little toolbar icon the shows the current layout and cycles through the Hyprland layouts dwindle, monocle, scrolling and master by either clicking on it or sending a key stroke.

<!-- A short description, and what a user gets out of it. -->

## External dependencies
None other than hyprland.
<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0-beta6
- **Plugin API level:** 3 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [ ] The code is readable and not obfuscated, minified, or generated.
- [ ] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
