### PR TITLE
pulsar-mouse: make the per-state widget colors configurable

### DIFF
--- a/pulsar-mouse/README.md
+++ b/pulsar-mouse/README.md
@@ -77,7 +77,7 @@ The `bar` and `battery` entries both read battery percentage/charging/low-power-
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `glyph_size` | `int` | `16` | Glyph size, 10-32. |
-| `color` | `color` | `on_surface` | Glyph color at a normal battery level, and on a wired mouse. |
+| `normal_color` | `color` | `on_surface` | Glyph color at a normal battery level, and on a wired mouse. |
 | `charging_color` | `color` | `secondary` | Glyph color while charging. |
 | `warning_color` | `color` | `error` | Glyph color at or below the Low Power Mode threshold. |
 | `error_color` | `color` | `error` | Glyph color when the mouse or the CLI can't be found. |
@@ -94,7 +94,9 @@ The `bar` and `battery` entries both read battery percentage/charging/low-power-
 | `show_percent` | `bool` | `true` | Turn off to rely on just the glyph and progress bar. |
 | `glyph_size` | `int` | `28` | Glyph size, 16-64. |
 
-The four state colors are per-widget, so the bar and desktop widgets can differ. All of them (bar's `color` included) sit behind the settings UI's **advanced** toggle, except the desktop widget's `color`. The defaults reproduce exactly what these were before they were configurable, so an existing setup looks unchanged until you touch one.
+The four state colors are per-widget, so the bar and desktop widgets can differ. All of them (bar's `normal_color` included) sit behind the settings UI's **advanced** toggle, except the desktop widget's `color`. The defaults reproduce exactly what these were before they were configurable, so an existing setup looks unchanged until you touch one.
+
+The normal-state setting is called `normal_color` on the bar widget but `color` on the desktop widget. That asymmetry is deliberate: a bar widget's plugin settings share a TOML table with Noctalia's own per-widget presentation settings, where `color` is already taken ("Color role for this widget's icon and label"). A plugin declaring `color` there does not shadow it, it aliases it - one key backs both pickers, so setting either silently moves the other. Desktop widgets have no such clash, and renaming that one would break existing configs.
 
 ## Notes
 

--- a/pulsar-mouse/README.md
+++ b/pulsar-mouse/README.md
@@ -30,7 +30,7 @@ noctalia msg plugins enable harveywuk/pulsar-mouse
 
 ### Bar Widget
 
-Add the `bar` bar widget to your bar. Shows a battery glyph, icon-only, with a tooltip for the full status (percentage, charging, signal strength when available) - the glyph is the only thing rendered regardless of bar orientation; the glyph turns a secondary accent color while charging, or red once battery drops to the mouse's configured Low Power Mode threshold (see Controls Panel; falls back to 15% on a driver that doesn't expose that threshold, e.g. nordic.py). On a wired mouse (no battery to show) it stays visible as a plain neutral glyph rather than hiding, since it's the only way to open the controls panel - DPI/lighting controls still work on a wired mouse, only the Power tab doesn't apply. If `pulsar-mouse-gui` isn't installed or running at all, this widget still works, it just always reads a fresh value directly from the mouse instead of the GUI's cached one (see Data source).
+Add the `bar` bar widget to your bar. Shows a battery glyph, icon-only, with a tooltip for the full status (percentage, charging, signal strength when available) - the glyph is the only thing rendered regardless of bar orientation; by default the glyph turns a secondary accent color while charging, or red once battery drops to the mouse's configured Low Power Mode threshold (see Controls Panel; falls back to 15% on a driver that doesn't expose that threshold, e.g. nordic.py) - each of those state colors is configurable, see Settings. On a wired mouse (no battery to show) it stays visible as a plain neutral glyph rather than hiding, since it's the only way to open the controls panel - DPI/lighting controls still work on a wired mouse, only the Power tab doesn't apply. If `pulsar-mouse-gui` isn't installed or running at all, this widget still works, it just always reads a fresh value directly from the mouse instead of the GUI's cached one (see Data source).
 
 ### Controls Panel
 
@@ -77,15 +77,24 @@ The `bar` and `battery` entries both read battery percentage/charging/low-power-
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `glyph_size` | `int` | `16` | Glyph size, 10-32. |
+| `color` | `color` | `on_surface` | Glyph color at a normal battery level, and on a wired mouse. |
+| `charging_color` | `color` | `secondary` | Glyph color while charging. |
+| `warning_color` | `color` | `error` | Glyph color at or below the Low Power Mode threshold. |
+| `error_color` | `color` | `error` | Glyph color when the mouse or the CLI can't be found. |
 
 ### Desktop Widget
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `color` | `color` | `primary` | Accent color for the percentage text and progress bar. |
+| `color` | `color` | `primary` | Accent color for the percentage text and progress bar at a normal battery level. |
+| `charging_color` | `color` | `secondary` | Used while charging. |
+| `warning_color` | `color` | `error` | Used at or below the Low Power Mode threshold. |
+| `error_color` | `color` | `error` | Used when the mouse or the CLI can't be found. |
 | `show_progress` | `bool` | `true` | Shows or hides the battery-level progress bar. |
 | `show_percent` | `bool` | `true` | Turn off to rely on just the glyph and progress bar. |
 | `glyph_size` | `int` | `28` | Glyph size, 16-64. |
+
+The four state colors are per-widget, so the bar and desktop widgets can differ. All of them (bar's `color` included) sit behind the settings UI's **advanced** toggle, except the desktop widget's `color`. The defaults reproduce exactly what these were before they were configurable, so an existing setup looks unchanged until you touch one.
 
 ## Notes
 

--- a/pulsar-mouse/bar.luau
+++ b/pulsar-mouse/bar.luau
@@ -17,9 +17,10 @@
 --
 -- Icon-only (no percentage label): battery level and charging state are
 -- already in the hover tooltip, so a bar-row number would just be the same
--- fact twice. Just the Tabler "mouse-filled" glyph, tinted red by
--- statusColor() same as before, swapping to "mouse-off" for a genuine
--- error/no-mouse state.
+-- fact twice. Just the Tabler "mouse-filled" glyph, tinted per state by
+-- statusColor(), swapping to "mouse-off" for a genuine error/no-mouse state.
+-- Each of those state colors is a setting (normal/charging/low/error),
+-- defaulting to what they were previously hardcoded to.
 --
 -- Signal quality has no synchronous getter (see gui.py's own comment on
 -- this) - it only arrives via an async hidraw event the GUI listens for, so
@@ -57,6 +58,14 @@ local checkingCli = false
 local isVertical = false
 local glyphSize = noctalia.getConfig("glyph_size")
 
+-- Per-state colors, defaulted in plugin.toml to the values these used to be
+-- hardcoded to. Read once here rather than per-render, same as glyph_size -
+-- a settings change reloads the widget anyway.
+local normalColor = noctalia.getConfig("color")
+local chargingColor = noctalia.getConfig("charging_color")
+local warningColor = noctalia.getConfig("warning_color")
+local errorColor = noctalia.getConfig("error_color")
+
 local function statusGlyph(color)
   local name = (errorText ~= nil or percent == nil) and "mouse-off" or "mouse-filled"
   return ui.glyph({ name = name, size = glyphSize, color = color })
@@ -64,15 +73,15 @@ end
 
 local function statusColor()
   if errorText ~= nil then
-    return "error"
+    return errorColor
   end
   if charging then
-    return "secondary"
+    return chargingColor
   end
   if percent ~= nil and percent <= (lowPowerThreshold or LOW_POWER_DEFAULT) then
-    return "error"
+    return warningColor
   end
-  return "on_surface"
+  return normalColor
 end
 
 local function tooltipText()
@@ -98,8 +107,10 @@ local function render()
   local glyph
   if not wireless then
     -- No battery to show, but still clickable - a wired mouse still has
-    -- DPI/lighting controls in the panel, just not the Power tab.
-    glyph = ui.glyph({ name = "mouse-filled", size = glyphSize, color = "on_surface" })
+    -- DPI/lighting controls in the panel, just not the Power tab. Takes the
+    -- normal-state color: there's nothing wrong here, it's just permanently
+    -- the only state this mouse has.
+    glyph = ui.glyph({ name = "mouse-filled", size = glyphSize, color = normalColor })
     barWidget.setTooltip(noctalia.tr("ui.wired"))
   else
     glyph = statusGlyph(statusColor())

--- a/pulsar-mouse/bar.luau
+++ b/pulsar-mouse/bar.luau
@@ -61,7 +61,10 @@ local glyphSize = noctalia.getConfig("glyph_size")
 -- Per-state colors, defaulted in plugin.toml to the values these used to be
 -- hardcoded to. Read once here rather than per-render, same as glyph_size -
 -- a settings change reloads the widget anyway.
-local normalColor = noctalia.getConfig("color")
+--
+-- `normal_color`, not `color` - see plugin.toml for why that name is
+-- unusable on a bar widget.
+local normalColor = noctalia.getConfig("normal_color")
 local chargingColor = noctalia.getConfig("charging_color")
 local warningColor = noctalia.getConfig("warning_color")
 local errorColor = noctalia.getConfig("error_color")

--- a/pulsar-mouse/desktop.luau
+++ b/pulsar-mouse/desktop.luau
@@ -25,6 +25,11 @@ local LOW_POWER_DEFAULT = 15 -- used when the driver has no low-power-threshold
                               -- getter (e.g. nordic.py) or it hasn't been read yet
 
 local color = noctalia.getConfig("color")
+-- The other three states. Defaulted in plugin.toml to the values these were
+-- previously hardcoded to, so an existing install renders identically.
+local chargingColor = noctalia.getConfig("charging_color")
+local warningColor = noctalia.getConfig("warning_color")
+local errorColor = noctalia.getConfig("error_color")
 local showProgress = noctalia.getConfig("show_progress")
 local showPercent = noctalia.getConfig("show_percent")
 local glyphSize = noctalia.getConfig("glyph_size")
@@ -38,13 +43,13 @@ local checkingCli = false
 
 local function statusColor()
   if errorText ~= nil then
-    return "error"
+    return errorColor
   end
   if charging then
-    return "secondary"
+    return chargingColor
   end
   if percent ~= nil and percent <= (lowPowerThreshold or LOW_POWER_DEFAULT) then
-    return "error"
+    return warningColor
   end
   return color
 end
@@ -77,7 +82,7 @@ local function render()
   if errorText ~= nil then
     -- Diagnostic, not decorative - stays visible even with show_percent off,
     -- since otherwise a broken setup would just silently show a bare glyph.
-    table.insert(rows, ui.label({ key = "status", text = errorText, fontSize = 12, color = "error" }))
+    table.insert(rows, ui.label({ key = "status", text = errorText, fontSize = 12, color = errorColor }))
   elseif showPercent and percent == nil then
     table.insert(rows, ui.label({ key = "status", text = "--", fontSize = 20, color = "outline" }))
   elseif showPercent then

--- a/pulsar-mouse/plugin.toml
+++ b/pulsar-mouse/plugin.toml
@@ -45,11 +45,19 @@ entry = "bar.luau"
   # so an existing install looks identical until someone changes one. Marked
   # advanced since the interesting knob for most people is glyph_size - these
   # are for matching a specific colorscheme.
+  #
+  # Deliberately NOT called `color`: a bar widget's settings share one TOML
+  # table with Noctalia's own per-widget presentation settings, and `color`
+  # is already taken there (the "Color role for this widget's icon and
+  # label" one). Declaring it here doesn't shadow that setting, it aliases
+  # it - one `color = ...` key ends up backing both pickers, so setting
+  # either silently moves the other. The desktop widget has no such clash,
+  # which is why its equivalent is still plain `color`.
   [[widget.setting]]
-  key = "color"
+  key = "normal_color"
   type = "color"
-  label_key = "settings.bar_color.label"
-  description_key = "settings.bar_color.description"
+  label_key = "settings.normal_color.label"
+  description_key = "settings.normal_color.description"
   default = "on_surface"
   advanced = true
 

--- a/pulsar-mouse/plugin.toml
+++ b/pulsar-mouse/plugin.toml
@@ -19,7 +19,7 @@
 
 id = "harveywuk/pulsar-mouse"
 name = "Pulsar Mouse"
-version = "1.6.1"
+version = "1.7.0"
 plugin_api = 9
 author = "harveywuk"
 license = "MIT"
@@ -41,6 +41,42 @@ entry = "bar.luau"
   max = 32
   step = 1
 
+  # Per-state glyph colors. The defaults reproduce what used to be hardcoded,
+  # so an existing install looks identical until someone changes one. Marked
+  # advanced since the interesting knob for most people is glyph_size - these
+  # are for matching a specific colorscheme.
+  [[widget.setting]]
+  key = "color"
+  type = "color"
+  label_key = "settings.bar_color.label"
+  description_key = "settings.bar_color.description"
+  default = "on_surface"
+  advanced = true
+
+  [[widget.setting]]
+  key = "charging_color"
+  type = "color"
+  label_key = "settings.charging_color.label"
+  description_key = "settings.charging_color.description"
+  default = "secondary"
+  advanced = true
+
+  [[widget.setting]]
+  key = "warning_color"
+  type = "color"
+  label_key = "settings.warning_color.label"
+  description_key = "settings.warning_color.description"
+  default = "error"
+  advanced = true
+
+  [[widget.setting]]
+  key = "error_color"
+  type = "color"
+  label_key = "settings.error_color.label"
+  description_key = "settings.error_color.description"
+  default = "error"
+  advanced = true
+
 [[panel]]
 id = "controls"
 entry = "panel.luau"
@@ -60,6 +96,32 @@ entry = "desktop.luau"
   label_key = "settings.color.label"
   description_key = "settings.color.description"
   default = "primary"
+
+  # The other three states (see bar's copy of these) - `color` above stays
+  # non-advanced since it's the one that was always here.
+  [[desktop_widget.setting]]
+  key = "charging_color"
+  type = "color"
+  label_key = "settings.charging_color.label"
+  description_key = "settings.charging_color.description"
+  default = "secondary"
+  advanced = true
+
+  [[desktop_widget.setting]]
+  key = "warning_color"
+  type = "color"
+  label_key = "settings.warning_color.label"
+  description_key = "settings.warning_color.description"
+  default = "error"
+  advanced = true
+
+  [[desktop_widget.setting]]
+  key = "error_color"
+  type = "color"
+  label_key = "settings.error_color.label"
+  description_key = "settings.error_color.description"
+  default = "error"
+  advanced = true
 
   [[desktop_widget.setting]]
   key = "show_progress"

--- a/pulsar-mouse/translations/en.json
+++ b/pulsar-mouse/translations/en.json
@@ -1,9 +1,5 @@
 {
   "settings": {
-    "bar_color": {
-      "description": "Glyph color at a normal battery level, and on a wired mouse",
-      "label": "Color"
-    },
     "charging_color": {
       "description": "Used while the mouse is charging",
       "label": "Charging Color"
@@ -18,6 +14,10 @@
     },
     "glyph_size": {
       "label": "Glyph Size"
+    },
+    "normal_color": {
+      "description": "Glyph color at a normal battery level, and on a wired mouse",
+      "label": "Normal Color"
     },
     "show_percent": {
       "description": "Turn off to rely on just the glyph (and progress bar, if shown)",

--- a/pulsar-mouse/translations/en.json
+++ b/pulsar-mouse/translations/en.json
@@ -1,8 +1,20 @@
 {
   "settings": {
+    "bar_color": {
+      "description": "Glyph color at a normal battery level, and on a wired mouse",
+      "label": "Color"
+    },
+    "charging_color": {
+      "description": "Used while the mouse is charging",
+      "label": "Charging Color"
+    },
     "color": {
       "description": "Accent color for the percentage text and progress bar",
       "label": "Color"
+    },
+    "error_color": {
+      "description": "Used when the mouse or the pulsar-mouse CLI can't be found",
+      "label": "Error Color"
     },
     "glyph_size": {
       "label": "Glyph Size"
@@ -13,6 +25,10 @@
     },
     "show_progress": {
       "label": "Show Progress Bar"
+    },
+    "warning_color": {
+      "description": "Used at or below the mouse's Low Power Mode threshold",
+      "label": "Low Battery Color"
     }
   },
   "ui": {


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `harveywuk/pulsar-mouse`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Makes the widgets' per-state colors configurable instead of hardcoded.

Both widgets baked in their state colors: `error` for a fault, `secondary` while charging, `error` at or below the mouse's low-power threshold. The desktop widget's single `color` setting only ever applied to the *normal* state, and the bar widget had no color setting at all — so its charging/low/error tints could not be matched to a colorscheme.

All four states are now `type = "color"` settings on each widget, in the same shape `battery-widget` uses:

| Bar setting | Desktop setting | Default | State |
| --- | --- | --- | --- |
| `normal_color` | `color` (unchanged) | `on_surface` / `primary` | Normal battery level; also the bar's wired-mouse glyph |
| `charging_color` | `charging_color` | `secondary` | Charging |
| `warning_color` | `warning_color` | `error` | At or below the Low Power Mode threshold |
| `error_color` | `error_color` | `error` | Mouse or `pulsar-mouse` CLI not found |

The defaults reproduce exactly what was previously hardcoded, so an existing install renders identically until someone changes one. They are per-widget, so the bar and desktop can differ.

The new settings are `advanced`, to keep `glyph_size` from being buried under four color pickers. The desktop widget's pre-existing `color` deliberately stays non-advanced so it does not disappear behind the toggle for anyone already using it.

### Why the bar's is `normal_color` and the desktop's is `color`

Worth flagging for other plugin authors, since it is invisible until you open the settings page: **a bar widget's plugin settings share one TOML table with Noctalia's own per-widget presentation settings**, and `color` is already taken there — the "Color role for this widget's icon and label" one under Presentation.

Declaring `color` as a bar-widget plugin setting does not shadow that setting, it *aliases* it. A single `color = "primary"` under `[widget.<id>]` drove both pickers at once, so setting either silently moved the other, and the plugin's own `getConfig("color")` and Noctalia's icon tint both acted on it. Renaming to `normal_color` resolves it. Desktop widgets have no such clash, and renaming that one would break existing configs, so it stays `color`.

If that collision is considered a core bug rather than something plugins should route around, happy to rename back once it is fixed.

### Left alone on purpose

The desktop widget's "Wired" placeholder and its `--` no-reading-yet row stay `outline`, since those are deliberately muted placeholders rather than status states; and the controls panel's colors are structural chrome, not state.

`translations/en.json` is also re-sorted alphabetically to match what the i18n bot did to it in 66226fc, so the diff here stays limited to the keys this PR actually changes.

## External dependencies

Unchanged from the existing plugin: the `pulsar-mouse` CLI from [pulsar-mouse-linux](https://github.com/harveywuk/pulsar-mouse-linux), already declared in `dependencies`. This PR adds no new dependency and no new process, file, or network access — it only changes which color string is handed to `ui.glyph`/`ui.label`/`ui.progress`.

## Testing

Against a live Noctalia 5.0.0 on Hyprland, from a path source pointing at the working tree.

- Full `plugins disable` / `plugins enable` cycle: all 3 entries load, and `noctalia.log` shows no warnings or errors from the plugin after the reload (in particular no `read undeclared setting`, which is what surfaces when the manifest and the Luau disagree on a key).
- Bar widget, normal state: default `on_surface` renders the white `mouse-filled` glyph. Setting `normal_color = "primary"` and reloading turns that glyph purple while every neighbouring bar item is untouched. With no `color` key present in the widget's table, the plugin's own code path is the only thing that can be producing it — which is exactly what the first attempt at this test could *not* establish, and how the aliasing above was found.
- Settings page renders all four pickers with their labels and descriptions, and Presentation's own Color picker stays on `Default` while `normal_color` is overridden.
- `plugin.toml` parses; every `label_key`/`description_key` resolves in `translations/en.json` with no orphaned keys left behind by the rename; `bar.luau` and `desktop.luau` pass `luau-analyze` with no syntax errors (only the expected unknown-global notes for host-injected `noctalia`/`ui`/`barWidget`/`desktopWidget`).

Not exercised live: the charging, low-battery, and error states, which need a draining/charging mouse or an unplugged one to reach naturally. They run through the same `statusColor()` branch as the normal state that is demonstrated above, and their defaults are byte-for-byte the previously hardcoded values.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 9

## Screenshots / Videos

The bar widget's glyph at a normal battery level, default vs. `normal_color = "primary"`. Nothing else in the bar changes:

![Bar glyph, default on_surface next to normal_color set to primary](https://raw.githubusercontent.com/harveywuk/community-plugins/pr-assets/pulsar-mouse-bar.png)

The four pickers on the widget's settings page. Note Presentation's own **Color** sitting on `Default` while **Normal Color** is overridden — that separation is the point of the rename described above; before it, overriding either one moved both:

![Settings page showing Normal Color, Charging Color, Low Battery Color and Error Color pickers](https://raw.githubusercontent.com/harveywuk/community-plugins/pr-assets/pulsar-mouse-settings.png)

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
