### PR TITLE
Update Battery widget plugin

### DIFF
--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/battery-widget"
 name = "Battery Widget"
-version = "2.0.0"
+version = "2.0.1"
 plugin_api = 3
 author = "yocraft"
 license = "MIT"

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -3,7 +3,7 @@ local color
 local data = { percent = 0, status = "unknown" }
 
 local label_content = noctalia.getConfig("label_content")
-local warning_threshold = 20
+local warning_threshold = 10
 
 local path = "/sys/class/power_supply/"
 local batName
@@ -108,7 +108,6 @@ local function getWarningThreshold()
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to get warning_threshold: " .. result.stderr)
-                notifyError()
                 return
             end
 
@@ -116,7 +115,6 @@ local function getWarningThreshold()
 
             if not res then
                 noctalia.log("battery-widget: invalid warning_threshold, keeping default")
-                notifyError()
                 return
             end
 
@@ -125,7 +123,6 @@ local function getWarningThreshold()
                 warning_threshold = parsed
             else
                 noctalia.log("battery-widget: invalid warning_threshold, keeping default")
-                notifyError()
             end
         end
     )
@@ -227,11 +224,13 @@ local function initData()
         function(result)
             if result.exitCode ~= 0 then
                 noctalia.log("battery-widget: failed to read battery: " .. result.stderr)
+                notifyError()
                 return
             end
 
             if not result.stdout then
                 noctalia.log("battery-widget: invalid battery output")
+                notifyError()
                 return
             end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/battery-widget`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Desktop/lockscreen widget that displays the current battery level and charging status.
<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
upower, gdbus on PATH

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 3

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
