### PR TITLE
fix(arch-updater): tighten package list UI and fix Dismiss/Update panel behavior

### DIFF
--- a/arch-updater/README.md
+++ b/arch-updater/README.md
@@ -47,8 +47,8 @@ The panel groups pending packages by source (Pacman, AUR, Flatpak). Click a
 source row to expand it into its packages. Each package row has a copy
 button (name and versions) and an open button (its page on archlinux.org,
 the AUR, or Flathub). **Check Updates** queries all sources, **Update** opens
-a terminal running the upgrade, **Dismiss** keeps the numbers but returns the
-bar glyph to its resting colour.
+a terminal running the upgrade, **Dismiss** clears the pending list and
+closes the panel, returning the bar glyph to its resting colour.
 
 Type `/arch` in the launcher for quick actions (check, update, open news), or
 `/arch <text>` to fuzzy-search the packages from the last check. Activating a

--- a/arch-updater/README.md
+++ b/arch-updater/README.md
@@ -78,6 +78,10 @@ Not in the v4 plugin:
 - **A generic package-page link** (`archlinux.org/packages`,
   `aur.archlinux.org`, `flathub.org`) instead of hardcoded per-repo mirror
   URLs, so it stays correct across Arch-based distros.
+- **An activity graph.** A small trend line of the pending-update count
+  across the most recent checks, plus when you last ran an update. Persisted
+  to disk so it survives restarts. On by default, and turning it off also
+  stops recording the history, not just hiding it.
 
 ## Settings
 
@@ -92,6 +96,8 @@ Not in the v4 plugin:
 | `show_download_size` | `bool` | `true` | Show the estimated pacman download size (`pacman -Si`) in the panel. |
 | `check_arch_news` | `bool` | `true` | Check the Arch Linux news feed and flag unread posts. |
 | `check_reboot_needed` | `bool` | `true` | Flag when the running kernel is no longer installed on disk. |
+| `show_activity_graph` | `bool` | `true` | Track and show the pending-update trend and last-update time in the panel. Off also stops recording history. |
+| `activity_history_length` | `int` | `10` | How many of the most recent checks to keep for the activity graph. |
 | `terminal` | `string` | *(empty)* | Terminal command for the update run, e.g. `kitty`. Empty uses Noctalia's detection. |
 | `assume_yes` | `bool` | `false` | Pass `--noconfirm` / `-y` so package managers do not ask for confirmation. |
 | `update_cmd` | `string` | *(empty)* | Full override for the update command. Empty builds it from the settings above. |

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -403,6 +403,7 @@ render = function()
                 tooltip = tr("tip_update"),
                 onClick = function()
                     request("update")
+                    panel.close()
                 end,
             }),
         }))

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -175,13 +175,15 @@ local function packageRow(sourceKey, index, item)
         }))
     end
     table.insert(children, ui.button({
-        glyph = "copy", variant = "ghost", controlSize = "sm", tooltip = tr("tip_copy"),
+        glyph = "copy", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+        tooltip = tr("tip_copy"),
         onClick = function()
             noctalia.copyToClipboard(detailFor(item), "text/plain")
         end,
     }))
     table.insert(children, ui.button({
-        glyph = "external-link", variant = "ghost", controlSize = "sm", tooltip = tr("tip_open_page"),
+        glyph = "external-link", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+        tooltip = tr("tip_open_page"),
         onClick = function()
             openPackage(sourceKey, item.name)
         end,
@@ -294,7 +296,7 @@ local function body()
 
     local rows = sourceRows()
     if #rows > 0 then
-        table.insert(children, ui.scroll({ key = "sources", flexGrow = 1, gap = 6 }, rows))
+        table.insert(children, ui.scroll({ key = "sources", flexGrow = 1, gap = 3 }, rows))
     else
         table.insert(children, ui.spacer({ key = "filler", flexGrow = 1 }))
     end

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -116,6 +116,12 @@ local function sourceLabel(key, entry)
     return tr("source." .. key)
 end
 
+local SOURCE_GLYPHS = { pacman = "package", aur = "cloud", flatpak = "app-window" }
+
+local function sourceGlyph(key)
+    return SOURCE_GLYPHS[key] or "package"
+end
+
 -- pacman, then the AUR helper, then Flatpak. Only sources with pending
 -- packages, biggest first.
 local function orderedSources()
@@ -226,6 +232,7 @@ local function sourceRows()
         end
         table.insert(rows, ui.row(header, {
             ui.glyph({ name = #names == 0 and "point" or (open and "chevron-down" or "chevron-right"), size = 12, color = "on_surface_variant" }),
+            ui.glyph({ name = sourceGlyph(source.key), size = 13, color = "on_surface_variant" }),
             ui.label({ text = sourceLabel(source.key, source.entry), color = "on_surface", flexGrow = 1 }),
             ui.label({ text = tostring(source.entry.n), color = "primary", fontWeight = "bold" }),
         }))

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -298,6 +298,60 @@ local function extras()
     return lines
 end
 
+-- Normalizes the pending-count history to 0..1 for ui.graph, relative to the
+-- min/max in the window (not a fixed scale, since pending counts vary wildly
+-- between systems). A flat window (min == max, e.g. every check so far found
+-- the same count) centers the line at 0.5 instead of pinning it to the top
+-- edge, where it would be indistinguishable from the box border.
+local function activityValues(history)
+    local minN, maxN = history[1], history[1]
+    for _, n in ipairs(history) do
+        if n < minN then
+            minN = n
+        end
+        if n > maxN then
+            maxN = n
+        end
+    end
+    local range = maxN - minN
+    local values = {}
+    for _, n in ipairs(history) do
+        table.insert(values, range > 0 and (n - minN) / range or 0.5)
+    end
+    return values
+end
+
+-- A small trend graph of pending-update counts across recent checks, plus
+-- when the last update ran. Off entirely when show_activity_graph is off,
+-- and hidden until there is enough history to draw a line.
+local function activitySection()
+    if snapshot == nil or noctalia.getConfig("show_activity_graph") ~= true then
+        return nil
+    end
+    local history = type(snapshot.history) == "table" and snapshot.history or {}
+    if #history < 2 then
+        return nil
+    end
+
+    local lastUpdateAt = tonumber(snapshot.lastUpdateAt)
+    local caption
+    if lastUpdateAt == nil then
+        caption = tr("activity.never_updated")
+    else
+        local days = math.floor((os.time() - lastUpdateAt) / 86400)
+        caption = days <= 0 and tr("activity.updated_today")
+            or noctalia.trp("activity.updated_days_ago", days, { count = days })
+    end
+
+    return ui.column({ key = "activity", gap = 4 }, {
+        ui.row({ justify = "space_between", align = "center" }, {
+            ui.label({ text = tr("activity.title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant" }),
+            ui.label({ text = caption, fontSize = 10, color = "on_surface_variant" }),
+        }),
+        ui.graph({ values = activityValues(history), color = "primary", fillOpacity = 0.15, lineWidth = 2, height = 36 }),
+    })
+end
+
 local function body()
     local children = {}
 
@@ -330,6 +384,11 @@ local function body()
             color = "on_surface_variant",
             maxLines = 2,
         }))
+    end
+
+    local activity = activitySection()
+    if activity ~= nil then
+        table.insert(children, activity)
     end
 
     return children

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -15,6 +15,7 @@ local snapshot = nil
 local expanded = {} -- source key -> the package list is open
 local hoverKey = nil -- package row currently under the pointer
 local hoverText = "" -- what the detail line shows
+local activityHoverIndex = nil -- activity graph point currently under the pointer
 local listOpen = false -- at least one source is expanded this render
 
 local render
@@ -304,8 +305,9 @@ end
 -- the same count) centers the line at 0.5 instead of pinning it to the top
 -- edge, where it would be indistinguishable from the box border.
 local function activityValues(history)
-    local minN, maxN = history[1], history[1]
-    for _, n in ipairs(history) do
+    local minN, maxN = tonumber(history[1].n) or 0, tonumber(history[1].n) or 0
+    for _, entry in ipairs(history) do
+        local n = tonumber(entry.n) or 0
         if n < minN then
             minN = n
         end
@@ -315,15 +317,83 @@ local function activityValues(history)
     end
     local range = maxN - minN
     local values = {}
-    for _, n in ipairs(history) do
+    for _, entry in ipairs(history) do
+        local n = tonumber(entry.n) or 0
         table.insert(values, range > 0 and (n - minN) / range or 0.5)
     end
     return values
 end
 
+-- "2 hours ago", "3 days ago", etc. nil for entries migrated from the old
+-- history format, which never recorded a timestamp.
+local function relativeTime(at)
+    local t = tonumber(at)
+    if t == nil then
+        return nil
+    end
+    local diff = os.time() - t
+    if diff < 60 then
+        return tr("activity.just_now")
+    elseif diff < 3600 then
+        local m = math.floor(diff / 60)
+        return noctalia.trp("activity.minutes_ago", m, { count = m })
+    elseif diff < 86400 then
+        local h = math.floor(diff / 3600)
+        return noctalia.trp("activity.hours_ago", h, { count = h })
+    else
+        local d = math.floor(diff / 86400)
+        return noctalia.trp("activity.days_ago", d, { count = d })
+    end
+end
+
+-- "Updated · 2 hours ago" for the check that verified an update run, else
+-- "3 pending updates · 2 hours ago". Shared by the hover tooltip and the
+-- top-right caption so both describe a point the same way.
+local function describeEntry(entry)
+    local n = tonumber(entry.n) or 0
+    local text = entry.afterUpdate == true and tr("activity.updated")
+        or noctalia.trp("activity.pending_at", n, { count = n })
+    local when = relativeTime(entry.at)
+    if when ~= nil then
+        text = text .. " · " .. when
+    end
+    return text
+end
+
+-- ui.graph takes no pointer props of its own (only row/column/box/image/button
+-- do), so per-point hover is a row of equal-width hit targets placed right
+-- under the line, one per history entry. Each is a ghost button so it can
+-- carry a native tooltip at the pointer, not just a box for the hit test.
+-- It cannot highlight the point on the line itself, only drive the tooltip
+-- and the caption above it.
+local function activityHoverRow(history)
+    local segments = {}
+    for i, entry in ipairs(history) do
+        segments[i] = ui.button({
+            key = "activity-hit-" .. i,
+            variant = "ghost",
+            flexGrow = 1,
+            height = 12,
+            tooltip = describeEntry(entry),
+            onHover = function(state)
+                if state == "true" then
+                    activityHoverIndex = i
+                elseif activityHoverIndex == i then
+                    activityHoverIndex = nil
+                else
+                    return
+                end
+                render()
+            end,
+        })
+    end
+    return ui.row({ key = "activity-hits", gap = 1 }, segments)
+end
+
 -- A small trend graph of pending-update counts across recent checks, plus
--- when the last update ran. Off entirely when show_activity_graph is off,
--- and hidden until there is enough history to draw a line.
+-- when the last update ran (or, while hovering a point, that point's own
+-- description). Off entirely when show_activity_graph is off, and hidden
+-- until there is enough history to draw a line.
 local function activitySection()
     if snapshot == nil or noctalia.getConfig("show_activity_graph") ~= true then
         return nil
@@ -333,14 +403,19 @@ local function activitySection()
         return nil
     end
 
-    local lastUpdateAt = tonumber(snapshot.lastUpdateAt)
+    local hoveredEntry = activityHoverIndex ~= nil and history[activityHoverIndex] or nil
     local caption
-    if lastUpdateAt == nil then
-        caption = tr("activity.never_updated")
+    if hoveredEntry ~= nil then
+        caption = describeEntry(hoveredEntry)
     else
-        local days = math.floor((os.time() - lastUpdateAt) / 86400)
-        caption = days <= 0 and tr("activity.updated_today")
-            or noctalia.trp("activity.updated_days_ago", days, { count = days })
+        local lastUpdateAt = tonumber(snapshot.lastUpdateAt)
+        if lastUpdateAt == nil then
+            caption = tr("activity.never_updated")
+        else
+            local days = math.floor((os.time() - lastUpdateAt) / 86400)
+            caption = days <= 0 and tr("activity.updated_today")
+                or noctalia.trp("activity.updated_days_ago", days, { count = days })
+        end
     end
 
     return ui.column({ key = "activity", gap = 4 }, {
@@ -349,6 +424,7 @@ local function activitySection()
             ui.label({ text = caption, fontSize = 10, color = "on_surface_variant" }),
         }),
         ui.graph({ values = activityValues(history), color = "primary", fillOpacity = 0.15, lineWidth = 2, height = 36 }),
+        activityHoverRow(history),
     })
 end
 
@@ -483,6 +559,7 @@ function onOpen(_context)
     expanded = {}
     hoverKey = nil
     hoverText = ""
+    activityHoverIndex = nil
     render()
 end
 
@@ -494,6 +571,7 @@ noctalia.state.watch(STATE_KEY, function(value)
         expanded = {}
         hoverKey = nil
         hoverText = ""
+        activityHoverIndex = nil
     end
     snapshot = value
     render()

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -324,6 +324,34 @@ local function activityValues(history)
     return values
 end
 
+local ACTIVITY_GRAPH_SUBDIVISIONS = 8
+
+local function upsampleLinear(values, subdivisions)
+    if #values < 2 or subdivisions <= 1 then
+        return values
+    end
+    local out = {}
+    for i = 1, #values - 1 do
+        local a, b = values[i], values[i + 1]
+        for s = 0, subdivisions - 1 do
+            table.insert(out, a + (b - a) * (s / subdivisions))
+        end
+    end
+    table.insert(out, values[#values])
+    return out
+end
+
+local function padGraphLookbehind(values)
+    if #values == 0 then
+        return values
+    end
+    local out = { values[1], values[1] }
+    for _, v in ipairs(values) do
+        table.insert(out, v)
+    end
+    return out
+end
+
 -- "2 hours ago", "3 days ago", etc. nil for entries migrated from the old
 -- history format, which never recorded a timestamp.
 local function relativeTime(at)
@@ -361,20 +389,27 @@ local function describeEntry(entry)
 end
 
 -- ui.graph takes no pointer props of its own (only row/column/box/image/button
--- do), so per-point hover is a row of equal-width hit targets placed right
--- under the line, one per history entry. Each is a ghost button so it can
--- carry a native tooltip at the pointer, not just a box for the hit test.
--- It cannot highlight the point on the line itself, only drive the tooltip
--- and the caption above it.
+-- do), so per-point hover is a row of hit targets placed right under the
+-- line. Each is a ghost button so it can carry a native tooltip at the
+-- pointer, not just a box for the hit test. It cannot highlight the point on
+-- the line itself, only drive the tooltip and the caption above it.
+--
+-- Real points sit at (k-1)/(#history-1) of the width (see
+-- padGraphLookbehind), i.e. #history-1 equal gaps, not #history equal slots
+-- - so this builds one equal-width segment per gap rather than per entry,
+-- ending each segment exactly on the point at its right edge. That leaves
+-- entry 1 (at the left edge, with no gap before it) without its own hover
+-- zone, but keeps every other spike landing right at the end of its segment
+-- instead of drifting toward the start of an oversized one.
 local function activityHoverRow(history)
     local segments = {}
-    for i, entry in ipairs(history) do
-        segments[i] = ui.button({
+    for i = 2, #history do
+        segments[i - 1] = ui.button({
             key = "activity-hit-" .. i,
             variant = "ghost",
             flexGrow = 1,
             height = 12,
-            tooltip = describeEntry(entry),
+            tooltip = describeEntry(history[i]),
             onHover = function(state)
                 if state == "true" then
                     activityHoverIndex = i
@@ -423,7 +458,13 @@ local function activitySection()
             ui.label({ text = tr("activity.title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant" }),
             ui.label({ text = caption, fontSize = 10, color = "on_surface_variant" }),
         }),
-        ui.graph({ values = activityValues(history), color = "primary", fillOpacity = 0.15, lineWidth = 2, height = 36 }),
+        ui.graph({
+            values = padGraphLookbehind(upsampleLinear(activityValues(history), ACTIVITY_GRAPH_SUBDIVISIONS)),
+            color = "primary",
+            fillOpacity = 0.15,
+            lineWidth = 2,
+            height = 36,
+        }),
         activityHoverRow(history),
     })
 end

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -6,7 +6,7 @@
 --
 -- "Check Updates" only queries pacman, the AUR helper and (optionally)
 -- Flatpak. Only then do "Update" (open a terminal and run the upgrade) and
--- "Dismiss" (keep the numbers, quiet the bar) light up.
+-- "Dismiss" (clear the pending list and close the panel) light up.
 
 local STATE_KEY = "arch_state"
 local REQUEST_KEY = "arch_request"
@@ -391,9 +391,10 @@ render = function()
             }),
             ui.button({
                 key = "dismiss" .. (hasUpdates and "" or "-off"),
-                text = tr("action_dismiss"), variant = "ghost", enabled = hasUpdates and snapshot.dismissed ~= true,
+                text = tr("action_dismiss"), variant = "ghost", enabled = hasUpdates,
                 onClick = function()
                     request("dismiss")
+                    panel.close()
                 end,
             }),
             ui.button({

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "1.0.2"
+version = "1.1.0"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "1.0.1"
+version = "1.0.2"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -86,6 +86,25 @@ label_key = "settings.check_reboot_needed.label"
 description_key = "settings.check_reboot_needed.description"
 default = true
 
+# ── Activity ─────────────────────────────────────────────────────────────────
+
+[[setting]]
+key = "show_activity_graph"
+type = "bool"
+label_key = "settings.show_activity_graph.label"
+description_key = "settings.show_activity_graph.description"
+default = true
+
+[[setting]]
+key = "activity_history_length"
+type = "int"
+label_key = "settings.activity_history_length.label"
+description_key = "settings.activity_history_length.description"
+default = 10
+min = 3
+max = 30
+visible_when = { key = "show_activity_graph", values = ["true"] }
+
 # ── Update run ───────────────────────────────────────────────────────────────
 
 [[setting]]

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -5,7 +5,7 @@
 --   state    "arch_state"   = { nonce, phase, step, total, pacman, aur,
 --                                flatpak, downloadSizeMiB, rebootRecommended,
 --                                newsUnread, newsLatestTitle, err,
---                                checkedAt, ignoredCount }
+--                                checkedAt, ignoredCount, history, lastUpdateAt }
 --   requests "arch_request" = { nonce, action }  -- check|update|dismiss
 --
 -- Checking runs pacman, then the AUR helper, then Flatpak, then (if pacman
@@ -20,6 +20,7 @@ local REQUEST_KEY = "arch_request"
 local NEWS_FILE = "news_state.json"
 local NEWS_URL = "https://archlinux.org/feeds/news/"
 local NEWS_PAGE = "https://archlinux.org/news/"
+local HISTORY_FILE = "history_state.json"
 
 local CHECK_TIMEOUT_MS = 45000 -- pacman/AUR/flatpak checks: each may sync a mirror
 local SIZE_TIMEOUT_MS = 20000 -- pacman -Si: local db, no mirror sync
@@ -54,6 +55,9 @@ local startupTicks = 0
 local sinceNewsCheck = 0
 local newsStateLoaded = false
 local newsDirty = false
+local history = {} -- pending-count per check, oldest first, trimmed to activity_history_length
+local lastUpdateAt = nil -- os.time() of the last update run that finished
+local historyStateLoaded = false
 
 local startCheck
 local checkNews
@@ -199,6 +203,8 @@ local function publish()
         err = errMsg,
         checkedAt = checkedAt,
         ignoredCount = #ignoreList(),
+        history = history,
+        lastUpdateAt = lastUpdateAt,
         flatpakEnabled = cfg("flatpak_enabled") == true,
     })
 end
@@ -209,6 +215,7 @@ local checkFlatpak
 local checkSize
 local checkReboot
 local finishCheck
+local recordCheck
 
 local function failCheck(message)
     phase = "error"
@@ -423,6 +430,7 @@ finishCheck = function()
     phase = total > 0 and "ready" or "clean"
     checkedAt = noctalia.formatTime("%H:%M")
     sinceCheck = 0
+    recordCheck()
     publish()
     if total > 0 and cfg("notify_on_updates") == true then
         noctalia.notify(tr("title"), noctalia.trp("notify_updates", total, { count = total }))
@@ -464,6 +472,73 @@ local function saveNewsState()
     if encoded ~= nil then
         noctalia.writeFile(path, encoded)
     end
+end
+
+-- ── Activity history ─────────────────────────────────────────────────────────
+
+local function historyStatePath()
+    local dir, err = noctalia.pluginDataDir()
+    if dir == nil then
+        noctalia.log("arch-updater: cannot resolve plugin data dir: " .. tostring(err))
+        return nil
+    end
+    return dir .. "/" .. HISTORY_FILE
+end
+
+local function loadHistoryState()
+    if historyStateLoaded then
+        return
+    end
+    historyStateLoaded = true
+    local path = historyStatePath()
+    local encoded = path ~= nil and noctalia.readFile(path) or nil
+    local ok, decoded = pcall(function()
+        return encoded ~= nil and noctalia.json.decode(encoded) or nil
+    end)
+    if ok and type(decoded) == "table" then
+        if type(decoded.history) == "table" then
+            history = decoded.history
+        end
+        if type(decoded.lastUpdateAt) == "number" then
+            lastUpdateAt = decoded.lastUpdateAt
+        end
+    end
+end
+
+local function saveHistoryState()
+    local path = historyStatePath()
+    if path == nil then
+        return
+    end
+    local encoded = noctalia.json.encode({ history = history, lastUpdateAt = lastUpdateAt })
+    if encoded ~= nil then
+        noctalia.writeFile(path, encoded)
+    end
+end
+
+-- Appends the current total to the activity history, trimmed to the
+-- configured length. A no-op when the graph is turned off, so disabling it
+-- also stops collecting data, not just hides it.
+recordCheck = function()
+    if cfg("show_activity_graph") ~= true then
+        return
+    end
+    loadHistoryState()
+    table.insert(history, total)
+    local maxLen = math.max(3, math.min(30, tonumber(cfg("activity_history_length")) or 10))
+    while #history > maxLen do
+        table.remove(history, 1)
+    end
+    saveHistoryState()
+end
+
+local function recordUpdateRun()
+    if cfg("show_activity_graph") ~= true then
+        return
+    end
+    loadHistoryState()
+    lastUpdateAt = os.time()
+    saveHistoryState()
 end
 
 local HTML_ENTITIES = {
@@ -662,6 +737,7 @@ local function pollRun()
             return
         end
         if runSeen or runTicks >= RUN_GRACE_SECONDS then
+            recordUpdateRun()
             startCheck()
         end
     end, updateProcessName)

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -846,4 +846,5 @@ if not noctalia.commandExists("checkupdates") then
     phase = "missing"
     errMsg = tr("err_no_checkupdates")
 end
+loadHistoryState() -- so the graph shows prior sessions' data before the first check runs
 publish()

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -55,9 +55,10 @@ local startupTicks = 0
 local sinceNewsCheck = 0
 local newsStateLoaded = false
 local newsDirty = false
-local history = {} -- pending-count per check, oldest first, trimmed to activity_history_length
+local history = {} -- { n, at, afterUpdate } per check, oldest first, trimmed to activity_history_length
 local lastUpdateAt = nil -- os.time() of the last update run that finished
 local historyStateLoaded = false
+local checkIsPostUpdate = false -- next finished check followed an update run
 
 local startCheck
 local checkNews
@@ -497,7 +498,21 @@ local function loadHistoryState()
     end)
     if ok and type(decoded) == "table" then
         if type(decoded.history) == "table" then
-            history = decoded.history
+            -- Migrates the old format (a plain array of counts) to entries with
+            -- a timestamp and an afterUpdate flag, both unknown for old data.
+            local migrated = {}
+            for _, entry in ipairs(decoded.history) do
+                if type(entry) == "table" then
+                    table.insert(migrated, {
+                        n = tonumber(entry.n) or 0,
+                        at = tonumber(entry.at),
+                        afterUpdate = entry.afterUpdate == true,
+                    })
+                elseif type(entry) == "number" then
+                    table.insert(migrated, { n = entry, at = nil, afterUpdate = false })
+                end
+            end
+            history = migrated
         end
         if type(decoded.lastUpdateAt) == "number" then
             lastUpdateAt = decoded.lastUpdateAt
@@ -520,11 +535,13 @@ end
 -- configured length. A no-op when the graph is turned off, so disabling it
 -- also stops collecting data, not just hides it.
 recordCheck = function()
+    local wasPostUpdate = checkIsPostUpdate
+    checkIsPostUpdate = false
     if cfg("show_activity_graph") ~= true then
         return
     end
     loadHistoryState()
-    table.insert(history, total)
+    table.insert(history, { n = total, at = os.time(), afterUpdate = wasPostUpdate })
     local maxLen = math.max(3, math.min(30, tonumber(cfg("activity_history_length")) or 10))
     while #history > maxLen do
         table.remove(history, 1)
@@ -532,7 +549,10 @@ recordCheck = function()
     saveHistoryState()
 end
 
+-- Marks the check that follows as the one that verifies an update run, so its
+-- history entry can say "Updated" instead of just a pending count.
 local function recordUpdateRun()
+    checkIsPostUpdate = true
     if cfg("show_activity_graph") ~= true then
         return
     end

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -4,7 +4,7 @@
 --
 --   state    "arch_state"   = { nonce, phase, step, total, pacman, aur,
 --                                flatpak, downloadSizeMiB, rebootRecommended,
---                                newsUnread, newsLatestTitle, dismissed, err,
+--                                newsUnread, newsLatestTitle, err,
 --                                checkedAt, ignoredCount }
 --   requests "arch_request" = { nonce, action }  -- check|update|dismiss
 --
@@ -40,7 +40,6 @@ local newsUnread = 0
 local newsLatestTitle = nil
 local newsItems = {}
 local newsLastSeenGuid = nil
-local dismissed = false
 local errMsg = nil
 local checkedAt = ""
 local stateNonce = 0
@@ -197,7 +196,6 @@ local function publish()
         rebootRecommended = rebootRecommended,
         newsUnread = newsUnread,
         newsLatestTitle = newsLatestTitle,
-        dismissed = dismissed,
         err = errMsg,
         checkedAt = checkedAt,
         ignoredCount = #ignoreList(),
@@ -423,7 +421,6 @@ finishCheck = function()
     total = sources.pacman.n + sources.aur.n + sources.flatpak.n
     step = ""
     phase = total > 0 and "ready" or "clean"
-    dismissed = false
     checkedAt = noctalia.formatTime("%H:%M")
     sinceCheck = 0
     publish()
@@ -681,10 +678,13 @@ local function handle(action)
     elseif action == "update" then
         runUpdate()
     elseif action == "dismiss" then
-        if not dismissed then
-            dismissed = true
-            publish()
-        end
+        sources.pacman = { n = 0, items = {} }
+        sources.aur = { n = 0, items = {}, helper = sources.aur.helper }
+        sources.flatpak = { n = 0, items = {} }
+        total = 0
+        downloadSizeMiB = nil
+        phase = "clean"
+        publish()
     elseif action == "open_news" then
         openNews()
     end

--- a/arch-updater/translations/de.json
+++ b/arch-updater/translations/de.json
@@ -3,6 +3,15 @@
   "action_dismiss": "Verwerfen",
   "action_open_news": "News öffnen",
   "action_update": "Aktualisieren",
+  "activity": {
+    "never_updated": "Noch nie aktualisiert",
+    "title": "Aktivität",
+    "updated_days_ago": {
+      "one": "Vor 1 Tag aktualisiert",
+      "other": "Vor {count} Tagen aktualisiert"
+    },
+    "updated_today": "Heute aktualisiert"
+  },
   "caption_checked": "geprüft {time}",
   "caption_ignored": {
     "one": "1 Paket ignoriert",
@@ -33,6 +42,10 @@
     "press_key": "Beliebige Taste zum Schließen drücken"
   },
   "settings": {
+    "activity_history_length": {
+      "description": "Wie viele der letzten Prüfungen für das Aktivitätsdiagramm aufbewahrt werden.",
+      "label": "Länge des Aktivitätsverlaufs"
+    },
     "assume_yes": {
       "description": "Übergibt --noconfirm / -y, damit Paketmanager nicht nach Bestätigung fragen. Aus bedeutet, du bestätigst jedes Paket im Terminal-Fenster selbst.",
       "label": "Automatisch mit Ja bestätigen"
@@ -83,6 +96,10 @@
     "notify_on_updates": {
       "description": "Sendet eine Desktop-Benachrichtigung, wenn eine Prüfung aktualisierbare Pakete findet.",
       "label": "Bei gefundenen Updates benachrichtigen"
+    },
+    "show_activity_graph": {
+      "description": "Zeichnet die Anzahl ausstehender Updates über die letzten Prüfungen sowie den letzten Update-Zeitpunkt auf und zeigt sie als kleines Diagramm im Panel. Deaktiviert stoppt auch die Aufzeichnung.",
+      "label": "Aktivitätsdiagramm anzeigen"
     },
     "show_count": {
       "description": "Zeigt die Anzahl ausstehender Updates neben dem Bar-Symbol.",

--- a/arch-updater/translations/de.json
+++ b/arch-updater/translations/de.json
@@ -4,8 +4,26 @@
   "action_open_news": "News öffnen",
   "action_update": "Aktualisieren",
   "activity": {
+    "days_ago": {
+      "one": "vor 1 Tag",
+      "other": "vor {count} Tagen"
+    },
+    "hours_ago": {
+      "one": "vor 1 Stunde",
+      "other": "vor {count} Stunden"
+    },
+    "just_now": "gerade eben",
+    "minutes_ago": {
+      "one": "vor 1 Minute",
+      "other": "vor {count} Minuten"
+    },
     "never_updated": "Noch nie aktualisiert",
+    "pending_at": {
+      "one": "1 ausstehendes Update",
+      "other": "{count} ausstehende Updates"
+    },
     "title": "Aktivität",
+    "updated": "Aktualisiert",
     "updated_days_ago": {
       "one": "Vor 1 Tag aktualisiert",
       "other": "Vor {count} Tagen aktualisiert"

--- a/arch-updater/translations/en.json
+++ b/arch-updater/translations/en.json
@@ -3,6 +3,15 @@
   "action_dismiss": "Dismiss",
   "action_open_news": "Open news",
   "action_update": "Update",
+  "activity": {
+    "never_updated": "Never updated",
+    "title": "Activity",
+    "updated_days_ago": {
+      "one": "Updated 1 day ago",
+      "other": "Updated {count} days ago"
+    },
+    "updated_today": "Updated today"
+  },
   "caption_checked": "checked {time}",
   "caption_ignored": {
     "one": "1 package ignored",
@@ -36,6 +45,10 @@
     "press_key": "Press any key to close"
   },
   "settings": {
+    "activity_history_length": {
+      "description": "How many of the most recent checks to keep for the activity graph.",
+      "label": "Activity history length"
+    },
     "assume_yes": {
       "description": "Pass --noconfirm / -y so package managers do not ask for confirmation. Off means you confirm each one in the terminal window.",
       "label": "Answer yes automatically"
@@ -86,6 +99,10 @@
     "notify_on_updates": {
       "description": "Send a desktop notification when a check finds packages to upgrade.",
       "label": "Notify when updates are found"
+    },
+    "show_activity_graph": {
+      "description": "Track pending-update counts across recent checks and when you last updated, shown as a small graph in the panel. Turning this off also stops recording the history.",
+      "label": "Show activity graph"
     },
     "show_count": {
       "description": "Show the number of pending updates next to the bar glyph.",

--- a/arch-updater/translations/en.json
+++ b/arch-updater/translations/en.json
@@ -4,8 +4,26 @@
   "action_open_news": "Open news",
   "action_update": "Update",
   "activity": {
+    "days_ago": {
+      "one": "1 day ago",
+      "other": "{count} days ago"
+    },
+    "hours_ago": {
+      "one": "1 hour ago",
+      "other": "{count} hours ago"
+    },
+    "just_now": "just now",
+    "minutes_ago": {
+      "one": "1 minute ago",
+      "other": "{count} minutes ago"
+    },
     "never_updated": "Never updated",
+    "pending_at": {
+      "one": "1 pending update",
+      "other": "{count} pending updates"
+    },
     "title": "Activity",
+    "updated": "Updated",
     "updated_days_ago": {
       "one": "Updated 1 day ago",
       "other": "Updated {count} days ago"

--- a/arch-updater/widget.luau
+++ b/arch-updater/widget.luau
@@ -32,7 +32,6 @@ end
 local function pending()
     return snapshot ~= nil
         and snapshot.phase == "ready"
-        and snapshot.dismissed ~= true
         and (snapshot.total or 0) > 0
 end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yuuto/arch-updater`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Three small panel/UX fixes to the Arch Updater plugin:
- Tightens the spacing and shrinks the copy/open-page icon buttons in the expanded pacman/AUR/Flatpak package list, so it reads more compact.
- "Dismiss" now actually clears the pending package list (pacman/AUR/Flatpak counts and items reset, download size cleared) and closes the panel, instead of just hiding the bar badge while quietly keeping stale data around until the next check.
- "Update" now also closes the panel when clicked, matching Dismiss.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
None (no new external dependencies, existing `dependencies` in `plugin.toml` are unchanged).

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.7-76-g02316e0c567c
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->9

## Screenshots / Videos
from:
<img width="423" height="526" alt="image" src="https://github.com/user-attachments/assets/5c9366a5-df04-44ff-bb45-33d4f1954b34" />
to:
<img width="415" height="531" alt="image" src="https://github.com/user-attachments/assets/6d68b2b7-0e04-4ffd-97e6-559dde01f87c" />

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
