### PR TITLE
Update dumbasaroc/bazaarsearch to 1.0.1

### DIFF
--- a/bazaarsearch/launcher.luau
+++ b/bazaarsearch/launcher.luau
@@ -87,7 +87,7 @@ local function bzrCreateErrorReport(data: BzrErrReport): LauncherResult
     id = "bzrerror:" .. full_err_msg,
     title = err_title,
     subtitle = bzrTR("error.report.user_instruction"),
-    glpyh = "toast-error"
+    glyph = "toast-error"
   }
 end
 

--- a/bazaarsearch/launcher.luau
+++ b/bazaarsearch/launcher.luau
@@ -141,7 +141,7 @@ local function bzrGetMetadata(query: string, bzr_search_data: BzrInitialSearchRe
           cmd_string = cmd_string,
           stage = "getMetadata",
           query = query,
-          err_title = bzrTR("err.msg.malformed_value_retval"),
+          err_title = bzrTR("error.msg.malformed_value_retval"),
           err_body = bzrTR("error.msg.busctl_incorrect_ident", { expected = "aa{sv}", recieved = busdata["type"] }),
         })})
       end

--- a/bazaarsearch/plugin.toml
+++ b/bazaarsearch/plugin.toml
@@ -3,7 +3,7 @@
 
 id = "dumbasaroc/bazaarsearch"
 name = "Bazaar Search"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 3
 author = "DumbAsARoc"
 license = "GPL-3.0"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `dumbasaroc/bazaarsearch`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Bazaar Search allows users to search for Flatpaks directly though the Noctalia Launcher. It works very similarly to KDE's Discover search in KRunner and Gnome Software search in GNOME's application search bar. Users search via `/bzr <search terms>` and can select Flatpak entries in the launcher. When clicked, they bring the user to the specified page in the Bazaar application.

## Changed since last version

- Fixed typo that caused a glyph to not display on a certain error path
- Fixed typo that caused a translation message to not display on a certain error path

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

- `busctl` (part of `systemd`)
- [Bazaar Flatpak Store](https://usebazaar.org/) (either installed via package manager or via Flatpak)

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

**All of this was tested on my development machine, currently running
CachyOS Rolling, Noctalia v5, and niri 26.04.**

- Changed `max_entries` to `0` (shows nothing), `5` (shows five or less entries), `10` (shows 10 or less entries), and 50 (shows 50 or less entries).
- Attempted with both Flatpak and binary versions of `bazaar`
  - Provided the Bazaar background service is online, both work.
- Opened plugin launcher provider without having the service online
  - If binary was installed (in my case, via `pacman`), plugin worked fine - it automatically opened the application via invoking the DBus interface.
  - If Flatpak was installed, plugin could not reopen the DBus interface due to Flatpak's sandboxing.
- Clicked on entries - brings the user directly to the Flatpak's store page within Bazaar.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0 (5.0.0_beta.8-1-dirty)
- **Plugin API level:** 3 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->
https://github.com/user-attachments/assets/ff81a1c6-a04a-4b46-8e8e-b3a0ed6266ef

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
