### PR TITLE
fix(nix-monitor): make generation checks configurable

### DIFF
--- a/nix-monitor/README.md
+++ b/nix-monitor/README.md
@@ -41,8 +41,9 @@ Update behavior:
 | --- | --- | --- |
 | `update_check_interval` | `60` | Minutes between remote revision checks. |
 | `update_check_duration_threshold` | `5` | Minutes before an update check is cancelled. |
-| `system_stats_check_interval` | `10` | Minutes between store-statistics checks. |
-| `system_stats_check_duration_threshold` | `5` | Minutes before a statistics check is cancelled. |
+| `generation_check_interval` | `60` | Minutes between NixOS and Home Manager generation checks. |
+| `system_stats_check_interval` | `60` | Minutes between store-statistics checks. |
+| `system_stats_check_duration_threshold` | `15` | Minutes before a statistics check is cancelled. |
 | `show_update_check_notification` | `false` | Notifies when an update check starts and finishes. |
 | `show_update_available_notification` | `true` | Notifies when a newer revision is available. |
 | `branch` | `nixos-unstable` | Nixpkgs branch compared by the service. |

--- a/nix-monitor/nix_monitor_service.luau
+++ b/nix-monitor/nix_monitor_service.luau
@@ -37,6 +37,7 @@ end
 local branch = cfg("branch")
 local updateCheckInterval = cfg("update_check_interval")
 local updateCheckDurationThreshold = cfg("update_check_duration_threshold")
+local generationsCheckInterval = cfg("generation_check_interval")
 local systemStatsCheckInterval = cfg("system_stats_check_interval")
 local systemStatsCheckDurationThreshold = cfg("system_stats_check_duration_threshold")
 local stateDir = noctalia.pluginDataDir() or "/tmp/nix-monitor"
@@ -292,7 +293,7 @@ function update()
 	end
 
 	-- Generations check
-	if (os.time() - getState("lastGenerationsCheckTime")) >= 10 then
+	if (os.time() - getState("lastGenerationsCheckTime")) >= 60 * generationsCheckInterval then
 		checkGenerations()
 	end
 

--- a/nix-monitor/plugin.toml
+++ b/nix-monitor/plugin.toml
@@ -1,6 +1,6 @@
 id              = "avivbintangaringga/nix-monitor"
 name            = "Nix Monitor"
-version         = "1.3.0"
+version         = "1.3.1"
 plugin_api      = 3
 icon            = "package"
 author          = "avivbintangaringga"
@@ -127,6 +127,14 @@ description_key = "setting.update_check_duration_threshold.description"
 default         = 5
 min             = 1
 max             = 30
+
+[[setting]]
+key             = "generation_check_interval"
+type            = "int"
+label_key       = "setting.generation_check_interval.label"
+description_key = "setting.generation_check_interval.description"
+default         = 60
+min             = 1
 
 [[setting]]
 key             = "system_stats_check_mode"

--- a/nix-monitor/translations/en.json
+++ b/nix-monitor/translations/en.json
@@ -40,6 +40,10 @@
       "description": "Add 'Press enter to exit' on the terminal window",
       "label": "Close on press Enter"
     },
+    "generation_check_interval": {
+      "description": "How often to check NixOS and Home Manager generations (in minutes)",
+      "label": "Generation check interval"
+    },
     "hide_clean_button": {
       "description": "Whether to hide the clean button on the panel",
       "label": "Hide clean button"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `avivbintangaringga/nix-monitor`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a `generation_check_interval` setting, in minutes, for NixOS and Home Manager generation checks. These checks were previously hard-coded to run every 10 seconds. On a system with multiple generations, each check spawned hundreds of short-lived processes; in testing, approximately 265 PIDs were allocated every 10 seconds.

The new setting defaults to 60 minutes. Generation data is still loaded immediately when the service starts and refreshed when the user clicks **Check**.

## External dependencies

No new dependencies. The existing generation checks use `nixos-rebuild`, `home-manager`, `tail`, `wc`, `grep`, and `awk`. Other existing plugin features use the remaining commands declared in `plugin.toml`.

## Testing

Validated the manifest and translation references with the repository validator. Ran all 44 validator tests and all 12 PR-template tests. On Niri with Noctalia 5.0.0, confirmed the previous 10-second checks allocated approximately 265 PIDs per run, then confirmed that a 3600-second interval removed those periodic PID bursts. Startup and manual checks use separate, unchanged code paths.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 3

## Screenshots / Videos

Not applicable; this changes a background polling interval and adds a standard integer setting.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
