### PR TITLE
fix(anilist): fixed some TypeErrors

### DIFF
--- a/anilist/plugin.toml
+++ b/anilist/plugin.toml
@@ -1,6 +1,6 @@
 id = "cleboost/anilist"
 name = "AniList (UNOFFICIAL)"
-version = "1.1.1"
+version = "1.1.2"
 plugin_api = 15
 author = "Cleboost"
 license = "MIT"

--- a/anilist/service.luau
+++ b/anilist/service.luau
@@ -318,10 +318,11 @@ local function writeCoverMeta(mediaId, url)
   if not metaPath then
     return
   end
-  noctalia.writeFile(metaPath, noctalia.json.encode({
+  local payload = noctalia.json.encode({
     url = url,
     version = COVER_CACHE_VERSION,
-  }))
+  })
+  noctalia.writeFile(metaPath, payload)
 end
 
 local function removeCoverCache(mediaId)
@@ -1290,10 +1291,11 @@ local function startOAuthLogin()
   local resultPath = dataDir .. "/" .. OAUTH_RESULT_FILE
   noctalia.removeFile(resultPath)
 
-  local credOk = noctalia.writeFile(credPath, noctalia.json.encode({
+  local credPayload = noctalia.json.encode({
     client_id = clientId,
     client_secret = clientSecret,
-  }))
+  })
+  local credOk = noctalia.writeFile(credPath, credPayload)
   if not credOk then
     setError(tr("oauth_unavailable"))
     return

--- a/anilist/service.luau
+++ b/anilist/service.luau
@@ -35,6 +35,7 @@ local oauthStartedAt = 0
 
 local libraryFetch = nil
 local finalizeQueue = nil
+local flushCoverSnapshot
 local legacyCachePurged = false
 local pendingLegacyPurge = false
 
@@ -411,7 +412,7 @@ local function requestCoverSnapshot()
   pendingCoverSnapshot = true
 end
 
-local function flushCoverSnapshot()
+function flushCoverSnapshot()
   if pendingCoverSnapshot then
     pendingCoverSnapshot = false
     publishSnapshot()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `cleboost/anilist`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixed following Errors

`TypeError: Unknown global 'flushCoverSnapshot'; consider assigning to it first`

Error in debug shell: `call to 'update' failed: [string "/home/just1n/.local/state/noctalia/plugins/materialized/community/anilist/service.luau"]:259: attempt to call a nil value`

More TypeErrors
<img width="768" height="113" alt="image" src="https://github.com/user-attachments/assets/209ae5a0-0422-4b73-ac21-a3cb14957733" />


Since I didn't know much about Luau, I fixed these errors with the help from Claude

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** noctalia v5.0.0 (v5.0.0-beta.7-51-ga53b22d338b0)
- **Plugin API level:** 15

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [ ] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [ ] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
