### PR TITLE
feat(hotspot): add Control Center shortcut to toggle hotspot

### DIFF
--- a/hotspot/README.md
+++ b/hotspot/README.md
@@ -8,7 +8,7 @@ devices in a panel, and control the service over IPC.
 | Field | Value |
 | --- | --- |
 | ID | `cleboost/hotspot` |
-| Entries | Bar widget: `toggle`; panel: `panel`; service: `hotspot` |
+| Entries | Bar widget: `toggle`; shortcut: `cc-toggle`; panel: `panel`; service: `hotspot` |
 
 ## Requirements
 
@@ -19,9 +19,9 @@ Install `nmcli` from NetworkManager, plus `iw` and `ip` from iproute2, on
 ## Usage
 
 1. Open the plugin settings and set the hotspot name and password.
-2. Add the `toggle` widget to a bar.
-3. Left-click the widget to open the panel with the connected device list.
-4. Right-click the widget to start or stop the hotspot.
+2. Add the `toggle` widget to a bar and/or the `cc-toggle` shortcut in Settings → Control Center.
+3. Left-click the bar widget to open the panel with the connected device list.
+4. Right-click the bar widget, or click the Control Center shortcut, to start or stop the hotspot.
 
 ```sh
 noctalia msg panel-toggle cleboost/hotspot:panel

--- a/hotspot/plugin.toml
+++ b/hotspot/plugin.toml
@@ -1,12 +1,12 @@
 id = "cleboost/hotspot"
 name = "Wi-Fi Hotspot"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 9
 author = "Cleboost"
 license = "MIT"
 icon = "router"
-description = "Start and stop a Wi-Fi hotspot from the bar, with connected device list and IPC control."
-tags = ["network", "bar", "panel", "service", "utility", "system", "indicator"]
+description = "Start and stop a Wi-Fi hotspot from the bar or Control Center, with connected device list and IPC control."
+tags = ["network", "bar", "panel", "service", "shortcut", "utility", "system", "indicator"]
 dependencies = ["nmcli", "iw", "ip"]
 
 [[setting]]
@@ -52,6 +52,10 @@ entry = "widget.luau"
   type = "glyph"
   label_key = "settings.glyph.label"
   default = "router"
+
+[[shortcut]]
+id = "cc-toggle"
+entry = "shortcut.luau"
 
 [[panel]]
 id = "panel"

--- a/hotspot/shortcut.luau
+++ b/hotspot/shortcut.luau
@@ -1,0 +1,35 @@
+--!nonstrict
+
+local COMMAND_KEY = "hotspot_command"
+
+local status = noctalia.state.get("hotspot_status") or {
+  active = false,
+  busy = false,
+  available = true,
+}
+
+local function sendCommand(action)
+  noctalia.state.set(COMMAND_KEY, { action = action })
+end
+
+local function render()
+  local active = status.active == true
+  shortcut.setLabel(if active then noctalia.tr("shortcut.active") else noctalia.tr("shortcut.inactive"))
+  shortcut.setIcon("router", "wifi-off")
+  shortcut.setActive(active)
+  shortcut.setEnabled(status.available ~= false and status.busy ~= true)
+end
+
+noctalia.state.watch("hotspot_status", function(value)
+  if type(value) == "table" then
+    status = value
+    render()
+  end
+end)
+
+render()
+
+function onClick()
+  if status.available == false or status.busy == true then return end
+  sendCommand("toggle")
+end

--- a/hotspot/translations/en.json
+++ b/hotspot/translations/en.json
@@ -44,6 +44,10 @@
       "stopping_title": "Stopping"
     }
   },
+  "shortcut": {
+    "active": "Hotspot on",
+    "inactive": "Hotspot off"
+  },
   "settings": {
     "glyph": {
       "label": "Bar glyph"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `cleboost/cleboost/hotspot`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Closes #349 by exposing a cc-toggle shortcut entry that mirrors service state and sends the existing hotspot_command toggle action.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0_beta8-1-dirty (CashyOS)
- **Plugin API level:** 9

## Screenshots / Videos

<img width="588" height="518" alt="image" src="https://github.com/user-attachments/assets/4698cf7e-5977-4f01-bc62-937966fb9434" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
