### PR TITLE
fix(eyecare): fixed silent audio fallback, add reset toast (#312)

### DIFF
--- a/eyecare/plugin.toml
+++ b/eyecare/plugin.toml
@@ -1,6 +1,6 @@
 id = "apex077/eyecare"
 name = "Eye-Care Reminders"
-version = "1.0.1"
+version = "1.0.2"
 plugin_api = 3
 author = "Apex077"
 license = "MIT"

--- a/eyecare/service.luau
+++ b/eyecare/service.luau
@@ -53,24 +53,18 @@ local function isSoundAllowed()
 
     -- Check Noctalia global sound configuration options
     local enableSounds = noctalia.getConfig("enable_sounds")
-    if enableSounds == false then
+    if enableSounds == false or enableSounds == "false" then
         return false
     end
 
     local soundEnabled = noctalia.getConfig("sound_enabled")
-    if soundEnabled == false then
+    if soundEnabled == false or soundEnabled == "false" then
         return false
     end
 
     local audioEnableSounds = noctalia.getConfig("audio.enable_sounds")
-    if audioEnableSounds == false then
+    if audioEnableSounds == false or audioEnableSounds == "false" then
         return false
-    end
-
-    if noctalia.sound and type(noctalia.sound.isEnabled) == "function" then
-        if not noctalia.sound.isEnabled() then
-            return false
-        end
     end
 
     if getSoundVolume() <= 0 then
@@ -80,27 +74,26 @@ local function isSoundAllowed()
     return true
 end
 
--- Play a notification sound using Noctalia runtime sound API if available, falling back to system players with volume scaling
+-- Play a notification sound using system players with volume scaling matching Noctalia's volume setting
 local function playSound(soundName)
     if not isSoundAllowed() then
         return
     end
 
     local vol = getSoundVolume()
-
-    if noctalia.sound and type(noctalia.sound.play) == "function" then
-        noctalia.sound.play(soundName, vol)
-        return
-    elseif type(noctalia.playSound) == "function" then
-        noctalia.playSound(soundName, vol)
+    if vol <= 0 then
         return
     end
 
     local path = "/usr/share/sounds/freedesktop/stereo/" .. soundName .. ".oga"
     local paVol = math.floor(vol * 65536)
     local pwVol = string.format("%.2f", vol)
-    
-    noctalia.runAsync(string.format("canberra-gtk-play -i %s || paplay --volume=%d %s || pw-play --volume=%s %s || aplay %s || true", soundName, paVol, path, pwVol, path, path))
+
+    local cmd = string.format(
+        "pw-play --volume=%s %s || paplay --volume=%d %s || canberra-gtk-play -i %s || aplay %s || true",
+        pwVol, path, paVol, path, soundName, path
+    )
+    noctalia.runAsync(cmd)
 end
 
 local lastLoggedIdle = nil
@@ -154,20 +147,7 @@ function update()
             end
         elseif breakTimer >= settings.break_duration_seconds then
             -- Break completed successfully
-            inBreak = false
-            breakTimer = 0
-            breakElapsed = 0
-            activeTime = 0
-            
-            if settings.enable_notifications then
-                noctalia.notify(
-                    noctalia.tr("notifications.eyecare-break-finished-title"),
-                    noctalia.tr("notifications.eyecare-break-finished-body")
-                )
-            end
-            if settings.enable_sound then
-                playSound("complete")
-            end
+            finishBreak()
         end
     else
         -- Not in break
@@ -212,12 +192,29 @@ local function triggerBreak()
     
     if settings.enable_notifications then
         noctalia.notify(
-            noctalia.tr("notifications.eyecare-break-title"),
-            noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds })
+            noctalia.tr("notifications.eyecare-break-title") or "Time for a break",
+            noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds }) or string.format("Focus on an object 20 feet away for %d seconds.", settings.break_duration_seconds)
         )
     end
     if settings.enable_sound then
         playSound("message")
+    end
+end
+
+local function finishBreak()
+    inBreak = false
+    breakTimer = 0
+    breakElapsed = 0
+    activeTime = 0
+
+    if settings.enable_notifications then
+        noctalia.notify(
+            noctalia.tr("notifications.eyecare-break-finished-title") or "Break finished",
+            noctalia.tr("notifications.eyecare-break-finished-body") or "Your eyes are rested. You can return to your screen."
+        )
+    end
+    if settings.enable_sound then
+        playSound("complete")
     end
 end
 
@@ -234,6 +231,13 @@ local function resetTimer()
     breakElapsed = 0
     activeTime = 0
     idleTime = 0
+
+    if settings.enable_notifications then
+        noctalia.notify(
+            noctalia.tr("notifications.eyecare-reset-title") or "Eye-Care",
+            noctalia.tr("notifications.eyecare-reset-body") or "Timer has been reset."
+        )
+    end
 end
 
 -- Listen to compositor IPC commands
@@ -244,7 +248,9 @@ function onIpc(event, payload)
         isSystemIdle = false
     elseif event == "trigger-break" then
         triggerBreak()
-    elseif event == "finish-break" or event == "abort-break" then
+    elseif event == "finish-break" then
+        finishBreak()
+    elseif event == "abort-break" then
         abortBreak()
     elseif event == "reset" then
         resetTimer()

--- a/eyecare/service.luau
+++ b/eyecare/service.luau
@@ -117,72 +117,6 @@ end
 
 local wasSystemIdle = false
 
--- Tick cycle actions (every 1 second)
-function update()
-    noctalia.setUpdateInterval(1000)
-
-    -- Detect transition from idle to active (unlock/wake up)
-    local transitionedToActive = (wasSystemIdle and not isSystemIdle)
-    wasSystemIdle = isSystemIdle
-
-    if inBreak then
-        breakTimer = breakTimer + 1
-        breakElapsed = breakTimer  -- Keep breakElapsed in sync for backward compatibility
-        
-        if transitionedToActive then
-            local grace_threshold = math.min(10, settings.break_duration_seconds)
-            if breakTimer >= grace_threshold then
-                -- User was away for at least the grace threshold and now returned,
-                -- so consider the break completed/accepted.
-                inBreak = false
-                breakTimer = 0
-                breakElapsed = 0
-                activeTime = 0
-            else
-                -- User returned almost immediately, abort/cancel the break
-                inBreak = false
-                breakTimer = 0
-                breakElapsed = 0
-                activeTime = 0
-            end
-        elseif breakTimer >= settings.break_duration_seconds then
-            -- Break completed successfully
-            finishBreak()
-        end
-    else
-        -- Not in break
-        if isSystemIdle then
-            idleTime = idleTime + 1
-            -- Natural break detection (user rested without prompting)
-            if idleTime >= settings.break_duration_seconds then
-                activeTime = 0
-            end
-        else
-            idleTime = 0
-            activeTime = activeTime + 1
-            if activeTime >= settings.active_duration_minutes * 60 then
-                -- Trigger Break Reminder
-                inBreak = true
-                breakTimer = 0
-                breakElapsed = 0
-                activeTime = 0
-                
-                if settings.enable_notifications then
-                    noctalia.notify(
-                        noctalia.tr("notifications.eyecare-break-title"),
-                        noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds })
-                    )
-                end
-                if settings.enable_sound then
-                    playSound("message")
-                end
-            end
-        end
-    end
-
-    updateState()
-end
-
 -- Helper functions for timer state transitions
 local function triggerBreak()
     inBreak = true
@@ -238,6 +172,72 @@ local function resetTimer()
             noctalia.tr("notifications.eyecare-reset-body") or "Timer has been reset."
         )
     end
+end
+
+-- Tick cycle actions (every 1 second)
+function update()
+    noctalia.setUpdateInterval(1000)
+
+    -- Detect transition from idle to active (unlock/wake up)
+    local transitionedToActive = (wasSystemIdle and not isSystemIdle)
+    wasSystemIdle = isSystemIdle
+
+    if inBreak then
+        breakTimer = breakTimer + 1
+        breakElapsed = breakTimer  -- Keep breakElapsed in sync for backward compatibility
+        
+        if transitionedToActive then
+            local grace_threshold = math.min(10, settings.break_duration_seconds)
+            if breakTimer >= grace_threshold then
+                -- User was away for at least the grace threshold and now returned,
+                -- so consider the break completed/accepted.
+                inBreak = false
+                breakTimer = 0
+                breakElapsed = 0
+                activeTime = 0
+            else
+                -- User returned almost immediately, abort/cancel the break
+                inBreak = false
+                breakTimer = 0
+                breakElapsed = 0
+                activeTime = 0
+            end
+        elseif breakTimer >= settings.break_duration_seconds then
+            -- Break completed successfully
+            finishBreak()
+        end
+    else
+        -- Not in break
+        if isSystemIdle then
+            idleTime = idleTime + 1
+            -- Natural break detection (user rested without prompting)
+            if idleTime >= settings.break_duration_seconds then
+                activeTime = 0
+            end
+        else
+            idleTime = 0
+            activeTime = activeTime + 1
+            if activeTime >= settings.active_duration_minutes * 60 then
+                -- Trigger Break Reminder
+                inBreak = true
+                breakTimer = 0
+                breakElapsed = 0
+                activeTime = 0
+                
+                if settings.enable_notifications then
+                    noctalia.notify(
+                        noctalia.tr("notifications.eyecare-break-title") or "Time for a break",
+                        noctalia.tr("notifications.eyecare-break-body", { seconds = settings.break_duration_seconds }) or string.format("Focus on an object 20 feet away for %d seconds.", settings.break_duration_seconds)
+                    )
+                end
+                if settings.enable_sound then
+                    playSound("message")
+                end
+            end
+        end
+    end
+
+    updateState()
 end
 
 -- Listen to compositor IPC commands

--- a/eyecare/translations/en.json
+++ b/eyecare/translations/en.json
@@ -3,7 +3,9 @@
     "eyecare-break-body": "Focus on an object 20 feet away for {seconds} seconds.",
     "eyecare-break-finished-body": "Your eyes are rested. You can return to your screen.",
     "eyecare-break-finished-title": "Break finished",
-    "eyecare-break-title": "Time for a break"
+    "eyecare-break-title": "Time for a break",
+    "eyecare-reset-body": "Timer has been reset.",
+    "eyecare-reset-title": "Eye-Care"
   },
   "settings": {
     "eyecare-active-duration": {

--- a/eyecare/widget.luau
+++ b/eyecare/widget.luau
@@ -94,7 +94,6 @@ end
 
 function onRightClick()
     noctalia.state.set("eyecare-request", "reset")
-    noctalia.notify("Eye-Care", "Timer has been reset.")
 end
 
 -- Initial render


### PR DESCRIPTION
Updated fix to issue #312

<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `apex077/eyecare`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Fixes issue #312 where `eyecare` notification sounds ignored Noctalia's global sound settings, volume slider, and failed silently on Noctalia v5 runtime:
- **Fixed Silent Audio Fallback**: Removed custom asset bank checks (`noctalia.sound.isEnabled()`) that false-positively blocked system freedesktop audio playback.
- **Fixed `finish-break` Chime**: Extracted `finishBreak()` to play the `complete` chime cue and send completion notification toast.
- **Fixed `reset` IPC Toast**: Added notification toast handling (`eyecare-reset-title` & `eyecare-reset-body`) to `resetTimer()` in `service.luau`.
- **Version Bump**: Updated version to `1.0.2` in `plugin.toml`, since I forgot to push previous changes in the previous commit :(.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
No new dependencies. All original dependencies as mentioned in `plugin.toml`.
## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `noctalia v5.0.0 (v5.0.0-beta.3-42-g8b5b1381d5a2)`
- **Plugin API level:** 3<!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
NA

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
