### PR TITLE
docs(obs-integration): update README

### DIFF
--- a/obs-integration/README.md
+++ b/obs-integration/README.md
@@ -21,12 +21,8 @@ credentials in `~/.config/osc/oscrc` (for example with `osc apiservice` setup
 or by copying a working `oscrc`). The plugin shells out to `osc` for every
 operation, so all authentication stays in your normal OBS configuration.
 
-## IPC
-```sh
-noctalia msg panel-toggle neyfua/obs-integration:panel
-```
+## Usage
 
-## Features
 ### My Projects
 
 The panel opens on **My Projects**: every project you maintain, plus every
@@ -79,6 +75,12 @@ The panel reopens where you left off — inside the same project or package.
 | --- | --- | --- | --- |
 | `checkout_dir` | `string` | `~/OBS` | Base directory where packages are checked out. Packages land in `<checkout_dir>/<project>/<package>`. |
 | `show_label` | `bool` | `false` | Show the "OBS" label next to the bar icon. |
+
+## IPC
+
+```sh
+noctalia msg panel-toggle neyfua/obs-integration:panel
+```
 
 ## Notes
 

--- a/obs-integration/README.md
+++ b/obs-integration/README.md
@@ -1,8 +1,10 @@
 # OBS Integration
 
-Manage openSUSE Build Service projects and packages from Noctalia. The bar
-widget toggles a panel for browsing your projects, checking out packages,
-editing metadata and files, and triggering rebuilds on OBS — without leaving
+![thumbnail](thumbnail.webp)
+
+Manage openSUSE Build Service projects and packages directly inside Noctalia. 
+The bar widget toggles a panel for browsing your projects, checking out packages,
+editing metadata and files, and triggering rebuilds on OBS without leaving
 the shell.
 
 ## Plugin
@@ -14,21 +16,17 @@ the shell.
 
 ## Requirements
 
-Install the openSUSE Build Service `osc` CLI on `PATH` and configure your
+Install the openSUSE Build Service `osc` CLI and configure your
 credentials in `~/.config/osc/oscrc` (for example with `osc apiservice` setup
 or by copying a working `oscrc`). The plugin shells out to `osc` for every
 operation, so all authentication stays in your normal OBS configuration.
 
-## Usage
-
-Add the `obs-integrate` widget to a bar. Left-click it to open the panel.
-
-Open the panel directly with:
-
+## IPC
 ```sh
 noctalia msg panel-toggle neyfua/obs-integration:panel
 ```
 
+## Features
 ### My Projects
 
 The panel opens on **My Projects**: every project you maintain, plus every


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `<author>/<plugin>`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Just updating the docs

## External dependencies

None

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.8
- **Plugin API level:** 9 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [ ] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [ ] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [ ] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [ ] I did not edit `catalog.toml`; CI generates it.
- [ ] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [ ] The code is readable and not obfuscated, minified, or generated.
- [ ] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
