### PR TITLE
feat: add better-clock and better-calendar plugins

### DIFF
--- a/better-calendar/plugin.toml
+++ b/better-calendar/plugin.toml
@@ -1,0 +1,21 @@
+id = "yugaaank/better-calendar"
+name = "Better Calendar"
+version = "1.1.0"
+plugin_api = 19
+author = "yugaaank"
+license = "MIT"
+icon = "calendar"
+description = "A premium Apple-inspired desktop calendar widget."
+tags = ["desktop", "calendar", "date", "utility"]
+
+[[desktop_widget]]
+id = "calendar"
+entry = "widget.luau"
+
+    [[desktop_widget.setting]]
+    key = "week_start"
+    type = "select"
+    label_key = "settings.week_start.label"
+    description_key = "settings.week_start.description"
+    default = "monday"
+    options = ["monday", "sunday"]

--- a/better-calendar/translations/en.json
+++ b/better-calendar/translations/en.json
@@ -1,0 +1,4 @@
+{
+    "settings.week_start.label": "Week Start",
+    "settings.week_start.description": "First day of the week"
+}

--- a/better-calendar/widget.luau
+++ b/better-calendar/widget.luau
@@ -1,0 +1,127 @@
+--!nonstrict
+-- Apple-inspired desktop calendar widget.
+
+local MONTHS = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+}
+
+local DAYS_MON = { "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su" }
+local DAYS_SUN = { "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" }
+
+local function daysInMonth(year, month)
+    local days = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
+    if month == 2 and (year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0)) then
+        return 29
+    end
+    return days[month]
+end
+
+local function firstDayOffset(year, month, weekStart)
+    local t = os.time({ year = year, month = month, day = 1 })
+    local wday = os.date("*t", t).wday
+    if weekStart == "monday" then
+        return (wday + 5) % 7
+    else
+        return (wday + 6) % 7
+    end
+end
+
+function update()
+    noctalia.setUpdateInterval(60000)
+
+    local weekStart = noctalia.getConfig("week_start") or "monday"
+    local dayNames = weekStart == "sunday" and DAYS_SUN or DAYS_MON
+
+    local now = os.date("*t")
+    local year = now.year
+    local month = now.month
+    local today = now.day
+
+    local totalDays = daysInMonth(year, month)
+    local offset = firstDayOffset(year, month, weekStart)
+
+    local children = {}
+
+    -- Header: month + year
+    table.insert(children, ui.row({
+        justify = "space_between",
+        align = "center",
+    }, {
+        ui.label({
+            text = MONTHS[month],
+            fontSize = 16,
+            fontWeight = "semibold",
+            color = "primary",
+        }),
+        ui.label({
+            text = tostring(year),
+            fontSize = 14,
+            color = "on_surface_variant",
+        }),
+    }))
+
+    -- Day names
+    local dayRow = {}
+    for _, d in ipairs(dayNames) do
+        table.insert(dayRow, ui.label({
+            text = d,
+            fontSize = 11,
+            fontWeight = "medium",
+            color = "on_surface_variant",
+            textAlign = "center",
+            width = 32,
+        }))
+    end
+    table.insert(children, ui.row({ justify = "space_between" }, dayRow))
+
+    -- Calendar grid
+    local row = {}
+    local col = 0
+
+    for _ = 1, offset do
+        table.insert(row, ui.label({ text = "", width = 32, textAlign = "center" }))
+        col = col + 1
+    end
+
+    for day = 1, totalDays do
+        local isToday = day == today
+        table.insert(row, ui.row({
+            width = 32,
+            height = 28,
+            radius = 8,
+            fill = isToday and "primary/0.20" or nil,
+            align = "center",
+            justify = "center",
+        }, {
+            ui.label({
+                text = tostring(day),
+                fontSize = 12,
+                fontWeight = isToday and "bold" or "regular",
+                color = isToday and "primary" or "on_surface",
+                textAlign = "center",
+            }),
+        }))
+        col = col + 1
+
+        if col == 7 then
+            table.insert(children, ui.row({ justify = "space_between" }, row))
+            row = {}
+            col = 0
+        end
+    end
+
+    if col > 0 then
+        while col < 7 do
+            table.insert(row, ui.label({ text = "", width = 32 }))
+            col = col + 1
+        end
+        table.insert(children, ui.row({ justify = "space_between" }, row))
+    end
+
+    desktopWidget.render(ui.column({
+        paddingH = 14,
+        paddingV = 14,
+        gap = 8,
+    }, children))
+end

--- a/better-clock/plugin.toml
+++ b/better-clock/plugin.toml
@@ -1,0 +1,34 @@
+id = "yugaaank/better-clock"
+name = "Better Clock"
+version = "1.1.0"
+plugin_api = 19
+author = "yugaaank"
+license = "MIT"
+icon = "clock"
+description = "A minimal digital clock desktop widget with customizable format."
+tags = ["desktop", "clock", "time", "utility"]
+
+[[desktop_widget]]
+id = "clock"
+entry = "widget.luau"
+
+    [[desktop_widget.setting]]
+    key = "time_format"
+    type = "string"
+    label_key = "settings.time_format.label"
+    description_key = "settings.time_format.description"
+    default = "{:%H:%M}"
+
+    [[desktop_widget.setting]]
+    key = "date_format"
+    type = "string"
+    label_key = "settings.date_format.label"
+    description_key = "settings.date_format.description"
+    default = "{:%A, %B %d}"
+
+    [[desktop_widget.setting]]
+    key = "show_date"
+    type = "bool"
+    label_key = "settings.show_date.label"
+    description_key = "settings.show_date.description"
+    default = true

--- a/better-clock/translations/en.json
+++ b/better-clock/translations/en.json
@@ -1,0 +1,8 @@
+{
+    "settings.time_format.label": "Time Format",
+    "settings.time_format.description": "Luau date format for time, e.g. {:%H:%M} or {:%I:%M %p}",
+    "settings.date_format.label": "Date Format",
+    "settings.date_format.description": "Luau date format for date, e.g. {:%A, %B %d}",
+    "settings.show_date.label": "Show Date",
+    "settings.show_date.description": "Display the date below the time"
+}

--- a/better-clock/widget.luau
+++ b/better-clock/widget.luau
@@ -1,0 +1,35 @@
+--!nonstrict
+-- Minimal digital clock desktop widget.
+
+local timeFormat = noctalia.getConfig("time_format") or "{:%H:%M}"
+local dateFormat = noctalia.getConfig("date_format") or "{:%A, %B %d}"
+local showDate = noctalia.getConfig("show_date")
+if showDate == nil then showDate = true end
+
+function update()
+    noctalia.setUpdateInterval(30000)
+
+    local children = {
+        ui.label({
+            text = noctalia.formatTime(timeFormat),
+            fontSize = 32,
+            fontWeight = "bold",
+            color = "on_surface",
+            textAlign = "center",
+        }),
+    }
+
+    if showDate then
+        table.insert(children, ui.label({
+            text = noctalia.formatTime(dateFormat),
+            fontSize = 13,
+            color = "on_surface_variant",
+            textAlign = "center",
+        }))
+    end
+
+    desktopWidget.render(ui.column({
+        align = "center",
+        justify = "center",
+    }, children))
+end

--- a/catalog.toml
+++ b/catalog.toml
@@ -1077,3 +1077,29 @@ icon = "layout-grid"
 description = "Shows and cycles the active workspace's layout"
 plugin_api = 3
 tags = ["hyprland"]
+
+[[plugin]]
+id = "yugaaank/better-clock"
+name = "Better Clock"
+version = "1.1.0"
+updated_at = 1785813000
+added_at = 1785812073
+author = "yugaaank"
+license = "MIT"
+icon = "clock"
+description = "A minimal digital clock desktop widget with customizable format."
+plugin_api = 19
+tags = ["desktop", "clock", "time", "utility"]
+
+[[plugin]]
+id = "yugaaank/better-calendar"
+name = "Better Calendar"
+version = "1.1.0"
+updated_at = 1785813000
+added_at = 1785812073
+author = "yugaaank"
+license = "MIT"
+icon = "calendar"
+description = "A premium Apple-inspired desktop calendar widget."
+plugin_api = 19
+tags = ["desktop", "calendar", "date", "utility"]


### PR DESCRIPTION
## Add two desktop widgets

### better-clock

Minimal digital clock widget.

- Configurable time format (`time_format`)
- Configurable date format (`date_format`)
- Toggle date visibility (`show_date`)
- 30-second update interval
- Uses `noctalia.formatTime()` for localization

### better-calendar

Apple-inspired calendar widget.

- Month and year header with primary color accent
- Day name grid (Monday or Sunday start)
- Today highlighted with `primary/0.20` fill
- Configurable week start (`week_start`)
- 60-second update interval

### Files

```
better-clock/
├── plugin.toml
├── widget.luau
└── translations/en.json

better-calendar/
├── plugin.toml
├── widget.luau
└── translations/en.json
```

### Dependencies

None. Both plugins use only Noctalia core APIs.