### PR TITLE
Update Battery widget plugin

### DIFF
--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -11,7 +11,7 @@ Desktop/lockscreen widget that displays the current battery level and charging s
 
 ## Requirements
 
-The plugin requires `upower` and `dbus` (`dbus-monitor` on `PATH`).
+The plugin requires `upower` and `dbus-monitor` (`dbus`) on `PATH`.
 
 ## Usage
 

--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -24,6 +24,7 @@ Add it to your desktop/lockscreen widgets using the widget editor. You can confi
 | `layout` | `select` | `horizontal` | Layout of the widget. |
 | `show_glyph` | `bool` | `true` | Show the battery icon. |
 | `show_label` | `bool` | `true` | Show text next to the icon. |
+| `label_content` | `select` | `percent` | What the battery label shows: charge percentage, time remaining, or power draw. |
 | `hide_plugged` | `bool` | `false` | Hide the battery widget when connected to AC power. |
 | `hide_full` | `bool` | `false` | Hide the battery widget when fully charged. |
 | `color` | `color` | `on_surface` | Color role for this widget's icon and label; fixed hex colors are also supported. |

--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -11,7 +11,7 @@ Desktop/lockscreen widget that displays the current battery level and charging s
 
 ## Requirements
 
-The plugin requires `upower` and `dbus`.
+The plugin requires `upower` and `dbus` (`dbus-monitor` on `PATH`).
 
 ## Usage
 

--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -9,6 +9,10 @@ Desktop/lockscreen widget that displays the current battery level and charging s
 | ID | `yocraft/battery-widget` |
 | Entries | Desktop widget: `widget` |
 
+## Requirements
+
+The plugin requires `upower` and `dbus`.
+
 ## Usage
 
 Add it to your desktop/lockscreen widgets using the widget editor. You can configure it in the widget settings.
@@ -27,7 +31,6 @@ Add it to your desktop/lockscreen widgets using the widget editor. You can confi
 | `charging_color` | `color` | `on_surface` | Color applied when connected to AC power. |
 | `battery` | `select` | `auto` | Detect the battery automatically or set a custom name. |
 | `battery_name` | `string` | `BAT0` | Set a custom name for the battery. |
-| `refresh_interval` | `int` | `60` | Controls how frequently the widget updates its content. (in seconds) |
 
 ## Notes
 

--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -11,7 +11,7 @@ Desktop/lockscreen widget that displays the current battery level and charging s
 
 ## Requirements
 
-The plugin requires `upower` and `dbus-monitor` (`dbus`) on `PATH`.
+The plugin requires `gdbus` on `PATH` and `upower`.
 
 ## Usage
 

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -8,7 +8,7 @@ deprecated = false
 icon = "battery"
 description = "Desktop/Lockscreen widget to show battery."
 tags = [ "desktop", "hardware", "system", "utility" ]
-dependencies = []
+dependencies = [ "upower", "dbus" ]
 
 [[desktop_widget]]
 id = "widget"
@@ -98,12 +98,3 @@ entry = "widget.luau"
     description_key = "settings.battery_name.description"
     default = "BAT0"
     visible_when = { key = "battery", values = ["custom"] }
-
-    [[desktop_widget.setting]]
-    key = "refresh_interval"
-    type = "int"
-    label_key = "settings.refresh_interval.label"
-    description_key = "settings.refresh_interval.description"
-    default = 60
-    min = 1
-    max = 600

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -40,6 +40,18 @@ entry = "widget.luau"
     default = true
 
     [[desktop_widget.setting]]
+    key = "label_content"
+    type = "select"
+    label_key = "settings.label_content.label"
+    description_key = "settings.label_content.description"
+    default = "percent"
+    options = [
+        { value = "percent", label_key = "settings.label_content.percent" },
+        { value = "time", label_key = "settings.label_content.time" },
+        { value = "rate", label_key = "settings.label_content.rate" },
+    ]
+
+    [[desktop_widget.setting]]
     key = "hide_plugged"
     type = "bool"
     label_key = "settings.hide_plugged.label"

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -8,7 +8,7 @@ deprecated = false
 icon = "battery"
 description = "Desktop/Lockscreen widget to show battery."
 tags = [ "desktop", "hardware", "system", "utility" ]
-dependencies = [ "upower", "dbus" ]
+dependencies = [ "upower", "gdbus" ]
 
 [[desktop_widget]]
 id = "widget"

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -1,7 +1,7 @@
 id = "yocraft/battery-widget"
 name = "Battery Widget"
-version = "1.0.1"
-plugin_api = 19
+version = "1.1.0"
+plugin_api = 3
 author = "yocraft"
 license = "MIT"
 deprecated = false

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/battery-widget"
 name = "Battery Widget"
-version = "1.1.0"
+version = "2.0.0"
 plugin_api = 3
 author = "yocraft"
 license = "MIT"

--- a/battery-widget/translations/en.json
+++ b/battery-widget/translations/en.json
@@ -48,7 +48,14 @@
     "warning_color": {
       "description": "Color applied when charge is at or below noctalia's warning threshold.",
       "label": "Warning Color"
-    }
+    },
+        "label_content": {
+            "label": "Label Content",
+            "description": "What the battery label shows: charge percentage, time remaining, or power draw.",
+            "percent": "Percent",
+            "time": "Time",
+            "rate": "Rate"
+        }
   },
     "notify": {
         "error": "Something went wrong. Check the Noctalia log for details."

--- a/battery-widget/translations/en.json
+++ b/battery-widget/translations/en.json
@@ -49,5 +49,8 @@
       "description": "Color applied when charge is at or below noctalia's warning threshold.",
       "label": "Warning Color"
     }
-  }
+  },
+    "notify": {
+        "error": "Something went wrong. Check the Noctalia log for details."
+    }
 }

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -1,6 +1,6 @@
 local glyph
 local color
-local data
+local data = { percent = 0, status = "unknown" }
 
 local label_content = noctalia.getConfig("label_content")
 local warning_threshold = 20
@@ -115,12 +115,18 @@ local function getWarningThreshold()
             local res = result.stdout
 
             if not res then
-                noctalia.log("battery-widget: invalid warning_threshold")
+                noctalia.log("battery-widget: invalid warning_threshold, keeping default")
                 notifyError()
                 return
             end
 
-            warning_threshold = tonumber(noctalia.string.trim(res))
+            local parsed = tonumber(noctalia.string.trim(res))
+            if parsed then
+                warning_threshold = parsed
+            else
+                noctalia.log("battery-widget: invalid warning_threshold, keeping default")
+                notifyError()
+            end
         end
     )
 end
@@ -162,16 +168,20 @@ local function formatRate(rate)
     return string.format("%.1f W", rate)
 end
 
+local function formatPercent()
+    return math.floor((data.percent or 0) + 0.5) .. "%"
+end
+
 local function getLabelText()
     if label_content == "time" then
         local connected = data.status == "charging" or data.status == "fully-charged" or data.status == "pending-charge"
         local seconds = connected and data.timeToFull or data.timeToEmpty
-        return formatTime(seconds) or (data.percent .. "%")
+        return formatTime(seconds) or formatPercent()
     elseif label_content == "rate" then
-        return formatRate(data.rate) or (data.percent .. "%")
+        return formatRate(data.rate) or formatPercent()
     end
 
-    return data.percent .. "%"
+    return formatPercent()
 end
 
 local function render()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -8,12 +8,18 @@ local warning_threshold = 20
 local path = "/sys/class/power_supply/"
 local batName
 
+local function notifyError()
+    noctalia.notifyError("Battery widget", "Something went wrong. Check the Noctalia log for details.")
+end
+
 if not noctalia.commandExists("dbus-monitor") then
     noctalia.log("battery-widget: dbus-monitor not found.")
+    notifyError()
     return
 end
 if not noctalia.commandExists("upower") then
     noctalia.log("battery-widget: upower not found.")
+    notifyError()
     return
 end
 
@@ -60,6 +66,7 @@ local function getWarningThreshold()
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to get warning_threshold: " .. result.stderr)
+                notifyError()
                 return
             end
 
@@ -67,6 +74,7 @@ local function getWarningThreshold()
 
             if not res then
                 noctalia.log("battery-widget: invalid warning_threshold: " .. res)
+                notifyError()
                 return
             end
 
@@ -125,6 +133,7 @@ local function refreshBattery()
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to read battery: " .. result.stderr)
+                notifyError()
                 return
             end
 
@@ -143,6 +152,7 @@ end
 batName = getBatName()
 if not batName then
     noctalia.log("battery-widget: battery not found")
+    notifyError()
     return
 end
 

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -12,15 +12,12 @@ local function notifyError()
     noctalia.notifyError("Battery widget", "Something went wrong. Check the Noctalia log for details.")
 end
 
-if not noctalia.commandExists("dbus-monitor") then
-    noctalia.log("battery-widget: dbus-monitor not found.")
-    notifyError()
-    return
-end
-if not noctalia.commandExists("upower") then
-    noctalia.log("battery-widget: upower not found.")
-    notifyError()
-    return
+for _, cmd in ipairs({ "dbus-monitor", "upower" }) do
+    if not noctalia.commandExists(cmd) then
+        noctalia.log("battery-widget: " .. cmd .. " not found.")
+        notifyError()
+        return
+    end
 end
 
 local function getBatName()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -1,23 +1,52 @@
 local glyph
 local color
-local percent
-local status
+local data
 
 local warning_threshold = 20
 
 local path = "/sys/class/power_supply/"
 local batName
 
+local stateMap = {
+    [0] = "unknown",
+    [1] = "charging",
+    [2] = "discharging",
+    [3] = "empty",
+    [4] = "fully-charged",
+    [5] = "pending-charge",
+    [6] = "pending-discharge",
+}
+
+local function shellEscape(raw)
+    return "'" .. raw:gsub("'", "'\\''") .. "'"
+end
+
 local function notifyError()
     noctalia.notifyError("Battery widget", noctalia.tr("notify.error"))
 end
 
-for _, cmd in ipairs({ "dbus-monitor", "upower" }) do
+for _, cmd in ipairs({ "gdbus", "upower" }) do
     if not noctalia.commandExists(cmd) then
         noctalia.log("battery-widget: " .. cmd .. " not found.")
         notifyError()
         return
     end
+end
+
+local function parse(output)
+    data = data or {}
+
+    local percent = output:match("'Percentage':%s*<([%d%.]+)>")
+    if percent then
+        data.percent = tonumber(percent)
+    end
+
+    local state = output:match("'State':%s*<uint32%s+(%d+)>")
+    if state then
+        data.status = stateMap[tonumber(state)] or "unknown"
+    end
+
+    return data
 end
 
 local function getBatName()
@@ -42,17 +71,17 @@ local function getBatName()
 end
 
 local function getGlyph()
-    if status == "charging" then
+    if data.status == "charging" then
         glyph = "battery-charging"
-    elseif status == "fully-charged" or status == "pending-charge" then
+    elseif data.status == "fully-charged" or data.status == "pending-charge" then
         glyph = "battery-plugged"
-    elseif status == "unknown" then
+    elseif data.status == "unknown" then
         glyph = "battery-exclamation"
     else
-        glyph = percent >= 85 and "battery-4"
-        or percent >= 55 and "battery-3"
-        or percent >= 30 and "battery-2"
-        or percent >= 10 and "battery-1"
+        glyph = data.percent >= 85 and "battery-4"
+        or data.percent >= 55 and "battery-3"
+        or data.percent >= 30 and "battery-2"
+        or data.percent >= 10 and "battery-1"
         or "battery-0"
     end
 end
@@ -70,7 +99,7 @@ local function getWarningThreshold()
             local res = result.stdout
 
             if not res then
-                noctalia.log("battery-widget: invalid warning_threshold: " .. res)
+                noctalia.log("battery-widget: invalid warning_threshold")
                 notifyError()
                 return
             end
@@ -81,11 +110,11 @@ local function getWarningThreshold()
 end
 
 local function getColor()
-    if status == "charging" or status == "fully-charged" or status == "pending-charge" then
+    if data.status == "charging" or data.status == "fully-charged" or data.status == "pending-charge" then
         color = noctalia.getConfig("charging_color")
         return
     end
-    if percent <= warning_threshold then
+    if data.percent <= warning_threshold then
         color = noctalia.getConfig("warning_color")
         return
     end
@@ -93,8 +122,8 @@ local function getColor()
 end
 
 local function render()
-    if (noctalia.getConfig("hide_plugged") and (status == "charging" or status == "pending-charge"))
-        or (noctalia.getConfig("hide_full") and status == "fully-charged") then
+    if (noctalia.getConfig("hide_plugged") and (data.status == "charging" or data.status == "pending-charge"))
+        or (noctalia.getConfig("hide_full") and data.status == "fully-charged") then
         desktopWidget.render(ui.row())
         return
     end
@@ -104,7 +133,7 @@ local function render()
         table.insert(content, ui.glyph({ name = glyph, color = color }))
     end
     if noctalia.getConfig("show_label") then
-        table.insert(content, ui.label({ text = percent .. "%", color = color }))
+        table.insert(content, ui.label({ text = data.percent .. "%", color = color }))
     end
 
     local vertical = noctalia.getConfig("layout") == "vertical"
@@ -119,29 +148,48 @@ local function render()
     )
 end
 
-local function shellEscape(raw)
-    return "'" .. raw:gsub("'", "'\\''") .. "'"
+local function refreshBattery(output)
+    parse(output)
+    getGlyph()
+    getColor()
+    render()
 end
 
-local function refreshBattery()
-    noctalia.runAsync(
-        "upower -i /org/freedesktop/UPower/devices/battery_"
-        .. batName,
+local function initData()
+    local cmd = string.format(
+        "gdbus call --system --dest org.freedesktop.UPower --object-path %s --method org.freedesktop.DBus.Properties.GetAll org.freedesktop.UPower.Device",
+        shellEscape("/org/freedesktop/UPower/devices/battery_" .. batName)
+    )
+    noctalia.runAsync(cmd,
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to read battery: " .. result.stderr)
-                notifyError()
                 return
             end
 
-            local output = result.stdout
+            if not result.stdout then
+                noctalia.log("battery-widget: invalid battery output")
+                return
+            end
 
-            percent = tonumber(output:match("percentage:%s*(%d+)%%"))
-            status = output:match("state:%s*(%S+)")
+            refreshBattery(result.stdout)
+        end
+    )
+end
 
-            getGlyph()
-            getColor()
-            render()
+local function watchBattery()
+    local cmd = string.format(
+        "gdbus monitor --system --dest org.freedesktop.UPower --object-path %s",
+        shellEscape("/org/freedesktop/UPower/devices/battery_" .. batName)
+    )
+    noctalia.runStream(cmd,
+        function(line)
+            for _, pattern in ipairs({ "Percentage", "State" }) do
+                if line:find(pattern) then
+                    refreshBattery(line)
+                    break
+                end
+            end
         end
     )
 end
@@ -155,22 +203,5 @@ end
 
 getWarningThreshold()
 
-local function watchBattery()
-    local cmd = string.format(
-        "gdbus monitor --system --dest org.freedesktop.UPower --object-path /org/freedesktop/UPower/devices/battery_%s",
-        batName
-    )
-    noctalia.runStream(cmd,
-        function(line)
-            for _, pattern in ipairs({ "Percentage", "State" }) do
-                if line:find(pattern) then
-                    refreshBattery()
-                    break
-                end
-            end
-        end
-    )
-end
-
-refreshBattery()
+initData()
 watchBattery()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -2,6 +2,7 @@ local glyph
 local color
 local data
 
+local label_content = noctalia.getConfig("label_content")
 local warning_threshold = 20
 
 local path = "/sys/class/power_supply/"
@@ -25,7 +26,7 @@ local function notifyError()
     noctalia.notifyError("Battery widget", noctalia.tr("notify.error"))
 end
 
-for _, cmd in ipairs({ "gdbus", "upower" }) do
+for _, cmd in ipairs({ "gdbus" }) do
     if not noctalia.commandExists(cmd) then
         noctalia.log("battery-widget: " .. cmd .. " not found.")
         notifyError()
@@ -38,12 +39,29 @@ local function parse(output)
 
     local percent = output:match("'Percentage':%s*<([%d%.]+)>")
     if percent then
-        data.percent = tonumber(percent)
+        data.percent = tonumber(percent) or 0
     end
 
     local state = output:match("'State':%s*<uint32%s+(%d+)>")
     if state then
         data.status = stateMap[tonumber(state)] or "unknown"
+    end
+
+    if label_content == "time" then
+        local timeToEmpty = output:match("'TimeToEmpty':%s*<int64%s+(%-?%d+)>")
+        if timeToEmpty then
+            data.timeToEmpty = tonumber(timeToEmpty)
+        end
+
+        local timeToFull = output:match("'TimeToFull':%s*<int64%s+(%-?%d+)>")
+        if timeToFull then
+            data.timeToFull = tonumber(timeToFull)
+        end
+    elseif label_content == "rate" then
+        local rate = output:match("'EnergyRate':%s*<([%-%d%.]+)>")
+        if rate then
+            data.rate = tonumber(rate)
+        end
     end
 
     return data
@@ -121,6 +139,43 @@ local function getColor()
     color = noctalia.getConfig("color")
 end
 
+local function formatTime(seconds)
+    if not seconds or seconds <= 0 then
+        return nil
+    end
+
+    local hours = math.floor(seconds / 3600)
+    local minutes = math.floor((seconds % 3600) / 60)
+
+    if hours > 0 and minutes > 0 then
+        return string.format("%dh %dm", hours, minutes)
+    elseif hours > 0 then
+        return string.format("%dh", hours)
+    else
+        return string.format("%dm", minutes)
+    end
+end
+
+local function formatRate(rate)
+    if not rate or rate <= 0 then
+        return nil
+    end
+
+    return string.format("%.1f W", rate)
+end
+
+local function getLabelText()
+    if label_content == "time" then
+        local connected = data.status == "charging" or data.status == "fully-charged" or data.status == "pending-charge"
+        local seconds = connected and data.timeToFull or data.timeToEmpty
+        return formatTime(seconds) or (data.percent .. "%")
+    elseif label_content == "rate" then
+        return formatRate(data.rate) or (data.percent .. "%")
+    end
+
+    return data.percent .. "%"
+end
+
 local function render()
     if (noctalia.getConfig("hide_plugged") and (data.status == "charging" or data.status == "pending-charge"))
         or (noctalia.getConfig("hide_full") and data.status == "fully-charged") then
@@ -133,7 +188,7 @@ local function render()
         table.insert(content, ui.glyph({ name = glyph, color = color }))
     end
     if noctalia.getConfig("show_label") then
-        table.insert(content, ui.label({ text = data.percent .. "%", color = color }))
+        table.insert(content, ui.label({ text = getLabelText(), color = color }))
     end
 
     local vertical = noctalia.getConfig("layout") == "vertical"
@@ -178,13 +233,21 @@ local function initData()
 end
 
 local function watchBattery()
+    local patterns = { "Percentage", "State" }
+    if label_content == "time" then
+        table.insert(patterns, "TimeToEmpty")
+        table.insert(patterns, "TimeToFull")
+    elseif label_content == "rate" then
+        table.insert(patterns, "EnergyRate")
+    end
+
     local cmd = string.format(
         "gdbus monitor --system --dest org.freedesktop.UPower --object-path %s",
         shellEscape("/org/freedesktop/UPower/devices/battery_" .. batName)
     )
     noctalia.runStream(cmd,
         function(line)
-            for _, pattern in ipairs({ "Percentage", "State" }) do
+            for _, pattern in ipairs(patterns) do
                 if line:find(pattern) then
                     refreshBattery(line)
                     break

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -157,13 +157,16 @@ getWarningThreshold()
 
 local function watchBattery()
     local cmd = string.format(
-        "dbus-monitor --system \"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/freedesktop/UPower/devices/battery_%s'\"",
+        "gdbus monitor --system --dest org.freedesktop.UPower --object-path /org/freedesktop/UPower/devices/battery_%s",
         batName
     )
     noctalia.runStream(cmd,
         function(line)
-            if line:find("Percentage") or line:find("State") then
-                refreshBattery()
+            for _, pattern in ipairs({ "Percentage", "State" }) do
+                if line:find(pattern) then
+                    refreshBattery()
+                    break
+                end
             end
         end
     )

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -56,7 +56,7 @@ local function getWarningThreshold()
 
             local res = result.stdout
 
-            if not warning_threshold then
+            if not res then
                 noctalia.log("battery-widget: invalid warning_threshold: " .. res)
                 return
             end

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -12,6 +12,10 @@ if not noctalia.commandExists("dbus-monitor") then
     noctalia.log("battery-widget: dbus-monitor not found.")
     return
 end
+if not noctalia.commandExists("upower") then
+    noctalia.log("battery-widget: upower not found.")
+    return
+end
 
 local function getBatName()
     local config = noctalia.getConfig("battery")
@@ -35,11 +39,11 @@ local function getBatName()
 end
 
 local function getGlyph()
-    if status == "Charging" then
+    if status == "charging" then
         glyph = "battery-charging"
-    elseif status == "Full" or status == "Not charging" then
+    elseif status == "fully-charged" or status == "pending-charge" then
         glyph = "battery-plugged"
-    elseif status == "Unknown" then
+    elseif status == "unknown" then
         glyph = "battery-exclamation"
     else
         glyph = percent >= 85 and "battery-4"
@@ -72,7 +76,7 @@ local function getWarningThreshold()
 end
 
 local function getColor()
-    if status == "Charging" or status == "Full" or status == "Not charging" then
+    if status == "charging" or status == "fully-charged" or status == "pending-charge" then
         color = noctalia.getConfig("charging_color")
         return
     end
@@ -84,8 +88,8 @@ local function getColor()
 end
 
 local function render()
-    if (noctalia.getConfig("hide_plugged") and (status == "Charging" or status == "Not charging"))
-        or (noctalia.getConfig("hide_full") and status == "Full") then
+    if (noctalia.getConfig("hide_plugged") and (status == "charging" or status == "pending-charge"))
+        or (noctalia.getConfig("hide_full") and status == "fully-charged") then
         desktopWidget.render(ui.row())
         return
     end
@@ -116,28 +120,18 @@ end
 
 local function refreshBattery()
     noctalia.runAsync(
-        "cat "
-        .. shellEscape(path .. batName .. "/capacity")
-        .. " "
-        .. shellEscape(path .. batName .. "/status"),
+        "upower -i /org/freedesktop/UPower/devices/battery_"
+        .. batName,
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to read battery: " .. result.stderr)
                 return
             end
 
-            local lines = {}
-            for line in result.stdout:gmatch("[^\r\n]+") do
-                table.insert(lines, line)
-            end
+            local output = result.stdout
 
-            if not lines[1] or not lines[2] then
-                noctalia.log("battery-widget: invalid battery output")
-                return
-            end
-
-            percent = tonumber(noctalia.string.trim(lines[1]))
-            status = noctalia.string.trim(lines[2])
+            percent = tonumber(output:match("percentage:%s*(%d+)%%"))
+            status = output:match("state:%s*(%S+)")
 
             getGlyph()
             getColor()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -26,12 +26,10 @@ local function notifyError()
     noctalia.notifyError("Battery widget", noctalia.tr("notify.error"))
 end
 
-for _, cmd in ipairs({ "gdbus" }) do
-    if not noctalia.commandExists(cmd) then
-        noctalia.log("battery-widget: " .. cmd .. " not found.")
-        notifyError()
-        return
-    end
+if not noctalia.commandExists("gdbus") then
+    noctalia.log("battery-widget: gdbus not found.")
+    notifyError()
+    return
 end
 
 local function parse(output)

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -60,7 +60,7 @@ local function getWarningThreshold()
                 noctalia.log("battery-widget: invalid warning_threshold: " .. res)
                 return
             end
-            
+
             warning_threshold = tonumber(noctalia.string.trim(res))
         end
     )
@@ -149,7 +149,19 @@ end
 
 getWarningThreshold()
 
-function update()
-    noctalia.setUpdateInterval(noctalia.getConfig("refresh_interval") * 1000)
-    refreshBattery()
+local function watchBattery()
+    local cmd = string.format(
+        "dbus-monitor --system \"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/freedesktop/UPower/devices/battery_%s'\"",
+        batName
+    )
+    noctalia.runStream(cmd,
+        function(line)
+            if line:find("Percentage") or line:find("State") then
+                refreshBattery()
+            end
+        end
+    )
 end
+
+refreshBattery()
+watchBattery()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -79,7 +79,7 @@ local function getColor()
 end
 
 local function render()
-    if (noctalia.getConfig("hide_plugged") and (status == "Charging" or status == "Not Charging"))
+    if (noctalia.getConfig("hide_plugged") and (status == "Charging" or status == "Not charging"))
         or (noctalia.getConfig("hide_full") and status == "Full") then
         desktopWidget.render(ui.row())
         return

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -9,7 +9,7 @@ local path = "/sys/class/power_supply/"
 local batName
 
 local function notifyError()
-    noctalia.notifyError("Battery widget", "Something went wrong. Check the Noctalia log for details.")
+    noctalia.notifyError("Battery widget", noctalia.tr("notify.error"))
 end
 
 for _, cmd in ipairs({ "dbus-monitor", "upower" }) do

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -32,7 +32,7 @@ end
 local function getGlyph()
     if status == "Charging" then
         glyph = "battery-charging"
-    elseif status == "Full" or status == "Not Charging" then
+    elseif status == "Full" or status == "Not charging" then
         glyph = "battery-plugged"
     elseif status == "Unknown" then
         glyph = "battery-exclamation"

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -8,6 +8,11 @@ local warning_threshold = 20
 local path = "/sys/class/power_supply/"
 local batName
 
+if not noctalia.commandExists("dbus-monitor") then
+    noctalia.log("battery-widget: dbus-monitor not found.")
+    return
+end
+
 local function getBatName()
     local config = noctalia.getConfig("battery")
 

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -72,12 +72,12 @@ local function getWarningThreshold()
 end
 
 local function getColor()
-    if status ~= "Charging" and percent <= warning_threshold then
-        color = noctalia.getConfig("warning_color")
+    if status == "Charging" or status == "Full" or status == "Not charging" then
+        color = noctalia.getConfig("charging_color")
         return
     end
-    if status == "Charging" or status == "Full" or status == "Not Charging" then
-        color = noctalia.getConfig("charging_color")
+    if percent <= warning_threshold then
+        color = noctalia.getConfig("warning_color")
         return
     end
     color = noctalia.getConfig("color")


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/battery-widget`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does
Desktop/lockscreen widget that displays the current battery level and charging status.
<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
upower and dbus

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 3

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
