### PR TITLE
fix(w-engine): sync palette when restoring wallpaper on startup

### DIFF
--- a/w-engine/plugin.toml
+++ b/w-engine/plugin.toml
@@ -1,6 +1,6 @@
 id = "tadomika_ari/w-engine"
 name = "W Engine"
-version = "1.1.0"
+version = "1.1.1"
 # Tile and control callbacks are Luau closures rather than named globals, which
 # the host resolves from plugin API 9 onwards.
 plugin_api = 9

--- a/w-engine/start.luau
+++ b/w-engine/start.luau
@@ -791,13 +791,17 @@ publishStatus()
 noctalia.runAsync(
 	"pkill linux-wallpaper 2>/dev/null; sleep 1; pkill -KILL linux-wallpaper 2>/dev/null; true",
 	function()
-		-- Bring back whatever was playing before the reload, cycle included.
+		-- Bring back whatever was playing before the reload, cycle included. The
+		-- palette is re-synced alongside the process: the shell restores its own
+		-- wallpaper on login, which drops the still we set for the live scene and
+		-- leaves the colors from whatever it picked instead.
 		for _, output in ipairs(noctalia.outputs()) do
 			local name = output.name
 			local id = data.current[name]
 			if type(id) == "string" and id ~= "" then
 				elapsed[name] = 0
 				launch(name, id)
+				syncPalette(name, id)
 			end
 		end
 		publishStatus()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `tadomika_ari/w-engine`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes the palette not matching the wallpaper after login.

The startup restore relaunched `linux-wallpaperengine` for the last selected
wallpaper but never re-applied the still that Noctalia derives its palette from,
so the colors after login came from whatever wallpaper the shell restored on its
own. Every other path that puts a wallpaper up pairs `launch()` with
`syncPalette()`; the startup path in `start.luau` now does too.

Switching wallpapers away and back was the only way to correct it, since that
runs `apply()`, which already syncs.

The sync runs inside the existing `runAsync` callback that follows the
`pkill; sleep 1` sweep, so it lands after the shell has finished its own startup
wallpaper restore rather than racing it. It is a no-op when the `sync_colors`
setting is off, and it cannot clobber the restore stash: `setShellWallpaper`
only records `saved_wallpaper[output]` when that entry is `nil`, and it is
already populated from the session where the wallpaper was picked. Stop still
restores the user's original wallpaper.

## External dependencies

None beyond what the plugin already declares (`linux-wallpaperengine`, `kill`,
`setsid`, `pkill`, plus optional `ffmpeg` for video frame extraction). This
change adds no new dependency, network call, or spawned process — it reuses the
existing `syncPalette()` helper.

## Testing

Reproduced and verified on a real login, not just a simulated one.

Forced reproduction, mid-session:

1. Clobbered the output's wallpaper to an unrelated image with
   `noctalia msg wallpaper-set HDMI-A-1 <other.png>`, so the palette no longer
   matched the running scene.
2. `noctalia msg plugins disable tadomika_ari/w-engine` — wallpaper stayed clobbered.
3. `noctalia msg plugins enable tadomika_ari/w-engine` — within 2s the wallpaper
   was back to the wallpaper's `preview.jpg` and held there across 12s of polling.
   Engine relaunched on the same wallpaper.

Real login, on a different wallpaper than the one used above:

- `linux-wallpaperengine` came up on the persisted selection (`2596848703`).
- `noctalia msg wallpaper-get <output>` returned that wallpaper's
  `preview.gif` — the still for the scene actually on screen.
- `noctalia msg color-scheme-get` reported `wallpaper m3-tonal-spot`, generated
  from that still, so the palette matched on the first shot with no manual
  switching.
- `saved_wallpaper` in the plugin's `data.json` still pointed at the original
  pre-takeover wallpaper, confirming the restore stash was untouched.

Also confirmed the `sleep 1` delay is sufficient against the shell's own startup
wallpaper restore — that ordering was the main risk in this change.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0 (712144465c44)
- **Plugin API level:** 9

## Screenshots / Videos

<!-- TODO: optional here — the change has no new visual surface, it only corrects
     which image the palette is generated from at login. A before/after of the bar
     colors against the same live wallpaper would show it best if you want one. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
