### PR TITLE
update bookmarks to 1.3.1

### DIFF
--- a/bookmarks/README.md
+++ b/bookmarks/README.md
@@ -134,16 +134,15 @@ Two types of entries exist: `bookmark` and `folder`.
 }
 ```
 
-| Key                                               | Type    | Required / Default                          | Notes                                           |
-| ------------------------------------------------- | ------- | ------------------------------------------- | ----------------------------------------------- |
-| `type`                                            | string  | `"bookmark"`                                |                                                 |
-| `glyph`                                           | string  | falls back to `"bookmark"` if empty/missing |                                                 |
-| `label`                                           | string  | required, enforced at save time             | `""` fails validation                           |
-| `cmd`                                             | string  | required for bookmarks                      | shell command to execute, enforced at save time |
-| `description`                                     | string  | optional, defaults to `""`                  | shown in the info tooltip if enabled            |
-| `runInBackground`                                 | boolean | optional, defaults to `false`               | mutually exclusive with `runInTerminal` in      |
-| the UI but the schema itself doesn't enforce that |
-| `runInTerminal`                                   | boolean | optional, defaults to `false`               |
+| Key               | Type    | Required / Default                          | Notes                                                                                        |
+| ----------------- | ------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `type`            | string  | `"bookmark"`                                |                                                                                              |
+| `glyph`           | string  | falls back to `"bookmark"` if empty/missing |                                                                                              |
+| `label`           | string  | required, enforced at save time             | `""` fails validation                                                                        |
+| `cmd`             | string  | required for bookmarks                      | shell command to execute, enforced at save time                                              |
+| `description`     | string  | optional, defaults to `""`                  | shown in the info tooltip if enabled                                                         |
+| `runInBackground` | boolean | optional, defaults to `false`               | mutually exclusive with `runInTerminal` in the UI but the schema itself doesn't enforce that |
+| `runInTerminal`   | boolean | optional, defaults to `false`               |
 
 ### Folders
 
@@ -156,13 +155,12 @@ Two types of entries exist: `bookmark` and `folder`.
 }
 ```
 
-| Key                                  | Type   | Required/Default                                                        | Notes      |
-| ------------------------------------ | ------ | ----------------------------------------------------------------------- | ---------- |
-| `type`                               | string | `"folder"`                                                              |
-| `glyph`                              | string | falls back to `"folder"` if empty/missing                               |
-| `label`                              | string | required                                                                |
-| `items`                              | array  | optional, treated as `{}` if missing, `folder.items=folder.items or {}` | contents — |
-| bookmarks only, one level of nesting |
+| Key     | Type   | Required/Default                                                        | Notes                                           |
+| ------- | ------ | ----------------------------------------------------------------------- | ----------------------------------------------- |
+| `type`  | string | `"folder"`                                                              |
+| `glyph` | string | falls back to `"folder"` if empty/missing                               |
+| `label` | string | required                                                                |
+| `items` | array  | optional, treated as `{}` if missing, `folder.items=folder.items or {}` | contents — bookmarks only, one level of nesting |
 
 ## Settings
 
@@ -199,3 +197,10 @@ The plugin itself has the following settings:
 - Index tracking on root level for keyboard-centric usage
   - Previously, when using a keyboard to navigate, going into a folder would reset the selected
     entry's index to 1 causing fat fingers to be annoying
+
+### v1.3.1
+
+- Fixed a bug where hovering over a bookmark would trigger scrolling event in populated lists
+    - It was also causing the scroll bar to render incorrectly
+    - The fix introduces a new bug where navigating items via keybinds doesn't trigger scrolling.
+    This issue will be fixed in future

--- a/bookmarks/bk_provider.luau
+++ b/bookmarks/bk_provider.luau
@@ -246,7 +246,7 @@ function onActivate(id)
 			local entry = item.entry
 			local cmd = entry.cmd
 			if type(cmd) ~= "string" or cmd == "" then
-				noctalia.notifyError(noctalia.tr("title"), noctalia.tr("err_no_command"))
+				noctalia.notifyError(noctalia.tr("title"), noctalia.tr("err.no_command"))
 				return
 			end
 			local label = entry.label or cmd
@@ -270,7 +270,7 @@ function onActivate(id)
 				if result.exitCode ~= 0 then
 					local detail = noctalia.string.trim(result.stderr or "")
 					local msg = noctalia.tr(
-						"err_exit_code",
+						"err.exit_code",
 						{ label = label, code = tostring(result.exitCode) }
 					)
 					if detail ~= "" then
@@ -283,7 +283,7 @@ function onActivate(id)
 			if not ok then
 				noctalia.notifyError(
 					noctalia.tr("title"),
-					noctalia.tr("err_launch_failed", { label = label })
+					noctalia.tr("err.launch_failed", { label = label })
 				)
 			end
 			return

--- a/bookmarks/panel.luau
+++ b/bookmarks/panel.luau
@@ -49,21 +49,6 @@ local function recallSelection(folder, rowCount)
 	return math.min(math.max(rememberedSelection[folder or 0] or 1, 1), rowCount)
 end
 
--- ui.scroll has no scroll-into-view API, so instead of scrolling to the
--- selection we only render a window of rows around it - the selection is
--- then always inside what's drawn. ROWS_PER_SCREEN is a rough fit for the
--- panel's height; doesn't need to be exact.
-local ROWS_PER_SCREEN = 9
-
-local function visibleWindow(count, selected)
-	if count <= ROWS_PER_SCREEN or selected == nil then
-		return 1, math.min(count, ROWS_PER_SCREEN)
-	end
-	local startIndex =
-		math.max(1, math.min(selected - ROWS_PER_SCREEN // 2, count - ROWS_PER_SCREEN + 1))
-	return startIndex, startIndex + ROWS_PER_SCREEN - 1
-end
-
 local draftKind = "bookmark" -- "bookmark" | "folder", set when the form opens
 local draftGlyph = "bookmark"
 local draftLabel = ""
@@ -157,13 +142,13 @@ local function loadBookmarks()
 	local raw, readErr = noctalia.readFile(path)
 	if raw == nil then
 		bookmarks = {}
-		listError = noctalia.tr("err_read_failed", { error = tostring(readErr) })
+		listError = noctalia.tr("err.read_failed", { error = tostring(readErr) })
 		return
 	end
 	local decoded, decodeErr = noctalia.json.decode(raw)
 	if type(decoded) ~= "table" then
 		bookmarks = {}
-		listError = noctalia.tr("err_corrupt", { error = tostring(decodeErr) })
+		listError = noctalia.tr("err.corrupt", { error = tostring(decodeErr) })
 		return
 	end
 	bookmarks = decoded
@@ -172,7 +157,7 @@ end
 
 local function saveBookmarks()
 	if path == nil then
-		return false, noctalia.tr("err_no_data_dir")
+		return false, noctalia.tr("err.no_data_dir")
 	end
 	local encoded, encodeErr = noctalia.json.encode(bookmarks)
 	if encoded == nil then
@@ -232,7 +217,7 @@ local function moveEntryTo(list, fromIndex, beforeIndex)
 		restoreArray(list, snapshot)
 		noctalia.notifyError(
 			noctalia.tr("title"),
-			noctalia.tr("err_reorder_failed", { error = err })
+			noctalia.tr("err.reorder_failed", { error = err })
 		)
 	end
 end
@@ -259,7 +244,7 @@ local function moveEntryAcross(fromList, fromIndex, toList)
 		restoreArray(toList, toSnapshot)
 		noctalia.notifyError(
 			noctalia.tr("title"),
-			noctalia.tr("err_reorder_failed", { error = err })
+			noctalia.tr("err.reorder_failed", { error = err })
 		)
 		return false
 	end
@@ -272,7 +257,7 @@ end
 local function runBookmark(entry)
 	local cmd = entry.cmd
 	if type(cmd) ~= "string" or cmd == "" then
-		noctalia.notifyError(noctalia.tr("title"), noctalia.tr("err_no_command"))
+		noctalia.notifyError(noctalia.tr("title"), noctalia.tr("err.no_command"))
 		return
 	end
 	local label = entry.label or cmd
@@ -295,7 +280,7 @@ local function runBookmark(entry)
 		if result.exitCode ~= 0 then
 			local detail = noctalia.string.trim(result.stderr or "")
 			local msg =
-				noctalia.tr("err_exit_code", { label = label, code = tostring(result.exitCode) })
+				noctalia.tr("err.exit_code", { label = label, code = tostring(result.exitCode) })
 			if detail ~= "" then
 				msg = msg .. ": " .. detail
 			end
@@ -307,7 +292,7 @@ local function runBookmark(entry)
 	if not ok then
 		noctalia.notifyError(
 			noctalia.tr("title"),
-			noctalia.tr("err_launch_failed", { label = label })
+			noctalia.tr("err.launch_failed", { label = label })
 		)
 	end
 end
@@ -384,7 +369,7 @@ local function moveToRootDropBar()
 	}, {
 		ui.glyph({ name = "corner-left-up", size = 14, color = "primary" }),
 		ui.label({
-			text = noctalia.tr("drop_out_of_folder"),
+			text = noctalia.tr("edit.drop_out_of_folder"),
 			fontSize = 12,
 			color = "primary",
 			flexGrow = 1,
@@ -451,11 +436,11 @@ local function entryRow(entry, index)
 	elseif not editMode and parseBool(noctalia.getConfig("show_info_button")) then
 		local description = noctalia.string.trim(entry.description or "")
 		local cmd = entry.cmd or ""
-		local infoTooltip = noctalia.tr("info_cmd_line", { cmd = cmd })
+		local infoTooltip = noctalia.tr("info.cmd_line", { cmd = cmd })
 		if description ~= "" then
 			infoTooltip = infoTooltip
 				.. "\n"
-				.. noctalia.tr("info_description_line", { description = description })
+				.. noctalia.tr("info.description_line", { description = description })
 		end
 		table.insert(
 			trailing,
@@ -474,7 +459,7 @@ local function entryRow(entry, index)
 				glyph = "pencil",
 				variant = "secondary",
 				controlSize = "sm",
-				tooltip = noctalia.tr("edit_tooltip"),
+				tooltip = noctalia.tr("edit.edit_tooltip"),
 				onClick = function()
 					_onEditEntry(index)
 				end,
@@ -483,7 +468,7 @@ local function entryRow(entry, index)
 				glyph = "trash",
 				variant = "destructive",
 				controlSize = "sm",
-				tooltip = noctalia.tr("delete_tooltip"),
+				tooltip = noctalia.tr("edit.delete_tooltip"),
 				onClick = function()
 					_onDeleteEntry(index)
 				end,
@@ -546,7 +531,7 @@ local function entryRow(entry, index)
 				payload = tostring(index),
 				previewAncestor = 1,
 				liftFromLayout = true,
-				tooltip = noctalia.tr("drag_tooltip"),
+				tooltip = noctalia.tr("edit.drag_tooltip"),
 				width = 16,
 				height = 16,
 			}, {
@@ -720,10 +705,9 @@ local function listView()
 				})
 			)
 		else
-			local startIndex, endIndex = visibleWindow(#results, selectedIndex)
 			local rows = {}
-			for rowIndex = startIndex, endIndex do
-				table.insert(rows, searchResultRow(results[rowIndex], rowIndex))
+			for rowIndex, result in ipairs(results) do
+				table.insert(rows, searchResultRow(result, rowIndex))
 			end
 			table.insert(children, ui.scroll({ flexGrow = 1, gap = 2 }, rows))
 		end
@@ -733,7 +717,7 @@ local function listView()
 	local topButtons = {
 		ui.button({
 			key = "new-bookmark",
-			text = noctalia.tr("new_bookmark"),
+			text = noctalia.tr("entry_form.new_bookmark"),
 			glyph = "plus",
 			variant = "primary",
 			flexGrow = 1,
@@ -749,7 +733,7 @@ local function listView()
 			topButtons,
 			ui.button({
 				key = "new-folder",
-				text = noctalia.tr("new_folder"),
+				text = noctalia.tr("entry_form.new_folder"),
 				glyph = "folder-plus",
 				variant = "secondary",
 				flexGrow = 1,
@@ -767,7 +751,9 @@ local function listView()
 			variant = "ghost",
 			controlSize = "sm",
 			width = 32,
-			tooltip = noctalia.tr(editMode and "hide_controls_tooltip" or "show_controls_tooltip"),
+			tooltip = noctalia.tr(
+				editMode and "edit.hide_controls_tooltip" or "edit.show_controls_tooltip"
+			),
 			onClick = "_onToggleEditMode",
 		})
 	)
@@ -795,19 +781,14 @@ local function listView()
 		)
 	else
 		local count = #list
-		local startIndex, endIndex = visibleWindow(count, selectedIndex)
 		local rows = {}
-		for index = startIndex, endIndex do
+		for index = 1, count do
 			if editMode then
 				table.insert(rows, insertionGap(index, "before"))
 			end
 			table.insert(rows, entryRow(list[index], index))
 		end
-		-- The trailing "after last row" gap only belongs at the very end of
-		-- the real list, not at the end of a windowed slice that's cut off
-		-- partway through - an "after" gap mid-list would duplicate the
-		-- "before" gap of the row right after the window.
-		if editMode and count > 0 and endIndex == count then
+		if editMode and count > 0 then
 			table.insert(rows, insertionGap(count, "after"))
 		end
 		table.insert(children, ui.scroll({ flexGrow = 1, gap = 2 }, rows))
@@ -818,7 +799,7 @@ local function listView()
 			children,
 			ui.button({
 				key = "delete-folder",
-				text = noctalia.tr("delete_folder_button"),
+				text = noctalia.tr("folder.delete_folder_button"),
 				glyph = "trash",
 				variant = "destructive",
 				onClick = "_onDeleteFolder",
@@ -833,9 +814,11 @@ local function formView()
 	local isFolder = draftKind == "folder"
 	local title
 	if editingIndex ~= nil then
-		title = isFolder and noctalia.tr("edit_folder") or noctalia.tr("edit_bookmark")
+		title = isFolder and noctalia.tr("entry_form.edit_folder")
+			or noctalia.tr("entry_form.edit_bookmark")
 	else
-		title = isFolder and noctalia.tr("new_folder") or noctalia.tr("new_bookmark")
+		title = isFolder and noctalia.tr("entry_form.new_folder")
+			or noctalia.tr("entry_form.new_bookmark")
 	end
 
 	local children = {
@@ -850,7 +833,7 @@ local function formView()
 			ui.button({
 				glyph = "close",
 				variant = "ghost",
-				tooltip = noctalia.tr("cancel_button"),
+				tooltip = noctalia.tr("entry_form.cancel_button"),
 				onClick = "_onCancelBookmark",
 			}),
 		}),
@@ -864,7 +847,7 @@ local function formView()
 			ui.input({
 				key = "glyph-input-" .. formRev,
 				value = draftGlyph,
-				placeholder = noctalia.tr("glyph_field"),
+				placeholder = noctalia.tr("entry_form.glyph_field"),
 				controlSize = "sm",
 				flexGrow = 1,
 				onChange = "_onGlyphChange",
@@ -874,8 +857,8 @@ local function formView()
 		ui.input({
 			key = "label-input-" .. formRev,
 			value = draftLabel,
-			placeholder = isFolder and noctalia.tr("folder_name_field")
-				or noctalia.tr("label_field"),
+			placeholder = isFolder and noctalia.tr("entry_form.folder_name_field")
+				or noctalia.tr("entry_form.label_field"),
 			controlSize = "sm",
 			focus = true,
 			onChange = "_onLabelChange",
@@ -888,7 +871,7 @@ local function formView()
 			ui.input({
 				key = "cmd-input-" .. formRev,
 				value = draftCmd,
-				placeholder = noctalia.tr("cmd_field"),
+				placeholder = noctalia.tr("entry_form.cmd_field"),
 				controlSize = "sm",
 				onChange = "_onCmdChange",
 			})
@@ -899,7 +882,7 @@ local function formView()
 			ui.input({
 				key = "description-input-" .. formRev,
 				value = draftDescription,
-				placeholder = noctalia.tr("description_field"),
+				placeholder = noctalia.tr("entry_form.description_field"),
 				controlSize = "sm",
 				onChange = "_onDescriptionChange",
 			})
@@ -914,7 +897,7 @@ local function formView()
 					onChange = "_onRunInBackgroundChange",
 				}),
 				ui.label({
-					text = noctalia.tr("run_in_background_field"),
+					text = noctalia.tr("entry_form.run_in_background_field"),
 					fontSize = 13,
 					color = "on_surface",
 				}),
@@ -930,7 +913,7 @@ local function formView()
 					onChange = "_onRunInTerminalChange",
 				}),
 				ui.label({
-					text = noctalia.tr("run_in_terminal_field"),
+					text = noctalia.tr("entry_form.run_in_terminal_field"),
 					fontSize = 13,
 					color = "on_surface",
 				}),
@@ -946,12 +929,12 @@ local function formView()
 		children,
 		ui.row({ gap = 8, justify = "end" }, {
 			ui.button({
-				text = noctalia.tr("save_button"),
+				text = noctalia.tr("entry_form.save_button"),
 				variant = "primary",
 				onClick = "_onSaveBookmark",
 			}),
 			ui.button({
-				text = noctalia.tr("cancel_button"),
+				text = noctalia.tr("entry_form.cancel_button"),
 				variant = "destructive",
 				onClick = "_onCancelBookmark",
 			}),
@@ -1074,7 +1057,7 @@ function _onDeleteFolder()
 		table.insert(bookmarks, currentFolder, removed)
 		noctalia.notifyError(
 			noctalia.tr("title"),
-			noctalia.tr("err_delete_failed", { error = err })
+			noctalia.tr("err.delete_failed", { error = err })
 		)
 		render()
 		return
@@ -1082,7 +1065,7 @@ function _onDeleteFolder()
 
 	noctalia.notify(
 		noctalia.tr("title"),
-		noctalia.tr("folder_deleted", { label = removed.label or "" })
+		noctalia.tr("folder.folder_deleted", { label = removed.label or "" })
 	)
 	-- Folder selections are now stale (indices after the deleted one
 	-- shifted), so drop everything but root's.
@@ -1167,7 +1150,9 @@ function _onSaveBookmark()
 	local isFolder = draftKind == "folder"
 
 	if label == "" then
-		draftError = noctalia.tr(isFolder and "err_label_required" or "err_label_cmd_required")
+		draftError = noctalia.tr(
+			isFolder and "entry_form.err_label_required" or "entry_form.err_label_cmd_required"
+		)
 		render()
 		return
 	end
@@ -1176,7 +1161,7 @@ function _onSaveBookmark()
 	if not isFolder then
 		cmd = noctalia.string.trim(draftCmd)
 		if cmd == "" then
-			draftError = noctalia.tr("err_label_cmd_required")
+			draftError = noctalia.tr("entry_form.err_label_cmd_required")
 			render()
 			return
 		end
@@ -1223,7 +1208,7 @@ function _onSaveBookmark()
 		else
 			table.remove(list)
 		end
-		draftError = noctalia.tr("err_save_failed", { error = err })
+		draftError = noctalia.tr("err.save_failed", { error = err })
 		render()
 		return
 	end
@@ -1329,7 +1314,7 @@ function _onDeleteEntry(index)
 		-- rather than blocking, to stay consistent with existing delete UX.
 		noctalia.notify(
 			noctalia.tr("title"),
-			noctalia.tr("folder_deleted", { label = entry.label or "" })
+			noctalia.tr("folder.folder_deleted", { label = entry.label or "" })
 		)
 	end
 
@@ -1342,7 +1327,7 @@ function _onDeleteEntry(index)
 		table.insert(list, index, removed)
 		noctalia.notifyError(
 			noctalia.tr("title"),
-			noctalia.tr("err_delete_failed", { error = err })
+			noctalia.tr("err.delete_failed", { error = err })
 		)
 		render()
 		return

--- a/bookmarks/plugin.toml
+++ b/bookmarks/plugin.toml
@@ -1,6 +1,6 @@
 id           = "dunarand/bookmarks"
 name         = "Bookmarks"
-version      = "1.3.0"
+version      = "1.3.1"
 plugin_api   = 13
 author       = "dunarand"
 license      = "MIT"

--- a/bookmarks/translations/en.json
+++ b/bookmarks/translations/en.json
@@ -1,52 +1,60 @@
 {
   "back_button": "Back",
-  "cancel_button": "Cancel",
-  "cmd_field": "Shell command",
-  "delete_folder_button": "Delete folder",
-  "delete_tooltip": "Delete",
-  "description_field": "Description (optional)",
-  "drag_tooltip": "Drag to reorder, or onto a folder to file it inside",
-  "drop_out_of_folder": "Drop here to move back to the main panel",
-  "edit_bookmark": "Edit Bookmark",
-  "edit_folder": "Edit Folder",
-  "edit_tooltip": "Edit",
+  "edit": {
+    "delete_tooltip": "Delete",
+    "drag_tooltip": "Drag to reorder, or onto a folder to file it inside",
+    "drop_out_of_folder": "Drop here to move back to the main panel",
+    "edit_tooltip": "Edit",
+    "hide_controls_tooltip": "Hide reorder/edit/delete controls",
+    "show_controls_tooltip": "Show reorder/edit/delete controls"
+  },
+  "entry_form": {
+    "cancel_button": "Cancel",
+    "cmd_field": "Shell command",
+    "description_field": "Description (optional)",
+    "edit_bookmark": "Edit Bookmark",
+    "edit_folder": "Edit Folder",
+    "err_label_cmd_required": "Label and command are required",
+    "err_label_required": "Label is required",
+    "folder_name_field": "Folder name",
+    "glyph_field": "Glyph name (e.g. bookmark)",
+    "label_field": "Label",
+    "new_bookmark": "New Bookmark",
+    "new_folder": "New Folder",
+    "run_in_background_field": "Run in background",
+    "run_in_terminal_field": "Run in terminal",
+    "save_button": "Save"
+  },
   "entry_saved": "Saved \"{label}\"",
   "entry_updated": "Updated \"{label}\"",
-  "err_corrupt": "Bookmarks file is corrupt: {error}",
-  "err_delete_failed": "Failed to delete: {error}",
-  "err_exit_code": "\"{label}\" exited with code {code}",
-  "err_label_cmd_required": "Label and command are required",
-  "err_label_required": "Label is required",
-  "err_launch_failed": "Failed to launch \"{label}\"",
-  "err_no_command": "This bookmark has no command",
-  "err_no_data_dir": "No data directory available",
-  "err_read_failed": "Failed to read bookmarks: {error}",
-  "err_reorder_failed": "Failed to reorder: {error}",
-  "err_save_failed": "Failed to save: {error}",
-  "folder_deleted": "Deleted folder \"{label}\" and its contents",
-  "folder_name_field": "Folder name",
-  "glyph_field": "Glyph name (e.g. bookmark)",
-  "hide_controls_tooltip": "Hide reorder/edit/delete controls",
-  "info_cmd_line": "Command: {cmd}",
-  "info_description_line": "Description: {description}",
-  "label_field": "Label",
-  "new_bookmark": "New Bookmark",
-  "new_folder": "New Folder",
+  "err": {
+    "corrupt": "Bookmarks file is corrupt: {error}",
+    "delete_failed": "Failed to delete: {error}",
+    "exit_code": "\"{label}\" exited with code {code}",
+    "launch_failed": "Failed to launch \"{label}\"",
+    "no_command": "This bookmark has no command",
+    "no_data_dir": "No data directory available",
+    "read_failed": "Failed to read bookmarks: {error}",
+    "reorder_failed": "Failed to reorder: {error}",
+    "save_failed": "Failed to save: {error}"
+  },
+  "folder": {
+    "delete_folder_button": "Delete folder",
+    "folder_deleted": "Deleted folder \"{label}\" and its contents"
+  },
+  "info": {
+    "cmd_line": "Command: {cmd}",
+    "description_line": "Description: {description}"
+  },
   "no_bookmarks": "No bookmarks yet",
   "no_search_results": "No matching bookmarks",
   "open_tooltip": "Open",
-  "run_in_background_field": "Run in background",
-  "run_in_terminal_field": "Run in terminal",
-  "save_button": "Save",
   "search_placeholder": "Search bookmarks...",
   "settings": {
     "bk_sort_by": {
       "description": "How bookmarks are ordered in \"/bk\" results when there's no search text.",
       "label": "/bk sort order",
-      "options": {
-        "history": "Recently used",
-        "usage_count": "Most used"
-      }
+      "options": { "history": "Recently used", "usage_count": "Most used" }
     },
     "data_path": {
       "description": "Where data.json is stored. Leave empty to use the default plugin data directory.",
@@ -73,6 +81,5 @@
       "label": "Tooltip"
     }
   },
-  "show_controls_tooltip": "Show reorder/edit/delete controls",
   "title": "Bookmarks"
 }

--- a/bookmarks/translations/tr.json
+++ b/bookmarks/translations/tr.json
@@ -1,56 +1,68 @@
 {
   "back_button": "Geri",
-  "cancel_button": "İptal",
-  "cmd_field": "Shell Komutu",
-  "delete_folder_button": "Klasörü Sil",
-  "delete_tooltip": "Sil",
-  "description_field": "Açıklama (İsteğe bağlı)",
-  "drag_tooltip": "Sıralamak için sürükle veya bir klasörün içine bırak",
-  "drop_out_of_folder": "Ana panele göndermek için buraya bırak",
-  "edit_bookmark": "Yer İmini Düzenle",
-  "edit_folder": "Klasörü Düzenle",
-  "edit_tooltip": "Düzenle",
+  "edit": {
+    "delete_tooltip": "Sil",
+    "drag_tooltip": "Sıralamak için sürükle veya bir klasörün içine bırak",
+    "drop_out_of_folder": "Ana panele göndermek için buraya bırak",
+    "edit_tooltip": "Düzenle",
+    "hide_controls_tooltip": "Sıralama/düzenleme/silme kontrollerini gizle",
+    "show_controls_tooltip": "Sıralama/düzenleme/silme kontrollerini göster"
+  },
+  "entry_form": {
+    "cancel_button": "İptal",
+    "cmd_field": "Shell Komutu",
+    "description_field": "Açıklama (İsteğe bağlı)",
+    "edit_bookmark": "Yer İmini Düzenle",
+    "edit_folder": "Klasörü Düzenle",
+    "err_label_cmd_required": "Etiket ve komut alanları gerekli",
+    "err_label_required": "Etiket gerekli",
+    "folder_name_field": "Klasör ismi",
+    "glyph_field": "Simge (ör. bookmark)",
+    "label_field": "İsim etiketi",
+    "new_bookmark": "Yeni Yer İmi",
+    "new_folder": "Yeni Klasör",
+    "run_in_background_field": "Arka planda çalıştır",
+    "run_in_terminal_field": "Konsolda çalıştır",
+    "save_button": "Kaydet"
+  },
   "entry_saved": "\"{label}\" kaydedildi",
   "entry_updated": "\"{label}\" güncellendi",
-  "err_corrupt": "Bozuk yer imleri dosyası: {error}",
-  "err_delete_failed": "Silinemedi: {error}",
-  "err_exit_code": "\"{label}\" {code} ile sonlandı",
-  "err_label_cmd_required": "Etiket ve komut alanları gerekli",
-  "err_label_required": "Etiket gerekli",
-  "err_launch_failed": "\"{label}\" açılamadı",
-  "err_no_command": "Bu yer iminin bir komutu yok",
-  "err_no_data_dir": "Eksik veri dizgini",
-  "err_read_failed": "Yer imleri okunamadı: {error}",
-  "err_reorder_failed": "Sıralama Yapılamadı: {error}",
-  "err_save_failed": "Kaydedilemedi: {error}",
-  "folder_deleted": "\"{label}\" klasörü ve içeriği silindi",
-  "folder_name_field": "Klasör ismi",
-  "glyph_field": "Simge (ör. bookmark)",
-  "hide_controls_tooltip": "Sıralama/düzenleme/silme kontrollerini gizle",
-  "info_cmd_line": "Komut: {cmd}",
-  "info_description_line": "Açıklama: {description}",
-  "label_field": "İsim etiketi",
-  "new_bookmark": "Yeni Yer İmi",
-  "new_folder": "Yeni Klasör",
+  "err": {
+    "corrupt": "Bozuk yer imleri dosyası: {error}",
+    "delete_failed": "Silinemedi: {error}",
+    "exit_code": "\"{label}\" {code} ile sonlandı",
+    "launch_failed": "\"{label}\" açılamadı",
+    "no_command": "Bu yer iminin bir komutu yok",
+    "no_data_dir": "Eksik veri dizgini",
+    "read_failed": "Yer imleri okunamadı: {error}",
+    "reorder_failed": "Sıralama Yapılamadı: {error}",
+    "save_failed": "Kaydedilemedi: {error}"
+  },
+  "folder": {
+    "delete_folder_button": "Klasörü Sil",
+    "folder_deleted": "\"{label}\" klasörü ve içeriği silindi"
+  },
+  "info": {
+    "cmd_line": "Komut: {cmd}",
+    "description_line": "Açıklama: {description}"
+  },
   "no_bookmarks": "Henüz bir yer imi yok",
   "no_search_results": "Eşleşen yer imi yok",
   "open_tooltip": "Aç",
-  "run_in_background_field": "Arka planda çalıştır",
-  "run_in_terminal_field": "Konsolda çalıştır",
-  "save_button": "Kaydet",
   "search_placeholder": "Yer imlerinde ara...",
   "settings": {
     "bk_sort_by": {
       "description": "\"/bk\" sonuçlarının arama yapılmadığı durumda yer imlerini nasıl sıralacağını belirler.",
       "label": "/bk sıralama önceliği",
-      "options": {
-        "history": "Son kullanılanlar",
-        "usage_count": "En sık kullanılanlar"
-      }
+      "options": { "history": "Son kullanılanlar", "usage_count": "En sık kullanılanlar" }
     },
     "data_path": {
       "description": "data.json dosyasının saklandığı konum. Varsayılan eklenti veri konumunu kullanmak için boş bırakın.",
       "label": "Veri dosyası"
+    },
+    "enable_bk_provider": {
+      "description": "Başlatıcıya, yer imlerini fuzzy-aramak ve çalıştırmak için \"/bk\" komutunu ekler.",
+      "label": "Enable /bk launcher provider"
     },
     "glyph": {
       "description": "Çubuk aracının simgesi (ör. bookmark)",
@@ -69,6 +81,5 @@
       "label": "İsim etiketi"
     }
   },
-  "show_controls_tooltip": "Sıralama/düzenleme/silme kontrollerini göster",
   "title": "Yer İmleri"
 }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `dunarand/bookmarks`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

- Fixed a bug where hovering over an item in populated lists would trigger auto-scrolling
- Fixed scrollbar rendering incorrectly
- Refactored translation strings to use nested keys when applicable

## External dependencies

not changed

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
