### PR TITLE
Update QR Code Encoder plugin

### DIFF
--- a/qrcode/README.md
+++ b/qrcode/README.md
@@ -30,6 +30,7 @@ Enter your text or URL and click on Generate or press enter to generate the QR c
 | `generate_button` | `bool` | `true` | Show Generate button, disable will submit on enter. |
 | `close_on_copy` | `bool` | `false` | Close the panel when copying the QR code. |
 | `notify` | `select` | `minimal` | Controls the notifications, minimal only notifies when Close on Copy is used. |
+| `keep_on_close` | `bool` | `false` | Keep the input, QR Code, status etc when closing the panel. |
 | `size` | `int` | `8` | Specify module size in dots (pixels). |
 | `correction_level` | `select` | `M` | Specify error correction level. |
 | `glyph` | `glyph` | `qrcode` | Bar widget icon glyph name. |
@@ -38,3 +39,4 @@ Enter your text or URL and click on Generate or press enter to generate the QR c
 ## Notes
 
 The plugin runs entirely locally and does not require network access.
+The plugin does not store anyting in files when the panel is closed, except when `keep_on_close` option is enabled.

--- a/qrcode/panel.luau
+++ b/qrcode/panel.luau
@@ -6,6 +6,7 @@ local status = "idle"
 
 local imageSize = 400
 
+local generateButton = noctalia.getConfig("generate_button")
 local notifyConf = noctalia.getConfig("notify")
 
 local function notify(text, error)
@@ -23,7 +24,7 @@ local function statusText()
     elseif status == "copied" then 
         return noctalia.tr("panel.status.copied")
     else
-        return noctalia.tr("panel.status.idle")
+        return noctalia.tr(generateButton and "panel.status.idle" or "panel.status.idlebis")
     end
 end
 
@@ -38,7 +39,7 @@ local function render()
         })
     }
 
-    if noctalia.getConfig("generate_button") then
+    if generateButton then
         table.insert(
             rowContent,
             ui.button({

--- a/qrcode/panel.luau
+++ b/qrcode/panel.luau
@@ -7,7 +7,22 @@ local status = "idle"
 local imageSize = 400
 
 local generateButton = noctalia.getConfig("generate_button")
+local keepOnClose = noctalia.getConfig("keep_on_close")
 local notifyConf = noctalia.getConfig("notify")
+
+-- when toggling off keep_on_close, the image will not be deleted, so this runs every config change
+if not keepOnClose then
+    local dir = noctalia.pluginDir()
+    local files = noctalia.listDir(dir)
+
+    if files then
+        for _, name in ipairs(files) do
+            if name:match("^qr-") then
+                noctalia.removeFile(dir .. "/" .. name)
+            end
+        end
+    end
+end
 
 local function notify(text, error)
     local cmd = error and noctalia.notifyError or noctalia.notify
@@ -36,6 +51,7 @@ local function render()
             placeholder = noctalia.tr("panel.placeholder"),
             onChange = "onTextChange",
             onSubmit = "onTextSubmit",
+            value = keepOnClose and currentText or ""
         })
     }
 
@@ -171,7 +187,9 @@ local function generate(text)
 end
 
 function onOpen(_context)
-    status = "idle"
+    if not keepOnClose then
+        status = "idle"
+    end
     render()
 end
 
@@ -221,7 +239,10 @@ function onCloseClicked()
 end
 
 function onClose()
-    if imagePath ~= nil then
+    if not keepOnClose and imagePath ~= nil then
         noctalia.removeFile(imagePath)
+        imagePath = nil
+        render()
+        -- calling render() here so it doesn't try to render the image when opening the panel
     end
 end

--- a/qrcode/panel.luau
+++ b/qrcode/panel.luau
@@ -51,7 +51,7 @@ local function render()
             placeholder = noctalia.tr("panel.placeholder"),
             onChange = "onTextChange",
             onSubmit = "onTextSubmit",
-            value = keepOnClose and currentText or ""
+            value = currentText
         })
     }
 
@@ -242,6 +242,8 @@ function onClose()
     if not keepOnClose and imagePath ~= nil then
         noctalia.removeFile(imagePath)
         imagePath = nil
+        errorMessage = nil
+        currentText = ""
         render()
         -- calling render() here so it doesn't try to render the image when opening the panel
     end

--- a/qrcode/plugin.toml
+++ b/qrcode/plugin.toml
@@ -74,6 +74,13 @@ options = [
 ]
 
 [[setting]]
+key = "keep_on_close"
+type = "bool"
+label_key = "settings.keep_on_close.label"
+description_key = "settings.keep_on_close.description"
+default = false
+
+[[setting]]
 key = "size"
 type = "int"
 label_key = "settings.size.label"

--- a/qrcode/plugin.toml
+++ b/qrcode/plugin.toml
@@ -14,6 +14,9 @@ dependencies = [ "qrencode" ]
 id = "widget"
 entry = "widget.luau"
 
+    [widget.actions]
+    left = "panel-toggle yocraft/qrcode:panel"
+
     [[widget.setting]]
     key = "glyph"
     type = "glyph"

--- a/qrcode/plugin.toml
+++ b/qrcode/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/qrcode"
 name = "QR Code Encoder"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 15
 author = "yocraft"
 license = "MIT"

--- a/qrcode/translations/en.json
+++ b/qrcode/translations/en.json
@@ -50,7 +50,8 @@
             "error": "Error: {message}",
             "ready": "QR code ready. Scan it here or click it to copy.",
             "copied": "QR code copied to clipboard.",
-            "idle": "Enter some text, then press Generate."
+            "idle": "Enter some text, then press Generate.",
+            "idlebis": "Enter some text, then press Enter."
         },
         "error": {
             "generate_failed": "failed to generate the QR code.",

--- a/qrcode/translations/en.json
+++ b/qrcode/translations/en.json
@@ -19,6 +19,10 @@
             "minimal": "Minimal",
             "none": "None"
         },
+        "keep_on_close": {
+            "label": "Keep on Close",
+            "description": "Keep the input, QR Code, status etc when closing the panel."
+        },
         "size": {
             "label": "QR Code Size",
             "description": "Specify module size in dots (pixels)."

--- a/qrcode/widget.luau
+++ b/qrcode/widget.luau
@@ -7,7 +7,3 @@ else
 end
 
 barWidget.setTooltip(noctalia.tr("widget.tooltip"))
-
-function onClick()
-    noctalia.togglePanel("yocraft/qrcode:panel")
-end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/qrcode`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Transform any text or URL into a QR code completely offline. Then scan or copy the code.
<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
qrencode

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 15

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
