### PR TITLE
Update Battery widget plugin

### DIFF
--- a/battery-widget/README.md
+++ b/battery-widget/README.md
@@ -1,6 +1,6 @@
 # Battery Widget
 
-Desktop/lockscreen widget that displays the current battery level and charging status.
+Desktop/Lockscreen widget that displays battery level, status, charging rate, and time remaining.
 
 ## Plugin
 

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -1,7 +1,7 @@
 id = "yocraft/battery-widget"
 name = "Battery Widget"
-version = "2.0.1"
-plugin_api = 3
+version = "2.1.0"
+plugin_api = 26
 author = "yocraft"
 license = "MIT"
 deprecated = false

--- a/battery-widget/plugin.toml
+++ b/battery-widget/plugin.toml
@@ -6,7 +6,7 @@ author = "yocraft"
 license = "MIT"
 deprecated = false
 icon = "battery"
-description = "Desktop/Lockscreen widget to show battery."
+description = "Desktop/Lockscreen widget that displays battery level, status, charging rate, and time remaining."
 tags = [ "desktop", "hardware", "system", "utility" ]
 dependencies = [ "upower", "gdbus" ]
 

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -225,10 +225,10 @@ end
 
 local function watchBattery()
     local patterns = { "Percentage", "State" }
-    if label_content == "time" then
+    if config.label_content == "time" then
         table.insert(patterns, "TimeToEmpty")
         table.insert(patterns, "TimeToFull")
-    elseif label_content == "rate" then
+    elseif config.label_content == "rate" then
         table.insert(patterns, "EnergyRate")
     end
 

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -4,15 +4,15 @@ local data = { percent = 0, status = "unknown" }
 
 local config = {
     warning_threshold = noctalia.getSetting("battery.warning_threshold") or 10,
-    layout = noctalia.getConfig("layout"),
-    show_glyph = noctalia.getConfig("show_glyph"),
-    show_label = noctalia.getConfig("show_label"),
-    label_content = noctalia.getConfig("label_content"),
-    hide_plugged = noctalia.getConfig("hide_plugged"),
-    hide_full = noctalia.getConfig("hide_full"),
-    color = noctalia.getConfig("color"),
-    warning_color = noctalia.getConfig("warning_color"),
-    charging_color = noctalia.getConfig("charging_color"),
+    layout = noctalia.getConfig("layout") or "horizontal",
+    show_glyph = noctalia.getConfig("show_glyph") or true,
+    show_label = noctalia.getConfig("show_label") or true,
+    label_content = noctalia.getConfig("label_content") or "percent",
+    hide_plugged = noctalia.getConfig("hide_plugged") or false,
+    hide_full = noctalia.getConfig("hide_full") or false,
+    color = noctalia.getConfig("color") or "on_surface",
+    warning_color = noctalia.getConfig("warning_color") or "error",
+    charging_color = noctalia.getConfig("charging_color") or "on_surface",
 }
 
 local path = "/sys/class/power_supply/"
@@ -76,12 +76,12 @@ local function parse(output)
 end
 
 local function getBatName()
-    local config = noctalia.getConfig("battery")
+    local config = noctalia.getConfig("battery") or "auto"
 
     if config == "bat0" then
         return "BAT0"
     elseif config == "custom" then
-        return noctalia.getConfig("battery_name")
+        return noctalia.getConfig("battery_name") or "BAT0"
     end
 
     local folders = noctalia.listDir(path)

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -3,7 +3,7 @@ local color
 local data = { percent = 0, status = "unknown" }
 
 local label_content = noctalia.getConfig("label_content")
-local warning_threshold = 10
+local warning_threshold = noctalia.getSetting("battery.warning_threshold") or 10
 
 local path = "/sys/class/power_supply/"
 local batName
@@ -100,32 +100,6 @@ local function getGlyph()
         or data.percent >= 10 and "battery-1"
         or "battery-0"
     end
-end
-
-local function getWarningThreshold()
-    noctalia.runAsync(
-        "grep warning_threshold ~/.local/state/noctalia/settings.toml | awk '{print $3}'",
-        function(result)
-            if result.exitCode ~= 0 then
-                noctalia.log("battery-widget: failed to get warning_threshold: " .. result.stderr)
-                return
-            end
-
-            local res = result.stdout
-
-            if not res then
-                noctalia.log("battery-widget: invalid warning_threshold, keeping default")
-                return
-            end
-
-            local parsed = tonumber(noctalia.string.trim(res))
-            if parsed then
-                warning_threshold = parsed
-            else
-                noctalia.log("battery-widget: invalid warning_threshold, keeping default")
-            end
-        end
-    )
 end
 
 local function getColor()
@@ -270,8 +244,6 @@ if not batName then
     notifyError()
     return
 end
-
-getWarningThreshold()
 
 initData()
 watchBattery()

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -2,8 +2,18 @@ local glyph
 local color
 local data = { percent = 0, status = "unknown" }
 
-local label_content = noctalia.getConfig("label_content")
-local warning_threshold = noctalia.getSetting("battery.warning_threshold") or 10
+local config = {
+    warning_threshold = noctalia.getSetting("battery.warning_threshold") or 10,
+    layout = noctalia.getConfig("layout"),
+    show_glyph = noctalia.getConfig("show_glyph"),
+    show_label = noctalia.getConfig("show_label"),
+    label_content = noctalia.getConfig("label_content"),
+    hide_plugged = noctalia.getConfig("hide_plugged"),
+    hide_full = noctalia.getConfig("hide_full"),
+    color = noctalia.getConfig("color"),
+    warning_color = noctalia.getConfig("warning_color"),
+    charging_color = noctalia.getConfig("charging_color"),
+}
 
 local path = "/sys/class/power_supply/"
 local batName
@@ -45,7 +55,7 @@ local function parse(output)
         data.status = stateMap[tonumber(state)] or "unknown"
     end
 
-    if label_content == "time" then
+    if config.label_content == "time" then
         local timeToEmpty = output:match("'TimeToEmpty':%s*<int64%s+(%-?%d+)>")
         if timeToEmpty then
             data.timeToEmpty = tonumber(timeToEmpty)
@@ -55,7 +65,7 @@ local function parse(output)
         if timeToFull then
             data.timeToFull = tonumber(timeToFull)
         end
-    elseif label_content == "rate" then
+    elseif config.label_content == "rate" then
         local rate = output:match("'EnergyRate':%s*<([%-%d%.]+)>")
         if rate then
             data.rate = tonumber(rate)
@@ -104,14 +114,14 @@ end
 
 local function getColor()
     if data.status == "charging" or data.status == "fully-charged" or data.status == "pending-charge" then
-        color = noctalia.getConfig("charging_color")
+        color = config.charging_color
         return
     end
-    if data.percent <= warning_threshold then
-        color = noctalia.getConfig("warning_color")
+    if data.percent <= config.warning_threshold then
+        color = config.warning_color
         return
     end
-    color = noctalia.getConfig("color")
+    color = config.color
 end
 
 local function formatTime(seconds)
@@ -144,11 +154,11 @@ local function formatPercent()
 end
 
 local function getLabelText()
-    if label_content == "time" then
+    if config.label_content == "time" then
         local connected = data.status == "charging" or data.status == "fully-charged" or data.status == "pending-charge"
         local seconds = connected and data.timeToFull or data.timeToEmpty
         return formatTime(seconds) or formatPercent()
-    elseif label_content == "rate" then
+    elseif config.label_content == "rate" then
         return formatRate(data.rate) or formatPercent()
     end
 
@@ -156,21 +166,21 @@ local function getLabelText()
 end
 
 local function render()
-    if (noctalia.getConfig("hide_plugged") and (data.status == "charging" or data.status == "pending-charge"))
-        or (noctalia.getConfig("hide_full") and data.status == "fully-charged") then
+    if (config.hide_plugged and (data.status == "charging" or data.status == "pending-charge"))
+        or (config.hide_full and data.status == "fully-charged") then
         desktopWidget.render(ui.row())
         return
     end
 
     local content = {}
-    if noctalia.getConfig("show_glyph") then
+    if config.show_glyph then
         table.insert(content, ui.glyph({ name = glyph, color = color }))
     end
-    if noctalia.getConfig("show_label") then
+    if config.show_label then
         table.insert(content, ui.label({ text = getLabelText(), color = color }))
     end
 
-    local vertical = noctalia.getConfig("layout") == "vertical"
+    local vertical = config.layout == "vertical"
 
     local layout = vertical and ui.column or ui.row
 

--- a/battery-widget/widget.luau
+++ b/battery-widget/widget.luau
@@ -2,17 +2,26 @@ local glyph
 local color
 local data = { percent = 0, status = "unknown" }
 
+local function getConf(key, default)
+    local value = noctalia.getConfig(key)
+    if value == nil then
+        return default
+    else
+        return value
+    end
+end
+
 local config = {
     warning_threshold = noctalia.getSetting("battery.warning_threshold") or 10,
-    layout = noctalia.getConfig("layout") or "horizontal",
-    show_glyph = noctalia.getConfig("show_glyph") or true,
-    show_label = noctalia.getConfig("show_label") or true,
-    label_content = noctalia.getConfig("label_content") or "percent",
-    hide_plugged = noctalia.getConfig("hide_plugged") or false,
-    hide_full = noctalia.getConfig("hide_full") or false,
-    color = noctalia.getConfig("color") or "on_surface",
-    warning_color = noctalia.getConfig("warning_color") or "error",
-    charging_color = noctalia.getConfig("charging_color") or "on_surface",
+    layout = getConf("layout", "horizontal"),
+    show_glyph = getConf("show_glyph", true),
+    show_label = getConf("show_label", true),
+    label_content = getConf("label_content", "percent"),
+    hide_plugged = getConf("hide_plugged", false),
+    hide_full = getConf("hide_full", false),
+    color = getConf("color", "on_surface"),
+    warning_color = getConf("warning_color", "error"),
+    charging_color = getConf("charging_color", "on_surface"),
 }
 
 local path = "/sys/class/power_supply/"
@@ -43,8 +52,6 @@ if not noctalia.commandExists("gdbus") then
 end
 
 local function parse(output)
-    data = data or {}
-
     local percent = output:match("'Percentage':%s*<([%d%.]+)>")
     if percent then
         data.percent = tonumber(percent) or 0


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses the marker line, a "##" heading,
     a "- **Field:**" line, or a "- [ ]" checklist entry. Fill those in, do not delete them.
     Everything else, including every one of these guidance comments, is yours to delete.

     Not ready for review yet? Mark the pull request as Draft; checklist boxes may stay
     unchecked while it is a draft. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/battery-widget`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Desktop/Lockscreen widget that displays battery level, status, charging rate, and time remaining.

This PR is mainly refactor, and using new api 26.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
gdbus on PATH, upower

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 26

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
