### PR TITLE
update(w-engine): add all option in selection output

### DIFF
--- a/w-engine/plugin.toml
+++ b/w-engine/plugin.toml
@@ -1,6 +1,6 @@
 id = "tadomika_ari/w-engine"
 name = "W Engine"
-version = "1.2.0"
+version = "1.3.0"
 # Tile and control callbacks are Luau closures rather than named globals, which
 # the host resolves from plugin API 9 onwards.
 plugin_api = 9

--- a/w-engine/start.luau
+++ b/w-engine/start.luau
@@ -61,6 +61,21 @@ local lastNonce = nil
 local workshopRoot = nil
 local rngState = 0
 
+-- Get All output for all fonctionnality --
+
+local allOutputs = nil
+local isAllOutputs = false
+
+local function getAllOutput()
+	local outputs = {}
+	for index, output in ipairs(noctalia.outputs()) do
+		table.insert(outputs, output.name)
+	end
+    return outputs
+end
+
+allOutputs = getAllOutput()
+
 local function tr(key, subst)
 	if subst then
 		return noctalia.tr(key, subst)
@@ -593,7 +608,7 @@ local function handleRequest(request)
 	end
 	lastNonce = request.nonce
 
-	local output = request.output
+	local output = request.output			-- here
 	if type(output) ~= "string" or output == "" then
 		output = noctalia.focusedOutputName()
 	end
@@ -601,12 +616,46 @@ local function handleRequest(request)
 		return
 	end
 
+	if output == "All" then
+		isAllOutputs = true
+	end
+	if output ~= "All" then
+		isAllOutputs = false
+	end
+
 	local action = request.action
 	if action == "apply" then
+		if isAllOutputs then
+			for _, outputForAll in ipairs(allOutputs) do
+				setCycle(outputForAll, false)
+				apply(outputForAll, request.id)
+			end
+			return
+		end
 		-- A one-shot pick takes over from any cycle on that output.
 		setCycle(output, false)
 		apply(output, request.id)
+
 	elseif action == "select" then
+		
+		if isAllOutputs then
+			for _, outputForAll in ipairs(allOutputs) do
+				local ids = {}
+				if type(request.ids) == "table" then
+					for _, id in ipairs(request.ids) do
+						if type(id) == "string" and id ~= "" then
+							table.insert(ids, id)
+						end
+					end
+				end
+				data.selection[outputForAll] = ids
+				shuffled[outputForAll] = nil
+				saveData()
+				publishStatus()
+			end
+			return
+		end
+
 		local ids = {}
 		if type(request.ids) == "table" then
 			for _, id in ipairs(request.ids) do
@@ -619,7 +668,34 @@ local function handleRequest(request)
 		shuffled[output] = nil
 		saveData()
 		publishStatus()
+
 	elseif action == "cycle" then
+
+		if isAllOutputs then
+			for _, outputForAll in ipairs(allOutputs) do
+				setCycle(outputForAll, request.enabled, request.minutes, request.order)
+				local cycle = cycleFor(outputForAll)
+				if cycle.enabled then
+					local ids = selectionFor(outputForAll)
+					if #ids == 0 then
+						setCycle(outputForAll, false)
+						noctalia.notify(tr("panel.title"), tr("panel.cycle_needs_selection"))
+					else
+						-- Start on the first pick straight away rather than leaving the
+						-- previous wallpaper up for a whole interval.
+						local first = cycle.order == "random" and nextRandom(outputForAll, ids) or ids[1]
+						apply(outputForAll, first)
+						noctalia.notify(
+							tr("panel.title"),
+							tr("panel.cycle_started", { count = #ids, minutes = cycle.minutes })
+						)
+					end
+				end
+				publishStatus()
+			end
+			return
+		end
+
 		setCycle(output, request.enabled, request.minutes, request.order)
 		local cycle = cycleFor(output)
 		if cycle.enabled then
@@ -640,6 +716,21 @@ local function handleRequest(request)
 		end
 		publishStatus()
 	elseif action == "stop" then
+		
+		if isAllOutputs then
+			for _, outputForAll in ipairs(allOutputs) do
+				
+				setCycle(outputForAll, false)
+				data.current[outputForAll] = nil
+				saveData()
+				stopProcess(outputForAll, nil)
+				restoreShellWallpaper(outputForAll)
+				publishStatus()
+
+			end
+			return
+		end
+
 		setCycle(output, false)
 		data.current[output] = nil
 		saveData()

--- a/w-engine/start.luau
+++ b/w-engine/start.luau
@@ -625,7 +625,7 @@ local function handleRequest(request)
 
 	local action = request.action
 	if action == "apply" then
-		if isAllOutputs then
+		if isAllOutputs then 				-- loop for All Output
 			for _, outputForAll in ipairs(allOutputs) do
 				setCycle(outputForAll, false)
 				apply(outputForAll, request.id)
@@ -638,7 +638,7 @@ local function handleRequest(request)
 
 	elseif action == "select" then
 		
-		if isAllOutputs then
+		if isAllOutputs then				-- loop for All Output
 			for _, outputForAll in ipairs(allOutputs) do
 				local ids = {}
 				if type(request.ids) == "table" then
@@ -671,7 +671,7 @@ local function handleRequest(request)
 
 	elseif action == "cycle" then
 
-		if isAllOutputs then
+		if isAllOutputs then					-- loop for All Output
 			for _, outputForAll in ipairs(allOutputs) do
 				setCycle(outputForAll, request.enabled, request.minutes, request.order)
 				local cycle = cycleFor(outputForAll)

--- a/w-engine/w-engine-panel.luau
+++ b/w-engine/w-engine-panel.luau
@@ -78,6 +78,9 @@ local function tr(key, subst)
 	return noctalia.tr(key)
 end
 
+-- Get All output for all fonctionnality --
+
+
 -- ── Workshop discovery ───────────────────────────────────────────────────────
 
 local function candidateRoots()
@@ -214,6 +217,26 @@ local function outputStatus()
 	end
 	local entry = outputs[outputName]
 	return type(entry) == "table" and entry or {}
+end
+
+
+local function hasStopState()		-- check for render stop button
+	if outputName ~= "All" then
+		local state = outputStatus()
+		return state.current ~= nil or state.restorable == true
+	end
+
+	local outputs = type(status) == "table" and status.outputs or nil
+	if type(outputs) ~= "table" then
+		return false
+	end
+
+	for _, entry in pairs(outputs) do
+		if type(entry) == "table" and (entry.current ~= nil or entry.restorable == true) then
+			return true
+		end
+	end
+	return false
 end
 
 local function storedDefaults()
@@ -553,7 +576,6 @@ local ENGINE_TOGGLES = {
 -- ── Rendering ────────────────────────────────────────────────────────────────
 
 local function header()
-	local state = outputStatus()
 	local children = {
 		ui.label({
 			text = tr("panel.title"),
@@ -575,7 +597,7 @@ local function header()
 		}),
 	}
 
-	if state.current or state.restorable then
+	if hasStopState() then
 		table.insert(
 			children,
 			ui.button({
@@ -596,6 +618,10 @@ local function header()
 		if output.name == outputName then
 			selectedIndex = index - 1
 		end
+	end
+	table.insert(outputs, "All")
+	if outputName == "All" then
+		selectedIndex = #outputs - 1
 	end
 	table.insert(children, ui.select({ options = outputs, selectedIndex = selectedIndex, onChange = "outputSelected" }))
 	table.insert(


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `<author>/<plugin>`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Add in selection box a "All" Option. 
Work for apply a wallpaper, cycle and clear.
<!-- A short description, and what a user gets out of it. -->

Mention: https://github.com/noctalia-dev/community-plugins/issues/313#issue-5100065178

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
