### PR TITLE
feat(phone-connect): allow configuring bar widget contents

### DIFF
--- a/phone-connect/README.md
+++ b/phone-connect/README.md
@@ -38,7 +38,7 @@ noctalia msg plugin icefish/phone-connect:kde all cmd '{"op":"ring","device":"<i
 - **Device status** — battery level, charging state, network type (5G/LTE), pairing
 - **Quick actions** — ring, ping, send clipboard, share text/files/URLs, SMS, SFTP browser
 - **Media control** — play/pause/skip/seek, album art, now-playing (MPRIS)
-- **Customization** — per-device image and alias, three panel placements
+- **Customization** — configurable bar contents, per-device image and alias, three panel placements
 - **Language** — English / Simplified Chinese
 
 ## Requirements
@@ -53,6 +53,8 @@ noctalia msg plugin icefish/phone-connect:kde all cmd '{"op":"ring","device":"<i
 |---------|---------|-------------|
 | State Update Interval | 30 | Seconds between device refreshes |
 | Show Charging Fill | true | Highlight bar widget when charging |
+| Show Device Name | false | Show the selected device's name or alias |
+| Battery Display | icon_and_percent | Show the battery icon, percentage, both, or neither |
 | Show Clipboard Action | true | Show clipboard button in panel |
 | Device Image | — | Custom image for selected device |
 | Device Alias | Your-Phone | Custom display name |

--- a/phone-connect/plugin.toml
+++ b/phone-connect/plugin.toml
@@ -12,7 +12,7 @@
 
 id = "icefish/phone-connect"
 name = "Phone Connect"
-version = "0.1.1"
+version = "0.1.2"
 plugin_api = 16
 author = "icefish"
 license = "MIT"
@@ -42,6 +42,26 @@ type = "bool"
 label_key = "settings.enable_charging_animation.label"
 description_key = "settings.enable_charging_animation.description"
 default = true
+
+[[setting]]
+key = "show_device_name"
+type = "bool"
+label_key = "settings.show_device_name.label"
+description_key = "settings.show_device_name.description"
+default = false
+
+[[setting]]
+key = "battery_display"
+type = "select"
+label_key = "settings.battery_display.label"
+description_key = "settings.battery_display.description"
+default = "icon_and_percent"
+options = [
+  { value = "icon_and_percent", label_key = "settings.battery_display.icon_and_percent" },
+  { value = "percent", label_key = "settings.battery_display.percent" },
+  { value = "icon", label_key = "settings.battery_display.icon" },
+  { value = "hidden", label_key = "settings.battery_display.hidden" },
+]
 
 [[setting]]
 key = "custom_image"

--- a/phone-connect/translations/en.json
+++ b/phone-connect/translations/en.json
@@ -58,6 +58,14 @@
     "unpaired": "Unpaired"
   },
   "settings": {
+    "battery_display": {
+      "description": "Choose whether the bar widget shows the battery icon, percentage, both, or neither.",
+      "hidden": "Hidden",
+      "icon": "Icon only",
+      "icon_and_percent": "Icon and percentage",
+      "label": "Battery Display",
+      "percent": "Percentage only"
+    },
     "custom_image": {
       "description": "Set a custom image for the selected device. Leave empty for default icon.",
       "label": "Device Image"
@@ -95,6 +103,10 @@
     "scan_subdirectories": {
       "description": "Recursively scan subdirectories of the recent images path.",
       "label": "Scan Subdirectories"
+    },
+    "show_device_name": {
+      "description": "Show the selected device's name or alias in the bar widget.",
+      "label": "Show Device Name"
     },
     "show_device_placeholder": {
       "description": "Show the device graphic in the details panel.",

--- a/phone-connect/widget.luau
+++ b/phone-connect/widget.luau
@@ -1,9 +1,9 @@
 -- widget.luau
 -- Phone Connect - bar widget (thin UI entry).
 --
--- Renders a bar pill reflecting the selected device: device glyph + battery
--- percent, colored by state (charging -> primary, low -> error, offline ->
--- dimmed). Left-click opens the details panel; right-click opens settings.
+-- Renders a device glyph with an optional name and configurable battery status,
+-- colored by state (charging -> primary, low -> error, offline -> dimmed).
+-- Left-click opens the details panel; right-click opens settings.
 -- Reads state from the service entry; no DBus logic here.
 
 -- Local translation: reads from pc.trTable (published by service) so users
@@ -57,6 +57,8 @@ local function render()
 	local backend = noctalia.state.get("pc.backend") or { available = false }
 	local d = selectedDevice()
 	local enableCharging = noctalia.getConfig("enable_charging_animation")
+	local showDeviceName = noctalia.getConfig("show_device_name") == true
+	local batteryDisplay = noctalia.getConfig("battery_display") or "icon_and_percent"
 
 	local children
 	if not backend.available then
@@ -87,20 +89,29 @@ local function render()
 		end
 
 		local kids = { ui.glyph({ name = glyphFor(d), size = 14, color = glyphColor }) }
+		if showDeviceName then
+			local aliasMap = noctalia.state.get("pc.aliasMap") or {}
+			local name = aliasMap[d.id] or d.name or "Your-Phone"
+			table.insert(kids, ui.label({ text = name, fontSize = 11, color = glyphColor }))
+		end
 
 		if reachable and hasCharge then
-			-- battery glyph + percent, colored by level
 			local batColor = "on_surface"
 			if charging then batColor = "primary"
 			elseif charge <= 20 then batColor = "error" end
-			table.insert(kids, ui.glyph({ name = batteryGlyph(charge, charging),
-				size = 12, color = batColor }))
-			table.insert(kids, ui.label({
-				text = tostring(charge) .. "%", fontSize = 11,
-				fontWeight = "medium", color = batColor,
-			}))
+
+			if batteryDisplay == "icon_and_percent" or batteryDisplay == "icon" then
+				table.insert(kids, ui.glyph({ name = batteryGlyph(charge, charging),
+					size = 12, color = batColor }))
+			end
+			if batteryDisplay == "icon_and_percent" or batteryDisplay == "percent" then
+				table.insert(kids, ui.label({
+					text = tostring(charge) .. "%", fontSize = 11,
+					fontWeight = "medium", color = batColor,
+				}))
+			end
 		elseif not reachable and d.isPaired then
-			-- offline but paired: show a small dimmed "offline" tag
+			-- Offline status remains visible even when other elements are hidden.
 			table.insert(kids, ui.label({ text = t("status.offline"),
 				fontSize = 10, color = "on_surface/0.5" }))
 		end
@@ -128,6 +139,7 @@ noctalia.state.watch("pc.devices", render)
 noctalia.state.watch("pc.order", render)
 noctalia.state.watch("pc.selected", render)
 noctalia.state.watch("pc.backend", render)
+noctalia.state.watch("pc.aliasMap", render)
 noctalia.state.watch("pc.trTable", render)
 
 render()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `icefish/phone-connect`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Now available in user configuration:
- enable/disable phone name in bar widget
- choose whether bar widget show battery icon, percent, both, or neither.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

None

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** recent main (nixos)
- **Plugin API level:** 16

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
<img width="59" height="34" alt="image" src="https://github.com/user-attachments/assets/877de5f2-dbb6-44b6-9a07-8992d8179b6f" />
<img width="168" height="34" alt="image" src="https://github.com/user-attachments/assets/b7243291-b388-4fa7-8df6-343bdd4b7b4a" />
<img width="34" height="33" alt="image" src="https://github.com/user-attachments/assets/4cfd3758-76c7-4009-85f5-018a480bbe71" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
