### PR TITLE
fix(tailscale): filter Mullvad exits out of status --json

### DIFF
--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -61,7 +61,7 @@ noctalia msg plugin davemhammer/tailscale:service all toggle
 
 ## Notes
 
-- Shells out to `tailscale status --json`, `tailscale debug prefs | jq …` (safe field projection), `tailscale exit-node list`, `tailscale set …`, `tailscale up` / `down`, optional `tailscale ping` / `tailscale ssh` in a terminal, and `xdg-open` for the admin URL.
+- Shells out to `tailscale status --json | jq …` (same Mullvad-exit filter as text `status`; those nodes stay on the Exit tab via `exit-node list`), `tailscale debug prefs | jq …` (safe field projection), `tailscale exit-node list`, `tailscale set …`, `tailscale up` / `down`, optional `tailscale ping` / `tailscale ssh` in a terminal, and `xdg-open` for the admin URL. A raw `--json` dump on a Mullvad-enabled tailnet is large enough to trip Noctalia's plugin CPU budget and auto-disable the service.
 - Advertise-exit state is read from prefs `AdvertiseRoutes` (`0.0.0.0/0` / `::/0`), not only `ExitNodeOption`.
 - Network: only through the Tailscale CLI/daemon (no separate HTTP client in the plugin).
 - Filesystem: no plugin-written credentials; uses local Tailscale state via the CLI.

--- a/tailscale/plugin.toml
+++ b/tailscale/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/tailscale"
 name = "Tailscale"
-version = "1.0.5"
+version = "1.0.6"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"

--- a/tailscale/service.luau
+++ b/tailscale/service.luau
@@ -94,6 +94,20 @@ local function runTs(args, callback, timeoutMs)
   return noctalia.runAsync(shellCommand(args), callback, timeoutMs or 25000)
 end
 
+-- Same rule as `tailscale status` (text): unused Mullvad exits belong on
+-- `exit-node list`, not in Peer. `--json` does not apply this, and the raw
+-- dump is large enough to trip Noctalia's 25ms plugin CPU budget.
+local function statusJsonCommand(bin)
+  local jq = [[
+    .Peer |= with_entries(select(
+      (.value.ExitNodeOption != true)
+      or (.value.ExitNode == true)
+      or ((.value.DNSName // "") | endswith("mullvad.ts.net.") | not)
+    ))
+  ]]
+  return shellCommand({ bin, "status", "--json" }) .. " | jq -c " .. shellQuote(jq)
+end
+
 local function updateRevision(signature)
   if signature ~= dataSignature then
     dataSignature = signature
@@ -584,8 +598,8 @@ refreshAll = function()
     end
   end
 
-  -- status --json (slim: only decode once; peer count is usually small)
-  runTs({ bin, "status", "--json" }, function(result)
+  -- status --json (jq slims before Luau decode; see statusJsonCommand)
+  noctalia.runAsync(statusJsonCommand(bin), function(result)
     if generation ~= refreshGeneration then
       return
     end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/tailscale`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

`tailscale status --json` includes the whole Mullvad/location-based exit catalog as `Peer` entries. On a Mullvad-enabled tailnet that is hundreds of KB and 500+ peers. Noctalia's plugin VM gives each callback 25ms of CPU; decoding that dump exceeds the budget, the service is auto-disabled, and the panel opens empty.

Text `tailscale status` already skips unused Mullvad exits (`ExitNodeOption && !ExitNode && DNSName` ends with `mullvad.ts.net.`) and tells you to use `exit-node list`. `--json` does not apply that filter, and there is no `--json` flag for it.

This pipes `status --json` through `jq` (already a declared dependency, same as prefs) with that same rule before Luau decodes it. Exit nodes stay on the Exit tab via `tailscale exit-node list`. Version `1.0.5` → `1.0.6`.

## External dependencies

Unchanged: `tailscale`, `jq`, `xdg-open`. `jq` now also filters `status --json`, not only `debug prefs`.

## Testing

Reproduced the auto-disable on Niri / NixOS with Mullvad exits in the netmap. After this filter, `noctalia msg plugin davemhammer/tailscale:service all refresh` succeeds and the panel shows real machines plus the exit-node list.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 10

## Screenshots / Videos

None — no UI change. Backend filter only; bar/panel already existed.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html). (unchanged; not a new plugin)
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations). (no locale files touched)
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.