### PR TITLE
ruh-vpn 0.1.1: fix IPv6 dial on IPv4-only networks, detect busy route table

### DIFF
--- a/catalog.toml
+++ b/catalog.toml
@@ -1326,8 +1326,8 @@ tags = ["network", "indicator", "bar", "panel", "service"]
 [[plugin]]
 id = "umedbazarov/ruh-vpn"
 name = "Ruh VPN"
-version = "0.1.0"
-updated_at = 1786323782
+version = "0.1.1"
+updated_at = 1786708218
 added_at = 1786323782
 author = "Умеджон Базаров"
 license = "MIT"

--- a/ruh-vpn/backend/service/vpn_service.py
+++ b/ruh-vpn/backend/service/vpn_service.py
@@ -53,6 +53,11 @@ from backend.storage.persistence import (
 )
 
 
+# sing-box auto_route default table (iproute2_table_index); every sing-box
+# based client (v2rayN, GUI.for.SingBox, …) shares it unless reconfigured.
+SINGBOX_ROUTE_TABLE = 2022
+
+
 def _now_log(level: str, message: str) -> None:
     print(f"[{level}] {message}", flush=True)
 
@@ -875,6 +880,23 @@ class VpnService:
                 self.state.emit_status()
                 return False
 
+        # Our own leftovers are gone by now (stop_all + pkill ran at the top of
+        # _start_locked, and TUN routes die with the process), so anything left
+        # in the auto_route table belongs to another sing-box based client
+        # (v2rayN etc.).  sing-box would only fail later with a cryptic
+        # "add route 0: file exists" (issue #327).
+        if await self._tun_route_table_busy():
+            self._log(
+                "error",
+                f"route table {SINGBOX_ROUTE_TABLE} is not empty; "
+                "another sing-box based VPN client appears to be connected",
+            )
+            self.state.status.message = (
+                "Another VPN's TUN is active — disconnect it first"
+            )
+            self.state.emit_status()
+            return False
+
         route_exclusions = await self._resolve_transport_endpoints(server)
         if not route_exclusions:
             host, _ = self._server_endpoint(server)
@@ -903,6 +925,19 @@ class VpnService:
             self.state.emit_status()
             return False
         return True
+
+    async def _tun_route_table_busy(self) -> bool:
+        """True when the sing-box auto_route table already holds routes."""
+        if shutil.which("ip") is None:
+            return False
+        for family in ("-4", "-6"):
+            rc, out = await self._run_capture(
+                ["ip", family, "route", "show", "table", str(SINGBOX_ROUTE_TABLE)]
+            )
+            # rc != 0 means the table does not exist — that is the clean case
+            if rc == 0 and out.strip():
+                return True
+        return False
 
     async def _resolve_host_ips(self, host: str, port: Optional[int]) -> list[str]:
         """Resolve a host to canonical literal IPs; a literal IP passes through."""

--- a/ruh-vpn/backend/singbox/config_builder.py
+++ b/ruh-vpn/backend/singbox/config_builder.py
@@ -116,6 +116,12 @@ def build_transport_config(server: Server, listen_port: int = 11080) -> dict[str
     Listens on 127.0.0.1:listen_port (SOCKS5) and forwards through the
     server-specific outbound.
 
+    The server address is usually a domain, and this is the only config that
+    resolves it locally.  Without an explicit resolver sing-box may pick an
+    AAAA record and dial IPv6, which dies with "network is unreachable" on
+    IPv4-only networks (issue #327).  prefer_ipv4 (not ipv4_only) keeps
+    IPv6-only endpoints working.
+
     For SSH, this returns None — SSH is handled outside sing-box.
     """
     if isinstance(server, SSHServer):
@@ -125,6 +131,11 @@ def build_transport_config(server: Server, listen_port: int = 11080) -> dict[str
     outbound = build_outbound(server, tag="proxy")
     return {
         "log": DEFAULT_LOG,
+        "dns": {
+            "servers": [{"type": "local", "tag": "local"}],
+            "final": "local",
+            "strategy": "prefer_ipv4",
+        },
         "inbounds": [
             {
                 "type": "socks",
@@ -138,7 +149,11 @@ def build_transport_config(server: Server, listen_port: int = 11080) -> dict[str
             outbound,
             {"type": "direct", "tag": "direct"},
         ],
-        "route": {"final": "proxy", "auto_detect_interface": True},
+        "route": {
+            "final": "proxy",
+            "auto_detect_interface": True,
+            "default_domain_resolver": "local",
+        },
     }
 
 

--- a/ruh-vpn/plugin.toml
+++ b/ruh-vpn/plugin.toml
@@ -1,6 +1,6 @@
 id           = "umedbazarov/ruh-vpn"
 name         = "Ruh VPN"
-version      = "0.1.0"
+version      = "0.1.1"
 plugin_api   = 3
 author       = "Умеджон Базаров"
 license      = "MIT"

--- a/ruh-vpn/tests/test_config_builder.py
+++ b/ruh-vpn/tests/test_config_builder.py
@@ -4,10 +4,23 @@ import subprocess
 
 import pytest
 
+from backend.models.server import VlessServer
 from backend.routing.rules import PRESETS
 from backend.singbox import config_builder
 
 ALL = list(PRESETS.keys())
+
+VLESS = VlessServer(
+    name="test",
+    address="example.com",
+    port=443,
+    uuid="8a41ee79-4b8f-4c8a-b64c-6cb43df77e30",
+    security="reality",
+    sni="example.com",
+    fp="chrome",
+    pbk="AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",  # any 32-byte key
+    sid="ab",
+)
 
 
 def test_rules_config_includes_presets():
@@ -28,12 +41,26 @@ def test_rules_config_dns_covers_domain_rule_sets():
     assert "geosite_sanctioned" in flattened
 
 
+def test_transport_config_resolves_prefer_ipv4():
+    # The transport is the only config resolving the (usually domain) server
+    # address locally; without prefer_ipv4 sing-box may dial an AAAA record
+    # on an IPv4-only network (issue #327).
+    cfg = config_builder.build_transport_config(VLESS)
+    assert cfg["dns"]["strategy"] == "prefer_ipv4"
+    assert cfg["route"]["default_domain_resolver"] == "local"
+
+
 @pytest.mark.skipif(shutil.which("sing-box") is None, reason="sing-box not installed")
 @pytest.mark.parametrize("presets", [[], ALL])
 def test_sing_box_accepts_generated_configs(tmp_path, presets):
     for name, cfg in {
+        "transport": config_builder.build_transport_config(VLESS),
         "rules": config_builder.build_rules_config(active_presets=presets),
         "global": config_builder.build_global_config(),
+        "tun": config_builder.build_tun_config(
+            upstream_socks_port=11081,
+            route_exclude_addresses=["203.0.113.1/32"],
+        ),
     }.items():
         path = tmp_path / f"{name}.json"
         path.write_text(json.dumps(cfg))


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `umedbazarov/ruh-vpn`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Bugfix release 0.1.1, fixes #327 (TUN and System modes failing to route traffic).

Root cause: the transport config (the only sing-box instance that resolves the
server domain locally) had no DNS strategy, so sing-box could pick an AAAA
record and dial IPv6. On an IPv4-only network that dies with
`network is unreachable` and breaks both TUN and System modes — the socks
`request rejected` and TUN DNS failures in the reported logs are all cascade
from this.

Changes:

- The transport config now resolves the server address via the system resolver
  with `strategy: prefer_ipv4` (not `ipv4_only`, so IPv6-only endpoints keep
  working) and sets `route.default_domain_resolver`.
- The second error in the report, `add route 0: file exists`, means route
  table 2022 (the auto_route default shared by every sing-box based client,
  v2rayN included) was already taken by another running client. Before
  starting TUN the plugin now checks that the table is free and reports
  "Another VPN's TUN is active — disconnect it first" instead of failing with
  the cryptic sing-box error. The check is a read-only `ip route show`, no
  new privileges involved.

## External dependencies

Unchanged from 0.1.0 (`sing-box`, `python3`, `ssh`/`sshpass`, `gsettings`,
`pkexec`+`setcap`/`getcap`, `nft`, `pkill`). The route-table check uses `ip`
(iproute2), read-only and unprivileged.

## Testing

Backend unit tests: `python -m pytest tests/` — 33 passing. The
`sing-box check` test now also validates the generated transport and TUN
configs (previously only rules/global were covered, which is how this slipped
through); verified against sing-box 1.13.x.

Manual verification of the fix on a live connection is in progress; will tick
the compositor box below once done.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.7
- **Plugin API level:** 3

## Screenshots / Videos

No visual changes in this release (backend-only fix).

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
