### PR TITLE
feat(pass): add new async and improved cache service

### DIFF
--- a/pass/README.md
+++ b/pass/README.md
@@ -12,7 +12,7 @@ Pass adds password-store search to the Noctalia launcher so you can copy passwor
 
 ## Requirements
 
-Install `pass`, `pass-otp`, `gpg`, and `wl-copy` on `PATH`.
+Install `pass`, `pass-otp`, `gpg`, `wl-copy`, and `find` on `PATH`.
 
 A working password store is expected in the same location `pass` uses: `$PASSWORD_STORE_DIR` when that variable is set, otherwise the default `~/.password-store`. OTP copying requires entries that are configured for `pass-otp`.
 
@@ -41,7 +41,7 @@ This plugin does not expose custom IPC actions. It provides launcher provider `s
 ## Notes
 
 - Filesystem reads: the service recursively scans `$PASSWORD_STORE_DIR` when set, otherwise `~/.password-store`, and indexes non-hidden `*.gpg` file names. It does not read decrypted password contents.
-- Spawned processes: activating a password result runs `pass -c <entry>`; activating an OTP result runs `pass otp -c <entry>`. If GPG reports an unlock failure, the plugin opens a terminal and runs the same command interactively.
+- Spawned processes: the cache service runs `find` asynchronously to index entry paths without blocking Noctalia's plugin runtime. Activating a password result runs `pass -c <entry>`; activating an OTP result runs `pass otp -c <entry>`. If GPG reports an unlock failure, the plugin opens a terminal and runs the same command interactively.
 - Clipboard/privacy: copied secrets are handled by `pass`/`pass-otp` and the system clipboard tooling, typically including `gpg` and `wl-copy` on Wayland. The plugin stores only entry paths/titles in Noctalia state, not decrypted secrets.
 - Network: the plugin makes no network calls.
 - Writes: the plugin does not write files directly. `pass`, `pass-otp`, `gpg`, or clipboard tools may update their own runtime files such as agent or clipboard state.

--- a/pass/plugin.toml
+++ b/pass/plugin.toml
@@ -1,6 +1,6 @@
 id = "emrtnn/pass"
 name = "Pass"
-version = "0.1.0"
+version = "0.1.1"
 plugin_api = 3
 author = "emrtnn"
 license = "MIT"
@@ -8,7 +8,7 @@ deprecated = false
 icon = "key"
 description = "Search and copy password-store entries from the Noctalia launcher"
 tags = ["launcher", "privacy", "productivity", "utility"]
-dependencies = ["pass", "pass-otp", "gpg", "wl-copy"]
+dependencies = ["pass", "pass-otp", "gpg", "wl-copy", "find"]
 
 [[setting]]
 key = "refresh_interval"

--- a/pass/service.luau
+++ b/pass/service.luau
@@ -1,9 +1,14 @@
 --!nonstrict
 
 local entries = {}
+local scanInFlight = false
 
 local function publish()
     noctalia.state.set("entries", entries)
+end
+
+local function shellEscape(value)
+    return "'" .. value:gsub("'", "'\\''") .. "'"
 end
 
 local function passwordStoreDir()
@@ -16,55 +21,10 @@ local function passwordStoreDir()
     return noctalia.expandPath("~/.password-store")
 end
 
-local function scan(dir, prefix)
-    prefix = prefix or ""
-
-    local names, err = noctalia.listDir(dir)
-
-    if not names then
-        noctalia.log("Failed to list " .. dir .. ": " .. tostring(err))
+local function rebuild()
+    if scanInFlight then
         return
     end
-
-    for _, name in ipairs(names) do
-        -- Ignore hidden files/directories (.git, .extensions, .gpg-id, ...)
-        if name:sub(1, 1) ~= "." then
-            -- listDir already proved the name exists, so an entry needs no stat.
-            -- Only non-entry names get one, to decide whether to recurse.
-            if name:sub(-4) == ".gpg" then
-                local path = prefix .. name:sub(1, -5)
-
-                local title = path
-                local subtitle = ""
-
-                local lastSlash = path:match("^.*()/")
-
-                if lastSlash then
-                    subtitle = path:sub(1, lastSlash - 1)
-                    title = path:sub(lastSlash + 1)
-                end
-
-                table.insert(entries, {
-                    id = path,
-                    path = path,
-                    title = title,
-                    subtitle = subtitle,
-                })
-
-            else
-                local full = dir .. "/" .. name
-                local info = noctalia.fileInfo(full)
-
-                if info and info.isDir then
-                    scan(full, prefix .. name .. "/")
-                end
-            end
-        end
-    end
-end
-
-local function rebuild()
-    entries = {}
 
     local root = passwordStoreDir()
 
@@ -73,13 +33,62 @@ local function rebuild()
         return
     end
 
-    scan(root)
+    -- Directory traversal can exceed Noctalia's callback CPU budget on large stores.
+    -- Run it in a subprocess and only build the small launcher cache in Luau.
+    local command = "cd " .. shellEscape(root)
+        .. " && find . -mindepth 1"
+        .. " \\( -type d -name '.*' -prune \\)"
+        .. " -o \\( -name '*.gpg' ! -name '.*' -print0 \\)"
 
-    table.sort(entries, function(a, b)
-        return a.title:lower() < b.title:lower()
-    end)
+    scanInFlight = true
 
-    publish()
+    local accepted = noctalia.runAsync(command, function(result)
+        scanInFlight = false
+
+        if result.exitCode ~= 0 then
+            noctalia.log("Failed to scan " .. root .. ": " .. (result.stderr or "unknown error"))
+            return
+        end
+
+        if result.stdoutTruncated then
+            noctalia.log("Failed to scan " .. root .. ": command output was truncated")
+            return
+        end
+
+        local nextEntries = {}
+
+        for file in (result.stdout or ""):gmatch("([^%z]+)%z") do
+            -- find returns paths as ./folder/entry.gpg.
+            local path = file:sub(3, -5)
+            local title = path
+            local subtitle = ""
+            local lastSlash = path:match("^.*()/")
+
+            if lastSlash then
+                subtitle = path:sub(1, lastSlash - 1)
+                title = path:sub(lastSlash + 1)
+            end
+
+            table.insert(nextEntries, {
+                id = path,
+                path = path,
+                title = title,
+                subtitle = subtitle,
+            })
+        end
+
+        table.sort(nextEntries, function(a, b)
+            return a.title:lower() < b.title:lower()
+        end)
+
+        entries = nextEntries
+        publish()
+    end, 60000)
+
+    if not accepted then
+        scanInFlight = false
+        noctalia.log("Failed to start password-store scan")
+    end
 end
 
 function update()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

 Plugin

 - Id: emrtnn/pass
 - [ ] New plugin
 - [x] Update to an existing plugin (version bumped in
       plugin.toml)

 What it does

 Fixes the cache service being disabled for users with large password stores.

 Password-store traversal now runs asynchronously through find instead of recursively calling synchronous filesystem APIs
 inside Noctalia's Luau callback CPU budget.

 The launcher behavior and result format remain unchanged.

 External dependencies

 - find: asynchronously discovers non-hidden `.gpg` entries.
 - pass: copies passwords from the password store.
 - pass-otp: generates and copies OTP codes.
 - gpg: decrypts password-store entries.
 - wl-copy: provides clipboard integration on Wayland.

 All dependencies are declared in plugin.toml.

 Testing

 Tested with:

 - A generated password store containing 1,000 visible .gpg entries across nested directories.
 - Hidden .gpg entries under .git and other hidden directories to verify they were excluded.
 - Non-entry files to verify they were ignored.
 - Store and entry paths containing spaces and apostrophes.
 - Multiple refresh cycles using the default 30-second interval.

 The service remained enabled with no CPU-budget, scan-failure, or auto-disable errors.

 Plugin lint completed with 0 errors and 0 warnings, and all
 repository manifests passed validation.

 - [ ] Tested on Niri
 - [ ] Tested on Hyprland
 - [ ] Tested on Sway
 - [x] Tested on another compositor: Mango
 - Noctalia version tested against: v5.0.0
 - Plugin API level: 3

 Screenshots / Videos

 Not applicable: this is a background cache-service performance fix and introduces no visual changes. Launcher results and behavior remain unchanged.

 Checklist

 - [x] The directory name matches the part of id after the /
       in plugin.toml exactly.
 - [x] It ships plugin.toml, README.md, thumbnail.webp, and
       translations/en.json.
 - [x] README.md follows the
       README template
       (https://github.com/noctalia-dev/community-plugins/blob
       /main/README_TEMPLATE.md), documents
       every entry id and dependency, and includes exact panel
       IPC commands and launcher prefixes where applicable.
 - [x] I created thumbnail.webp with the thumbnail generator
       (https://assets.noctalia.dev/plugins/thumbnail-generato
       r.html).
 - [x] version follows semver and is bumped in this PR;
       plugin_api is the oldest API level this plugin
       requires.
 - [x] Every non-English translation in this PR uses a locale
       supported by Noctalia core, and I can read, write, and
       understand that language well enough to review and
       maintain it (no unreviewed machine/LLM translations).
 - [x] I did not edit catalog.toml; CI generates it.
 - [x] This PR touches exactly one plugin directory.

 Code review attestation

 Plugins run as trusted, unsandboxed Luau in the user's
 session. Confirm:

 - [x] The code is readable and not obfuscated, minified, or
       generated.
 - [x] It does not download and execute remote code.
 - [x] Every network call, filesystem write, and spawned
       process is something the description above accounts
       for.
 - [x] I have the right to publish this code under the license
        declared in plugin.toml.