### PR TITLE
fix(hassio): keep the entity browser inside the host's CPU budget.

### DIFF
--- a/hassio/panel.luau
+++ b/hassio/panel.luau
@@ -21,6 +21,7 @@ local browserLoadingSince = nil
 local browserFailed = false
 
 local BROWSER_TIMEOUT_SECONDS = 20
+local MAX_BROWSER_ROWS = 200
 local searchText = ""
 local monitoredEntities = {} -- current monitored list (owned here, saved to file)
 local panelOpenCount = 0
@@ -152,6 +153,52 @@ end
 local ENTITY_LIST_TEMPLATE =
     "{% for s in states %}{{ s.entity_id }}\t{{ s.name | replace('\\t',' ') | replace('\\n',' ') }}\n{% endfor %}"
 
+-- Same shape minus the friendly names, for instances that reject the template above.
+local ENTITY_ID_TEMPLATE =
+    "{% for s in states %}{{ s.entity_id }}\n{% endfor %}"
+
+local MAX_ENTITY_ID_LENGTH = 255
+local MAX_FRIENDLY_NAME_LENGTH = 255
+-- Comfortably past id + name, so a record is never cut short by it.
+local MAX_RECORD_SCAN = 1024
+
+-- Scans with plain string.find only. A Lua pattern such as "([^\t\n]+)\t" backtracks
+-- through every separator-free byte and gmatch then restarts one byte later, so a
+-- response that lost its tabs costs O(bytes^2) inside a single uninterruptible C call:
+-- seconds of CPU, which the host kills for overrunning the callback budget.
+local function parseEntityList(body)
+    local list = {}
+    local len = #body
+    -- Without any newline the whole body is one record, so a space is not a separator.
+    local splitOnSpace = string.find(body, "\n", 1, true) ~= nil
+    local pos = 1
+    while pos <= len do
+        local eol = string.find(body, "\n", pos, true) or (len + 1)
+        local lineEnd = eol - 1
+        if string.sub(body, lineEnd, lineEnd) == "\r" then lineEnd -= 1 end
+
+        -- Searching the body itself would re-scan to the far end on every separator-less
+        -- line, which is the quadratic behaviour this parser exists to avoid.
+        local record = string.sub(body, pos, math.min(lineEnd, pos + MAX_RECORD_SCAN - 1))
+        local sep = string.find(record, "\t", 1, true)
+        if not sep and splitOnSpace then sep = string.find(record, " ", 1, true) end
+
+        local entityId = sep and string.sub(record, 1, sep - 1) or record
+        local dot = string.find(entityId, ".", 1, true)
+        if dot and dot > 1 and dot < #entityId and #entityId <= MAX_ENTITY_ID_LENGTH then
+            local name = sep and string.sub(record, sep + 1) or ""
+            if #name > MAX_FRIENDLY_NAME_LENGTH then name = string.sub(name, 1, MAX_FRIENDLY_NAME_LENGTH) end
+            table.insert(list, {
+                entity_id     = entityId,
+                friendly_name = name ~= "" and name or entityId,
+                domain        = string.sub(entityId, 1, dot - 1),
+            })
+        end
+        pos = eol + 1
+    end
+    return list
+end
+
 -- HA iterates `states` in entity_id order, so this is normally just the linear check.
 local function sortEntitiesIfNeeded(list)
     for i = 2, #list do
@@ -168,6 +215,56 @@ local function finishBrowserLoad(list, failed)
     browserLoadingSince = nil
     browserFailed = failed == true
     render()
+end
+
+-- /api/states on a large instance decodes for longer than one callback is allowed to
+-- run, so the conversion is resumable: whatever is left over is finished by update(),
+-- which gets a fresh budget on every tick.
+local pendingStates = nil
+local pendingList = nil
+local pendingCursor = 1
+local STATES_PER_TICK = 1000
+
+local function consumePendingStates()
+    local states = pendingStates
+    if states == nil then return end
+
+    if type(states) ~= "table" then
+        pendingStates = nil
+        pendingList = nil
+        noctalia.log("Could not list entities: /api/states was not decodable")
+        finishBrowserLoad({}, true)
+        return
+    end
+
+    local list = pendingList
+    local total = #states
+    local i = pendingCursor
+    local last = math.min(i + STATES_PER_TICK - 1, total)
+    while i <= last do
+        local s = states[i]
+        local entityId = type(s) == "table" and s.entity_id or nil
+        if type(entityId) == "string" then
+            local attrs = s.attributes
+            local dot = string.find(entityId, ".", 1, true)
+            table.insert(list, {
+                entity_id     = entityId,
+                friendly_name = (type(attrs) == "table" and attrs.friendly_name) or entityId,
+                domain        = dot and string.sub(entityId, 1, dot - 1) or entityId,
+            })
+        end
+        i += 1
+        -- Kept in step with `list` so an aborted chunk resumes without duplicating.
+        pendingCursor = i
+    end
+
+    if i > total then
+        -- Cleared only once the sort is through, so an abort here retries next tick.
+        sortEntitiesIfNeeded(list)
+        pendingStates = nil
+        pendingList = nil
+        finishBrowserLoad(list)
+    end
 end
 
 -- Continues an already-started load, so it deliberately doesn't re-check browserLoading.
@@ -190,21 +287,50 @@ local function fetchAllEntitiesFromStates()
         end
 
         local states = noctalia.json.decode(body)
-        if type(states) ~= "table" then
-            noctalia.log("Could not list entities: /api/states was not decodable")
-            finishBrowserLoad({}, true)
+        -- Nothing but plain assignments may sit between the decode and here. The decode
+        -- alone can outlast the budget, and the host only aborts at the next call or
+        -- loop instruction, so these stores still commit and update() can take over.
+        pendingStates = states
+        pendingList = {}
+        pendingCursor = 1
+        consumePendingStates()
+    end)
+end
+
+-- Continues an already-started load, so it deliberately doesn't re-check browserLoading.
+local function fetchAllEntitiesFromTemplate(template, label, onUnusable)
+    local cleanToken = getCleanToken()
+    local url = getCleanUrl()
+
+    noctalia.http({
+        url = url .. "/api/template",
+        method = "POST",
+        headers = {
+            "Authorization: Bearer " .. cleanToken,
+            "Content-Type: application/json",
+        },
+        body = noctalia.json.encode({ template = template }),
+    }, function(response: HttpResponse)
+        local httpStatus = response and response.status or 0
+        local body = response and response.body or ""
+
+        if httpStatus < 200 or httpStatus >= 300 or body == "" then
+            noctalia.log(label .. " template unavailable (status " .. tostring(httpStatus) .. ")")
+            onUnusable()
             return
         end
 
-        local list = {}
-        for _, s in ipairs(states) do
-            local attrs = s.attributes or {}
-            table.insert(list, {
-                entity_id    = s.entity_id,
-                friendly_name = attrs.friendly_name or s.entity_id,
-                domain       = s.entity_id:match("^([^.]+)"),
-            })
+        local list = parseEntityList(body)
+
+        if #list == 0 then
+            -- The preview is what tells us how a given instance actually answers.
+            local preview = string.gsub(string.sub(body, 1, 120), "%c", ".")
+            noctalia.log(label .. " template returned nothing usable (" .. #body
+                .. " bytes, starts with: " .. preview .. ")")
+            onUnusable()
+            return
         end
+
         sortEntitiesIfNeeded(list)
         finishBrowserLoad(list)
     end)
@@ -212,6 +338,8 @@ end
 
 local function fetchAllEntities()
     if browserLoading then return end
+    pendingStates = nil
+    pendingList = nil
     local cleanToken = getCleanToken()
     local url = getCleanUrl()
     if not url or url == "" or cleanToken == "" then
@@ -227,42 +355,11 @@ local function fetchAllEntities()
     browserFailed = false
     render()
 
-    noctalia.http({
-        url = url .. "/api/template",
-        method = "POST",
-        headers = {
-            "Authorization: Bearer " .. cleanToken,
-            "Content-Type: application/json",
-        },
-        body = noctalia.json.encode({ template = ENTITY_LIST_TEMPLATE }),
-    }, function(response: HttpResponse)
-        local httpStatus = response and response.status or 0
-        local body = response and response.body or ""
-
-        if httpStatus < 200 or httpStatus >= 300 or body == "" then
-            noctalia.log("Entity list template unavailable (status " .. tostring(httpStatus)
-                .. "), falling back to /api/states")
-            fetchAllEntitiesFromStates()
-            return
-        end
-
-        local list = {}
-        for entityId, name in body:gmatch("([^\t\n]+)\t([^\n]*)") do
-            table.insert(list, {
-                entity_id     = entityId,
-                friendly_name = name ~= "" and name or entityId,
-                domain        = entityId:match("^([^.]+)"),
-            })
-        end
-
-        if #list == 0 then
-            noctalia.log("Entity list template returned nothing usable, falling back to /api/states")
-            fetchAllEntitiesFromStates()
-            return
-        end
-
-        sortEntitiesIfNeeded(list)
-        finishBrowserLoad(list)
+    -- Cheapest source first. The id-only template needs no filters and no `name`
+    -- attribute, so it still answers on instances where the full one doesn't, and
+    -- /api/states is only reached when neither template works.
+    fetchAllEntitiesFromTemplate(ENTITY_LIST_TEMPLATE, "Entity list", function()
+        fetchAllEntitiesFromTemplate(ENTITY_ID_TEMPLATE, "Entity id", fetchAllEntitiesFromStates)
     end)
 end
 
@@ -599,11 +696,18 @@ local function buildBrowserBody()
 
     local q = searchText:lower()
     local filtered = {}
+    -- A row is six UI nodes and a closure, so rendering every match on a large instance
+    -- overruns the callback budget on each keystroke. Nobody scrolls past a few hundred.
+    local truncated = false
     for _, e in ipairs(allEntities) do
         if q == ""
             or e.entity_id:lower():find(q, 1, true)
             or e.friendly_name:lower():find(q, 1, true)
         then
+            if #filtered >= MAX_BROWSER_ROWS then
+                truncated = true
+                break
+            end
             table.insert(filtered, e)
         end
     end
@@ -622,6 +726,14 @@ local function buildBrowserBody()
                 ui.label({ text = e.entity_id, color = "on_surface_variant", fontSize = 12 }),
             }),
             ui.button({ glyph = pinned and "pin-filled" or "pin", onClick = function() toggleBrowserPin(entityId) end }),
+        }))
+    end
+
+    if truncated then
+        table.insert(rows, ui.label({
+            text = tr("browser_truncated", { count = MAX_BROWSER_ROWS }),
+            color = "on_surface_variant",
+            fontSize = 12,
         }))
     end
 
@@ -672,6 +784,12 @@ end
 
 function update()
     local now = os.clock()
+
+    -- A load that is still converting is making progress, so it outranks the timeout.
+    if pendingStates ~= nil then
+        consumePendingStates()
+        return
+    end
 
     if browserLoading and browserLoadingSince and (now - browserLoadingSince) > BROWSER_TIMEOUT_SECONDS then
         browserLoading = false

--- a/hassio/plugin.toml
+++ b/hassio/plugin.toml
@@ -1,6 +1,6 @@
 id = "pozzoo/hassio"
 name = "Home Assistant"
-version = "2.0.5"
+version = "2.0.6"
 plugin_api = 9
 author = "Pozzoo"
 license = "MIT"

--- a/hassio/translations/en.json
+++ b/hassio/translations/en.json
@@ -6,6 +6,7 @@
   "panel": {
     "auth_failed": "Authentication failed. Check your access token.",
     "brightness": "Brightness",
+    "browser_truncated": "Showing the first {count} matches. Refine your search to narrow it down.",
     "color_temp": "Color Temperature",
     "connecting": "Connecting…",
     "disconnected_reconnecting": "Disconnected. Reconnecting…",

--- a/hassio/translations/pt-BR.json
+++ b/hassio/translations/pt-BR.json
@@ -6,6 +6,7 @@
   "panel": {
     "auth_failed": "Falha na autenticação. Verifique seu token de acesso.",
     "brightness": "Brilho",
+    "browser_truncated": "Mostrando as primeiras {count} correspondências. Refine sua busca para reduzir a lista.",
     "color_temp": "Temperatura de Cor",
     "connecting": "Conectando…",
     "disconnected_reconnecting": "Desconectado. Reconectando…",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `pozzoo/hassio`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Follow-up to #205 . That fix worked, the service reaches connected now, but it moved the failure into the new /api/template parser, so the entity browser dies instead:

`[ERR] [luau] call to 'async http callback' failed: panel.luau:250:
script callback 'async http callback' exceeded its CPU budget`

Cause: `body:gmatch("([^\t\n]+)\t([^\n]*)")` is quadratic when the tab separator isn't where it's expected.` [^\t\n]+` grabs to the next newline, then backtracks one byte at a time hunting for a `\t` that isn't there, and gmatch restarts one position later, all inside one uninterruptible C call. At 2000 records, it's 1.2 ms well-formed, 26.3 ms with newlines but no tabs, and 50.6 s with neither. Affected instances return 200 with a body whose tabs aren't there.

Fixes #218 

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

`xdg-open` - used to open the Home Assistant URL in your browser.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0-beta.7
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 9

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
