### PR TITLE
fix(arch-updater): reduce CPU work in the HTTP callback

### DIFF
--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -54,6 +54,7 @@ local sinceCheck = 0
 local startupTicks = 0
 local sinceNewsCheck = 0
 local newsStateLoaded = false
+local newsDirty = false
 
 local startCheck
 local checkNews
@@ -537,7 +538,7 @@ checkNews = function()
         local parsed, items = pcall(parseNewsFeed, res.body)
         if parsed and type(items) == "table" then
             applyNewsItems(items)
-            publish()
+            newsDirty = true
         end
     end)
     if not ok then
@@ -736,6 +737,11 @@ function update()
             sinceNewsCheck = 0
             checkNews()
         end
+    end
+
+    if newsDirty then
+        newsDirty = false
+        publish()
     end
 end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yuuto/arch-updater`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
reduces CPU usage by moving the news publish from HTTP-callback into the next `update()` call

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
- `pacman-contrib` (`checkupdates`) required, for the pacman update check.
- `yay` or `paru` optional, for the AUR check/update. Auto-detected, or set
  explicitly via the **AUR helper** setting.
- `flatpak` optional, for the Flatpak check/update. Skipped automatically
  if not installed.
- `xdg-open` optional, to open a package's page or the Arch news page.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.7-64-g50f0f095053a
- **Plugin API level:**<!-- must match plugin_api in plugin.toml --> 9

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
