### PR TITLE
feat(phone-connect): option to hide battery icon

### DIFF
--- a/phone-connect/plugin.toml
+++ b/phone-connect/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "icefish/phone-connect"
 name = "Phone Connect"
-version = "0.1.1"
+version = "0.1.2"
 plugin_api = 16
 author = "icefish"
 license = "MIT"
@@ -99,6 +99,13 @@ entry = "service.luau"
 [[widget]]
 id = "bar"
 entry = "widget.luau"
+
+  [[widget.setting]]
+  key = "show_battery_icon"
+  type = "bool"
+  label_key = "widget.show_battery_icon.label"
+  description_key = "widget.show_battery_icon.description"
+  default = true
 
 # Right-click opens settings via onRightClick in the script
 # (noctalia.openSettings). Left-click toggles the details panel. We deliberately

--- a/phone-connect/translations/en.json
+++ b/phone-connect/translations/en.json
@@ -116,5 +116,11 @@
     "not_paired": "Not paired",
     "offline": "Offline",
     "unavailable": "Unavailable"
+  },
+  "widget": {
+    "show_battery_icon": {
+      "description": "Show widget battery icon",
+      "label": "Battery Icon"
+    }
   }
 }

--- a/phone-connect/widget.luau
+++ b/phone-connect/widget.luau
@@ -57,6 +57,7 @@ local function render()
 	local backend = noctalia.state.get("pc.backend") or { available = false }
 	local d = selectedDevice()
 	local enableCharging = noctalia.getConfig("enable_charging_animation")
+	local showBatteryIcon = noctalia.getConfig("show_battery_icon")
 
 	local children
 	if not backend.available then
@@ -93,8 +94,11 @@ local function render()
 			local batColor = "on_surface"
 			if charging then batColor = "primary"
 			elseif charge <= 20 then batColor = "error" end
-			table.insert(kids, ui.glyph({ name = batteryGlyph(charge, charging),
-				size = 12, color = batColor }))
+
+  		if showBatteryIcon then
+  			table.insert(kids, ui.glyph({ name = batteryGlyph(charge, charging),
+					size = 12, color = batColor }))
+			end
 			table.insert(kids, ui.label({
 				text = tostring(charge) .. "%", fontSize = 11,
 				fontWeight = "medium", color = batColor,


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `icefish/phone-connect`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Add widget option to hide battery icon.

## External dependencies

None

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.7-71-ge41c99439605)
- **Plugin API level:** 16

## Screenshots / Videos

None

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
