### PR TITLE
arch-updater: fix the news-timer watchdog kill; terminal/background update modes, ignore management, one polkit password, update history with rollback

### DIFF
--- a/arch-updater/README.md
+++ b/arch-updater/README.md
@@ -1,8 +1,11 @@
 # Arch Updater
 
 Check pacman, AUR and Flatpak for updates from the bar, with an estimated
-download size and an Arch news heads-up before you upgrade. Runs the update
-in a terminal window.
+download size and an Arch news heads-up before you upgrade. One click runs
+the whole upgrade in the background: polkit asks for your password, the
+panel shows a live log tail and a progress bar, and a notification reports
+the result. A terminal fallback stays available for runs that need real
+prompts.
 
 ## Plugin
 
@@ -15,22 +18,22 @@ in a terminal window.
 ## Requirements
 
 - `pacman-contrib` on `PATH` (for `checkupdates`), required.
-- `pacman`, `sh`, `sudo`, `awk`, `sed`, `test` and `uname`, required — base
-  tools from any standard Arch install, used to run and parse the pacman
-  check, build the download size estimate, check the running kernel, and
-  run the plain-pacman upgrade.
+- `pacman`, `sh`, `awk`, `sed`, `tail`, `test` and `uname`, required — base
+  tools from any standard Arch install, used to run and parse the checks,
+  build the download size estimate, check the running kernel, and follow the
+  update log.
+- `pkexec` (polkit) with an authentication agent, required for the
+  background update. Noctalia's built-in polkit agent works out of the box.
 - `yay` or `paru` on `PATH`, optional, for the AUR check and update.
   Auto-detected by default, see the **AUR helper** setting.
 - `flatpak`, optional, for the Flatpak check and update.
-- `xdg-open`, optional, to open a package page or the Arch news page.
-- A terminal emulator for the update run: Noctalia's own detection
-  (`$TERMINAL`, then `ghostty`, `kitty`, `alacritty`, `wezterm`, `foot`,
-  `konsole`, `gnome-terminal`, `ptyxis`, `xterm`), or the one named in the
-  **Terminal** setting.
+- `xdg-open`, optional, to open a package page, the update log, or the Arch
+  news page.
+- `sudo` and a terminal emulator, optional, only for the **Retry in
+  terminal** fallback: Noctalia's own detection (`$TERMINAL`, then the
+  common emulators), or the one named in the **Terminal** setting.
 
-Everything except `pacman-contrib`, `pacman`, `sh`, `sudo`, `awk`, `sed`,
-`test` and `uname` is optional. A missing optional tool is skipped, not
-treated as an error.
+A missing optional tool is skipped, not treated as an error.
 
 ## Usage
 
@@ -44,44 +47,63 @@ noctalia msg panel-toggle yuuto/arch-updater:panel
 ```
 
 The panel groups pending packages by source (Pacman, AUR, Flatpak). Click a
-source row to expand it into its packages. Each package row has a copy
-button (name and versions) and an open button (its page on archlinux.org,
-the AUR, or Flathub). **Check Updates** queries all sources, **Update** opens
-a terminal running the upgrade, **Dismiss** clears the pending list and
-closes the panel, returning the bar glyph to its resting colour.
+source row to expand it into its packages. Each package row has an ignore
+button (see **Ignored packages**), a copy button (name and versions) and an
+open button (its page on archlinux.org, the AUR, or Flathub).
 
-Type `/arch` in the launcher for quick actions (check, update, open news), or
-`/arch <text>` to fuzzy-search the packages from the last check. Activating a
-result opens that package's page.
+**Update** starts the background run: pkexec raises the polkit password
+dialog, everything else is non-interactive (`--noconfirm`, and for the AUR
+helper `--skipreview` / the `--answer*` flags), so any remaining question
+gets its default answer. While the run is going the package list gives way
+to a live tail of the update log with a progress bar, and the bar widget
+shows a percentage instead of the count. The run is spawned detached, so it
+survives a shell restart: a restarted engine re-attaches to an unfinished
+log and keeps showing progress. When the run ends you get a notification
+and an automatic re-check; a failed run keeps its log on screen and offers
+**Retry in terminal**, where prompts and the PKGBUILD review work normally.
 
-## Extras
+**Dismiss** clears the pending list until the next check. **Check Updates**
+queries all sources.
 
-Not in the v4 plugin:
+Type `/arch` in the launcher for quick actions (check, update, open news),
+or `/arch <text>` to fuzzy-search the packages from the last check.
+Activating a result opens that package's page.
 
-- **Arch Linux news.** The news feed is checked periodically. An unread post
-  is flagged in the panel and the bar tooltip, with a button that opens the
-  news page and marks it read. Arch news is where manual-intervention steps
-  get announced, so it's worth seeing before a big upgrade.
-- **Reboot recommendation.** Detected from whether the running kernel's
-  `/usr/lib/modules/<version>` directory still exists, so it works for any
-  kernel flavour (`linux`, `linux-lts`, `linux-zen`, `linux-cachyos`, ...)
-  without naming one. Shown in the panel and the bar tooltip, and colours the
-  bar glyph independently of the pending count.
-- **Estimated download size** for the pending pacman packages (`pacman -Si`),
-  shown before you commit to **Update**.
-- **An ignore list that's actually enforced.** v4 only let you rewrite the
-  raw check/update commands. Here, packages in **Ignore packages** are
-  filtered out of both the count and the update run (`--ignore`), on top of
-  `pacman.conf`'s own `IgnorePkg`.
-- **Auto-detected AUR helper**, with `yay`/`paru`/a custom command/off as
-  explicit overrides.
-- **A generic package-page link** (`archlinux.org/packages`,
-  `aur.archlinux.org`, `flathub.org`) instead of hardcoded per-repo mirror
-  URLs, so it stays correct across Arch-based distros.
-- **An activity graph.** A small trend line of the pending-update count
-  across the most recent checks, plus when you last ran an update. Persisted
-  to disk so it survives restarts. On by default, and turning it off also
-  stops recording the history, not just hiding it.
+### Ignored packages
+
+Three ignore sources are merged and shown in an expandable **Ignored**
+section at the bottom of the package list:
+
+- **Panel-managed.** The ignore button on a package row adds it to a list
+  kept in the plugin's data directory. These entries have a restore button
+  in the Ignored section.
+- **The `ignore_packages` setting.** Shown with a *settings* tag; clicking
+  the tag opens the plugin's settings.
+- **`pacman.conf`'s `IgnorePkg`.** Update checkers report these packages
+  with an `[ignored]` marker; they are shown with a *pacman.conf* tag and
+  are managed only in that file. The plugin never edits `pacman.conf`.
+
+Ignored packages are excluded from the pending count and passed as
+`--ignore` to the update run (Flatpak refs are filtered out of `flatpak
+update` the same way).
+
+### One polkit password per run
+
+`pkexec` authenticates every pacman transaction separately, so an update
+that syncs databases and installs AUR builds can raise several password
+dialogs. Until a keep-authorization polkit rule is installed, the panel
+shows a hint line with an **Ask once** button: it installs (through one
+`pkexec` call you confirm) a rule that keeps a successful authentication
+for ~5 minutes — like `sudo`'s timestamp — scoped to `pkexec` launching
+`/usr/bin/pacman` for an active local `wheel` session. The rule text ships
+in `polkit/49-arch-updater-pacman.rules` and can also be installed by hand:
+
+```sh
+sudo install -Dm644 polkit/49-arch-updater-pacman.rules /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
+```
+
+The hint can be hidden with the **Hide the polkit rule suggestion**
+setting.
 
 ## Settings
 
@@ -90,17 +112,16 @@ Not in the v4 plugin:
 | `aur_helper` | `select` | `auto` | Which AUR helper to use: auto-detect (yay, then paru), `yay`, `paru`, a custom command, or off. |
 | `aur_check_cmd` | `string` | *(empty)* | Custom AUR check command, only used when `aur_helper` is `custom`. Must print `name oldver -> newver` per line. |
 | `flatpak_enabled` | `bool` | `true` | Also check and update Flatpak. Skipped automatically when `flatpak` isn't installed. |
-| `ignore_packages` | `string_list` | *(empty)* | Package names excluded from the count and passed as `--ignore` on update. |
+| `ignore_packages` | `string_list` | *(empty)* | Package names excluded from the count and passed as `--ignore` on update, on top of the panel-managed list and `pacman.conf`'s `IgnorePkg`. |
 | `auto_check_hours` | `int` | `0` | Check automatically every N hours. `0` never checks on its own. |
 | `notify_on_updates` | `bool` | `true` | Send a desktop notification when a check finds packages to upgrade. |
 | `show_download_size` | `bool` | `true` | Show the estimated pacman download size (`pacman -Si`) in the panel. |
 | `check_arch_news` | `bool` | `true` | Check the Arch Linux news feed and flag unread posts. |
 | `check_reboot_needed` | `bool` | `true` | Flag when the running kernel is no longer installed on disk. |
-| `show_activity_graph` | `bool` | `true` | Track and show the pending-update trend and last-update time in the panel. Off also stops recording history. |
-| `activity_history_length` | `int` | `10` | How many of the most recent checks to keep for the activity graph. |
-| `terminal` | `string` | *(empty)* | Terminal command for the update run, e.g. `kitty`. Empty uses Noctalia's detection. |
-| `assume_yes` | `bool` | `false` | Pass `--noconfirm` / `-y` so package managers do not ask for confirmation. |
-| `update_cmd` | `string` | *(empty)* | Full override for the update command. Empty builds it from the settings above. |
+| `hide_polkit_hint` | `bool` | `false` | Hide the panel line offering to install the polkit keep-authorization rule. |
+| `log_lines` | `int` | `14` | How many of the latest update-log lines the panel shows during a run (6–30). |
+| `terminal` | `string` | *(empty)* | Terminal command, only for the **Retry in terminal** fallback. Empty uses Noctalia's detection. |
+| `update_cmd` | `string` | *(empty)* | Full override for the background update command. Empty builds it from the settings above, running pacman through `pkexec`. |
 | `glyph` | `glyph` | `package` | The glyph shown for the widget on the bar. |
 | `show_count` | `bool` | `true` | Show the pending-update count next to the bar glyph. |
 | `hide_on_empty` | `bool` | `false` | Hide the widget entirely when there is nothing to show. |
@@ -110,36 +131,54 @@ Not in the v4 plugin:
 ```sh
 noctalia msg plugin yuuto/arch-updater:service all check
 noctalia msg plugin yuuto/arch-updater:service all update
+noctalia msg plugin yuuto/arch-updater:service all update_terminal
 noctalia msg plugin yuuto/arch-updater:service all dismiss
+noctalia msg plugin yuuto/arch-updater:service all ignore:NAME
+noctalia msg plugin yuuto/arch-updater:service all unignore:NAME
 ```
+
+`update` starts the background run, `update_terminal` the terminal
+fallback. `ignore:NAME` / `unignore:NAME` edit the panel-managed ignore
+list.
 
 ## Notes
 
-- **Commands spawned.** `checkupdates`; the configured AUR helper's `-Qua`
-  (or your custom command); `flatpak list` / `flatpak remote-ls --updates`;
-  `pacman -Si` for the download size (piped through `awk` to sum it); a local
-  `test -d` against `uname -r` for the reboot check; and, for the update,
-  your terminal running `sh` to launch `sudo pacman`/the AUR helper,
-  optionally `flatpak update` (filtered through `awk` when packages are
-  ignored, using `sed` to combine the Flatpak listings during the check). No
-  upgrade command runs outside the terminal.
+- **Commands spawned.** Checks: `checkupdates`; the AUR helper's `-Qua` (or
+  your custom command); `flatpak list` / `flatpak remote-ls --updates`
+  (combined with `sed`/`awk`); `pacman -Si` piped through `awk` for the
+  download size; `test -d` against `uname -r` for the reboot check. Update:
+  a detached `sh` running `pkexec pacman -Syu` or the AUR helper with
+  `--sudo pkexec`, then optionally `flatpak update` — all output redirected
+  to the update log, which the engine follows with `tail`. The terminal
+  fallback runs the interactive equivalents (`sudo pacman -Syu`, the helper
+  without auto-answers) under your terminal, `tee`'d into the same log.
+- **Privileges.** Escalation happens only through polkit: `pkexec pacman`
+  for repo packages, and the AUR helper escalates its install steps through
+  `pkexec` itself (`--sudo pkexec`). AUR builds run unprivileged as usual.
+  The optional **Ask once** button installs the shipped polkit rule via one
+  user-confirmed `pkexec install` call; nothing else touches system
+  configuration, and `pacman.conf` is never modified.
 - **Network.** `checkupdates`, the AUR helper and the Flatpak check contact
   mirrors, the AUR RPC, or a Flatpak remote, same as the corresponding
-  upgrade would. The Arch news check fetches `archlinux.org/feeds/news/` on
-  its own schedule, independent of a manual check.
-- **Privileges.** The plugin never elevates anything itself. Plain pacman
-  updates run via `sudo pacman -Syu` in the terminal, where `sudo` prompts
-  normally. An AUR helper handles its own privilege escalation as usual.
-- **Files.** One small file in the plugin's data directory tracks the last
-  Arch news post you've read, so unread counts survive a restart. Nothing
-  else is written; `pacman.conf` is never modified.
-- **Sizes are pacman-only.** AUR and Flatpak downloads aren't sized. Most AUR
-  packages build from source, where a download size wouldn't mean much.
+  upgrade would. The Arch news check fetches `archlinux.org/feeds/news/`
+  once at startup and then every 6 hours.
+- **Files written.** All in the plugin's data directory: `update.log` (the
+  current/last run, with `::START`/`::EXIT` markers), `ignore.json` (the
+  panel-managed ignore list), `news_state.json` (the last read news post),
+  a staged copy of the polkit rule, and a marker recording that the rule
+  was installed (`/etc/polkit-1/rules.d` is not readable by regular users
+  on Arch, so presence can't always be probed directly).
+- **Stuck-run guard.** A background run whose log stops growing for 30
+  minutes is declared failed; the panel then offers the terminal fallback.
+  Unfinished logs older than 6 hours are not resumed after a restart.
+- **Sizes are pacman-only.** AUR and Flatpak downloads aren't sized. Most
+  AUR packages build from source, where a download size wouldn't mean much.
 
 ## Credits
 
 Ported from the v4 QML "Arch Updater" plugin (MIT), rebuilt for v5's Luau
-plugin API with a different feature set. See **Extras** above.
+plugin API. Background update mode, ignore management and the polkit
+integration contributed by [UmedjonBA](https://github.com/UmedjonBA).
 
 ## License
 

--- a/arch-updater/README.md
+++ b/arch-updater/README.md
@@ -1,11 +1,13 @@
 # Arch Updater
 
 Check pacman, AUR and Flatpak for updates from the bar, with an estimated
-download size and an Arch news heads-up before you upgrade. One click runs
-the whole upgrade in the background: polkit asks for your password, the
-panel shows a live log tail and a progress bar, and a notification reports
-the result. A terminal fallback stays available for runs that need real
-prompts.
+download size and an Arch news heads-up before you upgrade. **Update** runs
+the upgrade in one of two modes (the **Update mode** setting): a terminal
+window with the usual interactive upgrade — prompts and the PKGBUILD review
+work as normal (the default, same behavior as before), or fully in the
+background — polkit asks for your password, the panel shows a live log tail
+and a progress bar, and a notification reports the result. Either way the
+run is logged and recorded in an update history with per-package rollback.
 
 ## Plugin
 
@@ -17,20 +19,22 @@ prompts.
 
 ## Requirements
 
-- `pacman-contrib` on `PATH` (for `checkupdates`), required.
-- `pacman`, `sh`, `awk`, `sed`, `tail`, `test` and `uname`, required — base
-  tools from any standard Arch install, used to run and parse the checks,
-  build the download size estimate, check the running kernel, and follow the
-  update log.
+- `pacman-contrib` on `PATH` (for `checkupdates` and `pactree`), required.
+- `pacman`, `sh`, `awk`, `sed`, `grep`, `tail`, `head`, `tee`, `wc`, `date`,
+  `rm`, `install`, `test` and `uname`, required — base tools from any
+  standard Arch install (coreutils and friends), used to run and parse the
+  checks, build the download size estimate, check the running kernel,
+  follow and open the update log, and install the optional polkit rule.
 - `pkexec` (polkit) with an authentication agent, required for the
-  background update. Noctalia's built-in polkit agent works out of the box.
+  background update mode and for rollback. Noctalia's built-in polkit agent
+  works out of the box.
 - `yay` or `paru` on `PATH`, optional, for the AUR check and update.
   Auto-detected by default, see the **AUR helper** setting.
 - `flatpak`, optional, for the Flatpak check and update.
-- `xdg-open`, optional, to open a package page, the update log, or the Arch
-  news page.
-- `sudo` and a terminal emulator, optional, only for the **Retry in
-  terminal** fallback: Noctalia's own detection (`$TERMINAL`, then the
+- `xdg-open`, optional, to open a package page or the Arch news page.
+- `less`, plus `sudo` and a terminal emulator, for the terminal update mode
+  (the default), the **Retry in terminal** fallback and the **Open full
+  log** viewer: Noctalia's own terminal detection (`$TERMINAL`, then the
   common emulators), or the one named in the **Terminal** setting.
 
 A missing optional tool is skipped, not treated as an error.
@@ -51,23 +55,66 @@ source row to expand it into its packages. Each package row has an ignore
 button (see **Ignored packages**), a copy button (name and versions) and an
 open button (its page on archlinux.org, the AUR, or Flathub).
 
-**Update** starts the background run: pkexec raises the polkit password
-dialog, everything else is non-interactive (`--noconfirm`, and for the AUR
-helper `--skipreview` / the `--answer*` flags), so any remaining question
-gets its default answer. While the run is going the package list gives way
-to a live tail of the update log with a progress bar, and the bar widget
-shows a percentage instead of the count. The run is spawned detached, so it
-survives a shell restart: a restarted engine re-attaches to an unfinished
-log and keeps showing progress. When the run ends you get a notification
-and an automatic re-check; a failed run keeps its log on screen and offers
-**Retry in terminal**, where prompts and the PKGBUILD review work normally.
+**Update** follows the **Update mode** setting:
 
+- **In a terminal window** (default): opens a terminal running the usual
+  interactive upgrade — `sudo pacman -Syu` or the AUR helper without any
+  auto-answer flags, so prompts, conflicts and the PKGBUILD review work
+  exactly as on the command line. The output is `tee`'d into the update
+  log, so the panel still shows the live tail, the progress bar and the
+  bar-widget percentage, and the run still lands in the update history.
+- **In the background**: pkexec raises the polkit password dialog,
+  everything else is non-interactive (`--noconfirm`, and for the AUR helper
+  `--skipreview` / the `--answer*` flags), so any remaining question gets
+  its default answer. The run is spawned detached and survives a shell
+  restart: a restarted engine re-attaches to an unfinished log and keeps
+  showing progress. A background run that cannot proceed non-interactively
+  stops cleanly with a non-zero exit before touching the system; a failed
+  run keeps its log on screen and offers **Retry in terminal**.
+
+When a run ends you get a notification and an automatic re-check.
 **Dismiss** clears the pending list until the next check. **Check Updates**
 queries all sources.
 
 Type `/arch` in the launcher for quick actions (check, update, open news),
 or `/arch <text>` to fuzzy-search the packages from the last check.
 Activating a result opens that package's page.
+
+### Update history and rollback
+
+A strip at the bottom of the panel has one segment per recorded run (the
+last 15), oldest on the left; rollbacks get their own segments. Hover shows
+the date and package count, click opens the run's package list: each row
+shows `name from → to` with a rollback button (a second click confirms),
+and the header offers rolling back the whole run in one transaction.
+
+Rollback installs the old package files straight from the caches
+(`/var/cache/pacman/pkg`, paru's/yay's build dirs) with
+`pkexec pacman -U`: the chosen version is installed directly, no stepping
+through intermediate upgrades. Dependencies updated in the same run ride
+along in the same transaction (resolved with `pactree` against the run's
+package list), so a program and its libraries move back together.
+`--nodeps` is never used: a downgrade that would break another package's
+versioned dependencies makes pacman refuse the whole transaction before
+anything changes. When a run's package list is opened, the engine probes
+the caches and reverse dependencies: packages whose old file is gone are
+greyed out, and the rollback tooltip warns how many installed packages
+require the one being rolled back. Flatpak entries are shown but not
+rollbackable.
+
+Before a run is recorded, `pacman -Q` confirms which packages actually
+changed: anything declined during an interactive terminal run is left out
+of the entry, so the history never offers to "undo" an update that did not
+happen. Failed runs are not recorded.
+
+### Activity graph
+
+The optional activity graph (off by default, **Show activity graph**)
+tracks the pending-update count across recent checks and when you last
+updated, drawn as a small trend line above the history strip. Hovering the
+dot axis under the line highlights a check and describes it (count, time,
+or "Updated" for the check that verified a run). Turning the setting off
+also stops recording the data.
 
 ### Ignored packages
 
@@ -84,19 +131,32 @@ section at the bottom of the package list:
   are managed only in that file. The plugin never edits `pacman.conf`.
 
 Ignored packages are excluded from the pending count and passed as
-`--ignore` to the update run (Flatpak refs are filtered out of `flatpak
-update` the same way).
+`--ignore` to the update run in both modes (Flatpak refs are filtered out
+of `flatpak update` the same way).
 
 ### One polkit password per run
 
-`pkexec` authenticates every pacman transaction separately, so an update
-that syncs databases and installs AUR builds can raise several password
-dialogs. Until a keep-authorization polkit rule is installed, the panel
-shows a hint line with an **Ask once** button: it installs (through one
-`pkexec` call you confirm) a rule that keeps a successful authentication
-for ~5 minutes — like `sudo`'s timestamp — scoped to `pkexec` launching
-`/usr/bin/pacman` for an active local `wheel` session. The rule text ships
-in `polkit/49-arch-updater-pacman.rules` and can also be installed by hand:
+`pkexec` authenticates every pacman transaction separately, so a background
+update that syncs databases and installs AUR builds can raise several
+password dialogs. Until a keep-authorization polkit rule is installed, the
+panel shows a hint line with an **Ask once** button (only in background
+mode — the terminal mode goes through `sudo` and never hits this): it
+installs, through one `pkexec` call you confirm, a rule that keeps a
+successful authentication for ~5 minutes — like `sudo`'s timestamp.
+
+**Scope, stated plainly:** the rule grants `AUTH_ADMIN_KEEP` for *any*
+`pkexec`-launched `/usr/bin/pacman` call made from an active local session
+of a `wheel` member — not only this plugin's calls — comparable to a
+manually added NOPASSWD-with-timeout sudoers line. It is strictly opt-in,
+the same wording appears in the install button's tooltip, and it can be
+removed at any time:
+
+```sh
+sudo rm /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
+```
+
+The rule text ships in `polkit/49-arch-updater-pacman.rules` and can also
+be installed by hand:
 
 ```sh
 sudo install -Dm644 polkit/49-arch-updater-pacman.rules /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
@@ -118,9 +178,13 @@ setting.
 | `show_download_size` | `bool` | `true` | Show the estimated pacman download size (`pacman -Si`) in the panel. |
 | `check_arch_news` | `bool` | `true` | Check the Arch Linux news feed and flag unread posts. |
 | `check_reboot_needed` | `bool` | `true` | Flag when the running kernel is no longer installed on disk. |
+| `show_activity_graph` | `bool` | `false` | Track pending-update counts across checks and show them as a small graph. Off also stops recording. |
+| `activity_history_length` | `int` | `10` | How many recent checks the activity graph keeps (3–30). |
+| `update_mode` | `select` | `terminal` | How **Update** runs the upgrade: in a terminal window (interactive, like before) or in the background (non-interactive). |
+| `rollback_auto_ignore` | `bool` | `false` | After a successful rollback, add the rolled-back packages to the plugin's ignore list. |
 | `hide_polkit_hint` | `bool` | `false` | Hide the panel line offering to install the polkit keep-authorization rule. |
 | `log_lines` | `int` | `14` | How many of the latest update-log lines the panel shows during a run (6–30). |
-| `terminal` | `string` | *(empty)* | Terminal command, only for the **Retry in terminal** fallback. Empty uses Noctalia's detection. |
+| `terminal` | `string` | *(empty)* | Terminal command for terminal-mode updates, the retry fallback and the log viewer. Empty uses Noctalia's detection. |
 | `update_cmd` | `string` | *(empty)* | Full override for the background update command. Empty builds it from the settings above, running pacman through `pkexec`. |
 | `glyph` | `glyph` | `package` | The glyph shown for the widget on the bar. |
 | `show_count` | `bool` | `true` | Show the pending-update count next to the bar glyph. |
@@ -131,15 +195,16 @@ setting.
 ```sh
 noctalia msg plugin yuuto/arch-updater:service all check
 noctalia msg plugin yuuto/arch-updater:service all update
+noctalia msg plugin yuuto/arch-updater:service all update_background
 noctalia msg plugin yuuto/arch-updater:service all update_terminal
 noctalia msg plugin yuuto/arch-updater:service all dismiss
 noctalia msg plugin yuuto/arch-updater:service all ignore:NAME
 noctalia msg plugin yuuto/arch-updater:service all unignore:NAME
 ```
 
-`update` starts the background run, `update_terminal` the terminal
-fallback. `ignore:NAME` / `unignore:NAME` edit the panel-managed ignore
-list.
+`update` follows the **Update mode** setting; `update_background` and
+`update_terminal` force one mode. `ignore:NAME` / `unignore:NAME` edit the
+panel-managed ignore list.
 
 ## Notes
 
@@ -149,36 +214,57 @@ list.
   download size; `test -d` against `uname -r` for the reboot check. Update:
   a detached `sh` running `pkexec pacman -Syu` or the AUR helper with
   `--sudo pkexec`, then optionally `flatpak update` — all output redirected
-  to the update log, which the engine follows with `tail`. The terminal
-  fallback runs the interactive equivalents (`sudo pacman -Syu`, the helper
-  without auto-answers) under your terminal, `tee`'d into the same log.
+  to the update log, which the engine follows with `tail`/`grep`. The
+  terminal mode runs the interactive equivalents (`sudo pacman -Syu`, the
+  helper without auto-answers) under your terminal, `tee`'d into the same
+  log. Rollback: `pactree` to resolve same-run dependencies, a shell glob
+  over the package caches to find the old files, `pkexec pacman -U` to
+  install them, and `pactree -rd1` piped through `wc` for the
+  reverse-dependency warning. After a successful run, `pacman -Q` verifies
+  which packages actually changed before the history entry is written.
+  **Open full log** shows the log with `less` in your terminal.
 - **Privileges.** Escalation happens only through polkit: `pkexec pacman`
-  for repo packages, and the AUR helper escalates its install steps through
-  `pkexec` itself (`--sudo pkexec`). AUR builds run unprivileged as usual.
-  The optional **Ask once** button installs the shipped polkit rule via one
-  user-confirmed `pkexec install` call; nothing else touches system
-  configuration, and `pacman.conf` is never modified.
+  for repo packages and rollback, and the AUR helper escalates its install
+  steps through `pkexec` itself (`--sudo pkexec`). AUR builds run
+  unprivileged as usual. The terminal mode escalates through `sudo` inside
+  your terminal, as a manual upgrade would. The optional **Ask once**
+  button installs the shipped polkit rule via one user-confirmed
+  `pkexec install` call; nothing else touches system configuration, and
+  `pacman.conf` is never modified.
 - **Network.** `checkupdates`, the AUR helper and the Flatpak check contact
   mirrors, the AUR RPC, or a Flatpak remote, same as the corresponding
   upgrade would. The Arch news check fetches `archlinux.org/feeds/news/`
   once at startup and then every 6 hours.
 - **Files written.** All in the plugin's data directory: `update.log` (the
-  current/last run, with `::START`/`::EXIT` markers), `ignore.json` (the
-  panel-managed ignore list), `news_state.json` (the last read news post),
-  a staged copy of the polkit rule, and a marker recording that the rule
-  was installed (`/etc/polkit-1/rules.d` is not readable by regular users
-  on Arch, so presence can't always be probed directly).
-- **Stuck-run guard.** A background run whose log stops growing for 30
+  current/last run, with `::START`/`::EXIT` markers), `run_meta.json` (the
+  current run's kind and package list, so a restarted shell can keep
+  tracking it; removed when the run ends), `runs.json` (the update history,
+  last 15 successful runs), `history_state.json` (the activity graph data),
+  `ignore.json` (the panel-managed ignore list), `news_state.json` (the
+  last read news post), a staged copy of the polkit rule, and a marker
+  recording that the rule was installed (`/etc/polkit-1/rules.d` is not
+  readable by regular users on Arch, so presence can't always be probed
+  directly).
+- **Stuck-run guard.** A *background* run whose log stops growing for 30
   minutes is declared failed; the panel then offers the terminal fallback.
-  Unfinished logs older than 6 hours are not resumed after a restart.
+  Terminal runs are exempt — log silence there can just be you reading a
+  PKGBUILD diff. Unfinished logs older than 6 hours are not resumed after
+  a restart.
 - **Sizes are pacman-only.** AUR and Flatpak downloads aren't sized. Most
   AUR packages build from source, where a download size wouldn't mean much.
+- **`-git` (devel) packages and rollback.** After rolling one back, the
+  next check usually does *not* list it as an update: paru/yay track devel
+  packages by the last built commit, not the installed version. Move
+  forward again through the rollback's own history segment, or with
+  `paru -S <package>`. Regular repo packages reappear as pending on the
+  very next check.
 
 ## Credits
 
 Ported from the v4 QML "Arch Updater" plugin (MIT), rebuilt for v5's Luau
-plugin API. Background update mode, ignore management and the polkit
-integration contributed by [UmedjonBA](https://github.com/UmedjonBA).
+plugin API. Background update mode, ignore management, the polkit
+integration, and the update history with rollback contributed by
+[UmedjonBA](https://github.com/UmedjonBA).
 
 ## License
 

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -4,9 +4,11 @@
 -- actions this panel emits, so closing the panel never interrupts a check or
 -- a run in progress.
 --
--- "Check Updates" only queries pacman, the AUR helper and (optionally)
--- Flatpak. Only then do "Update" (open a terminal and run the upgrade) and
--- "Dismiss" (clear the pending list and close the panel) light up.
+-- One click on "Update" starts the background run: pkexec raises the polkit
+-- password dialog, everything else is non-interactive. While it runs, the
+-- package list gives way to a live tail of the update log plus a progress
+-- bar. A failed run keeps its log on screen and offers a terminal fallback
+-- where prompts work normally.
 
 local STATE_KEY = "arch_state"
 local REQUEST_KEY = "arch_request"
@@ -15,7 +17,6 @@ local snapshot = nil
 local expanded = {} -- source key -> the package list is open
 local hoverKey = nil -- package row currently under the pointer
 local hoverText = "" -- what the detail line shows
-local activityHoverIndex = nil -- activity graph point currently under the pointer
 local listOpen = false -- at least one source is expanded this render
 
 local render
@@ -24,10 +25,10 @@ local function tr(key, args)
     return noctalia.tr(key, args)
 end
 
-local function request(action)
+local function request(action, pkg)
     local prev = noctalia.state.get(REQUEST_KEY)
     local nonce = (type(prev) == "table" and tonumber(prev.nonce) or 0) + 1
-    noctalia.state.set(REQUEST_KEY, { nonce = nonce, action = action })
+    noctalia.state.set(REQUEST_KEY, { nonce = nonce, action = action, pkg = pkg })
 end
 
 local function shellQuote(value)
@@ -79,11 +80,19 @@ local function busy()
     return phase == "checking" or phase == "running"
 end
 
--- Only "checking" blocks a new check: "running" still allows one, since it
--- doubles as a manual unstick if the update's process-poll heuristic ever
--- misses the terminal finishing.
 local function checking()
     return phaseOf() == "checking"
+end
+
+local function runFailed()
+    return phaseOf() == "error" and snapshot ~= nil and tonumber(snapshot.runExit) ~= nil and tonumber(snapshot.runExit) ~= 0
+end
+
+local function logLines()
+    if snapshot == nil or type(snapshot.logTail) ~= "table" then
+        return {}
+    end
+    return snapshot.logTail
 end
 
 local function headline()
@@ -146,12 +155,18 @@ local function orderedSources()
     return pending
 end
 
+-- Sources that are installed, enabled and have nothing pending. Flatpak is
+-- skipped entirely when it is not on the system, so the panel doesn't brag
+-- about a tool that isn't there.
 local function cleanSources()
     if snapshot == nil then
         return {}
     end
     local names = {}
-    local candidates = { { key = "pacman", entry = snapshot.pacman }, { key = "flatpak", entry = snapshot.flatpak } }
+    local candidates = { { key = "pacman", entry = snapshot.pacman } }
+    if snapshot.flatpakEnabled == true then
+        table.insert(candidates, { key = "flatpak", entry = snapshot.flatpak })
+    end
     if snapshot.aur ~= nil and (snapshot.aur.n or 0) == 0 and noctalia.getConfig("aur_helper") ~= "off" then
         table.insert(candidates, { key = "aur", entry = snapshot.aur })
     end
@@ -181,6 +196,13 @@ local function packageRow(sourceKey, index, item)
             text = to, fontSize = 11, color = "primary", fontWeight = "semibold", maxWidth = VERSION_WIDTH, maxLines = 1,
         }))
     end
+    table.insert(children, ui.button({
+        glyph = "eye-off", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+        tooltip = tr("tip_ignore"),
+        onClick = function()
+            request("ignore", item.name)
+        end,
+    }))
     table.insert(children, ui.button({
         glyph = "copy", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
         tooltip = tr("tip_copy"),
@@ -252,6 +274,175 @@ local function sourceRows()
     return rows
 end
 
+-- ── Ignored packages ─────────────────────────────────────────────────────────
+
+-- One display list: packages the last check saw as ignored (with versions),
+-- then panel-managed and settings-based ignores with nothing pending.
+local function ignoredEntries()
+    if snapshot == nil then
+        return {}
+    end
+    local entries = {}
+    local seen = {}
+    local pending = type(snapshot.ignoredPending) == "table" and snapshot.ignoredPending or {}
+    for _, item in ipairs(pending) do
+        if type(item) == "table" and item.name ~= nil and not seen[item.name] then
+            seen[item.name] = true
+            table.insert(entries, item)
+        end
+    end
+    local dynamic = type(snapshot.ignoredDynamic) == "table" and snapshot.ignoredDynamic or {}
+    for _, name in ipairs(dynamic) do
+        if not seen[name] then
+            seen[name] = true
+            table.insert(entries, { name = name, source = "plugin" })
+        end
+    end
+    local config = type(snapshot.ignoredConfig) == "table" and snapshot.ignoredConfig or {}
+    for _, name in ipairs(config) do
+        if not seen[name] then
+            seen[name] = true
+            table.insert(entries, { name = name, source = "settings" })
+        end
+    end
+    return entries
+end
+
+-- Only panel-managed ignores can be lifted from here.
+local function isRemovable(name)
+    if snapshot == nil or type(snapshot.ignoredDynamic) ~= "table" then
+        return false
+    end
+    for _, entry in ipairs(snapshot.ignoredDynamic) do
+        if entry == name then
+            return true
+        end
+    end
+    return false
+end
+
+local function ignoredRow(index, item)
+    local children = {
+        ui.label({ text = item.name, fontSize = 11, color = "on_surface_variant", flexGrow = 1, maxLines = 1 }),
+    }
+    if item.to ~= nil and item.to ~= "" then
+        table.insert(children, ui.label({
+            text = item.to, fontSize = 11, color = "on_surface_variant", maxWidth = VERSION_WIDTH, maxLines = 1,
+        }))
+    end
+    if item.source ~= "system" and isRemovable(item.name) then
+        table.insert(children, ui.button({
+            glyph = "eye", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+            tooltip = tr("tip_unignore"),
+            onClick = function()
+                request("unignore", item.name)
+            end,
+        }))
+    elseif item.source == "system" then
+        -- IgnorePkg belongs to root; the tag only explains where to lift it.
+        table.insert(children, ui.button({
+            text = tr("ignored_tag_system"), variant = "ghost", controlSize = "sm",
+            tooltip = tr("ignored_tip_system"),
+            onClick = function() end,
+        }))
+    else
+        table.insert(children, ui.button({
+            text = tr("ignored_tag_settings"), variant = "ghost", controlSize = "sm",
+            tooltip = tr("ignored_tip_settings"),
+            onClick = function()
+                noctalia.runAsync("noctalia msg settings-open-plugin yuuto/arch-updater >/dev/null 2>&1")
+            end,
+        }))
+    end
+    return ui.row({ key = "ign-" .. index, paddingH = 18, gap = 6, align = "center" }, children)
+end
+
+local function ignoredRows()
+    local entries = ignoredEntries()
+    if #entries == 0 then
+        return {}
+    end
+    local open = expanded["ignored"] == true
+    local rows = {}
+    table.insert(rows, ui.row({
+        key = "src-ignored" .. (open and "-open" or ""),
+        gap = 8,
+        align = "center",
+        onClick = function()
+            expanded["ignored"] = not expanded["ignored"]
+            render()
+        end,
+    }, {
+        ui.glyph({ name = open and "chevron-down" or "chevron-right", size = 12, color = "on_surface_variant" }),
+        ui.glyph({ name = "eye-off", size = 13, color = "on_surface_variant" }),
+        ui.label({ text = tr("ignored_title"), color = "on_surface_variant", flexGrow = 1 }),
+        ui.label({ text = tostring(#entries), color = "on_surface_variant", fontWeight = "bold" }),
+    }))
+    if open then
+        for index, item in ipairs(entries) do
+            table.insert(rows, ignoredRow(index, item))
+        end
+    end
+    return rows
+end
+
+-- Live tail of the update log, with a progress bar while packages are being
+-- processed. Shown during a run and kept on screen after a failed one.
+local function logSection()
+    local children = {}
+
+    local header = {
+        ui.label({ text = tr("log_title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant", flexGrow = 1 }),
+    }
+    local done = snapshot ~= nil and type(snapshot.progress) == "table" and tonumber(snapshot.progress.done) or 0
+    local expect = snapshot ~= nil and type(snapshot.progress) == "table" and tonumber(snapshot.progress.total) or 0
+    if phaseOf() == "running" and expect > 0 then
+        table.insert(header, ui.label({
+            text = tostring(math.min(done, expect)) .. " / " .. tostring(expect),
+            fontSize = 11,
+            color = "on_surface_variant",
+        }))
+    end
+    table.insert(children, ui.row({ key = "log-head", gap = 6, align = "center" }, header))
+
+    if phaseOf() == "running" and expect > 0 then
+        table.insert(children, ui.progress({ key = "log-progress", progress = math.min(done / expect, 1) }))
+    end
+
+    local lines = logLines()
+    local rows = {}
+    if #lines == 0 then
+        table.insert(rows, ui.label({
+            key = "log-empty", text = tr("log_waiting"), fontSize = 10, color = "on_surface_variant",
+        }))
+    else
+        for index, line in ipairs(lines) do
+            table.insert(rows, ui.label({
+                key = "log-" .. index,
+                text = line,
+                fontSize = 10,
+                color = "on_surface_variant",
+                maxLines = 1,
+            }))
+        end
+    end
+    table.insert(children, ui.column({ key = "log-lines", gap = 2, flexGrow = 1 }, rows))
+
+    if snapshot ~= nil and type(snapshot.logPath) == "string" and snapshot.logPath ~= "" then
+        local path = snapshot.logPath
+        table.insert(children, ui.row({ key = "log-actions", gap = 6 }, {
+            ui.button({
+                text = tr("action_open_log"), variant = "ghost", controlSize = "sm",
+                onClick = function()
+                    openUrl("file://" .. path)
+                end,
+            }),
+        }))
+    end
+
+    return ui.column({ key = "log", gap = 6, flexGrow = 1 }, children)
+end
+
 -- Download size, reboot recommendation and Arch news. Each is its own line,
 -- so turning one off in settings just removes that line.
 local function extras()
@@ -277,6 +468,27 @@ local function extras()
         }))
     end
 
+    -- Offered until the polkit keep-authorization rule is installed.
+    if snapshot.polkitRule == false and phaseOf() ~= "running" and noctalia.getConfig("hide_polkit_hint") ~= true then
+        table.insert(lines, ui.row({ key = "polkit", gap = 6, align = "center" }, {
+            ui.glyph({ name = "shield", size = 13, color = "on_surface_variant" }),
+            ui.label({
+                text = tr("polkit_hint"),
+                fontSize = 12,
+                color = "on_surface_variant",
+                flexGrow = 1,
+                maxLines = 2,
+            }),
+            ui.button({
+                text = tr("action_polkit_install"), variant = "ghost", controlSize = "sm",
+                tooltip = tr("tip_polkit_install"),
+                onClick = function()
+                    request("polkit_install")
+                end,
+            }),
+        }))
+    end
+
     if (snapshot.newsUnread or 0) > 0 then
         table.insert(lines, ui.row({ key = "news", gap = 6, align = "center" }, {
             ui.glyph({ name = "news", size = 13, color = "on_surface" }),
@@ -299,213 +511,49 @@ local function extras()
     return lines
 end
 
--- Normalizes the pending-count history to 0..1 for ui.graph, relative to the
--- min/max in the window (not a fixed scale, since pending counts vary wildly
--- between systems). A flat window (min == max, e.g. every check so far found
--- the same count) centers the line at 0.5 instead of pinning it to the top
--- edge, where it would be indistinguishable from the box border.
-local function activityValues(history)
-    local minN, maxN = tonumber(history[1].n) or 0, tonumber(history[1].n) or 0
-    for _, entry in ipairs(history) do
-        local n = tonumber(entry.n) or 0
-        if n < minN then
-            minN = n
-        end
-        if n > maxN then
-            maxN = n
-        end
-    end
-    local range = maxN - minN
-    local values = {}
-    for _, entry in ipairs(history) do
-        local n = tonumber(entry.n) or 0
-        table.insert(values, range > 0 and (n - minN) / range or 0.5)
-    end
-    return values
-end
-
-local ACTIVITY_GRAPH_SUBDIVISIONS = 8
-
-local function upsampleLinear(values, subdivisions)
-    if #values < 2 or subdivisions <= 1 then
-        return values
-    end
-    local out = {}
-    for i = 1, #values - 1 do
-        local a, b = values[i], values[i + 1]
-        for s = 0, subdivisions - 1 do
-            table.insert(out, a + (b - a) * (s / subdivisions))
-        end
-    end
-    table.insert(out, values[#values])
-    return out
-end
-
-local function padGraphLookbehind(values)
-    if #values == 0 then
-        return values
-    end
-    local out = { values[1], values[1] }
-    for _, v in ipairs(values) do
-        table.insert(out, v)
-    end
-    return out
-end
-
--- "2 hours ago", "3 days ago", etc. nil for entries migrated from the old
--- history format, which never recorded a timestamp.
-local function relativeTime(at)
-    local t = tonumber(at)
-    if t == nil then
-        return nil
-    end
-    local diff = os.time() - t
-    if diff < 60 then
-        return tr("activity.just_now")
-    elseif diff < 3600 then
-        local m = math.floor(diff / 60)
-        return noctalia.trp("activity.minutes_ago", m, { count = m })
-    elseif diff < 86400 then
-        local h = math.floor(diff / 3600)
-        return noctalia.trp("activity.hours_ago", h, { count = h })
-    else
-        local d = math.floor(diff / 86400)
-        return noctalia.trp("activity.days_ago", d, { count = d })
-    end
-end
-
--- "Updated · 2 hours ago" for the check that verified an update run, else
--- "3 pending updates · 2 hours ago". Shared by the hover tooltip and the
--- top-right caption so both describe a point the same way.
-local function describeEntry(entry)
-    local n = tonumber(entry.n) or 0
-    local text = entry.afterUpdate == true and tr("activity.updated")
-        or noctalia.trp("activity.pending_at", n, { count = n })
-    local when = relativeTime(entry.at)
-    if when ~= nil then
-        text = text .. " · " .. when
-    end
-    return text
-end
-
--- ui.graph takes no pointer props of its own (only row/column/box/image/button
--- do), so per-point hover is a row of hit targets placed right under the
--- line. Each is a ghost button so it can carry a native tooltip at the
--- pointer, not just a box for the hit test. It cannot highlight the point on
--- the line itself, only drive the tooltip and the caption above it.
---
--- Real points sit at (k-1)/(#history-1) of the width (see
--- padGraphLookbehind), i.e. #history-1 equal gaps, not #history equal slots
--- - so this builds one equal-width segment per gap rather than per entry,
--- ending each segment exactly on the point at its right edge. That leaves
--- entry 1 (at the left edge, with no gap before it) without its own hover
--- zone, but keeps every other spike landing right at the end of its segment
--- instead of drifting toward the start of an oversized one.
-local function activityHoverRow(history)
-    local segments = {}
-    for i = 2, #history do
-        segments[i - 1] = ui.button({
-            key = "activity-hit-" .. i,
-            variant = "ghost",
-            flexGrow = 1,
-            height = 12,
-            tooltip = describeEntry(history[i]),
-            onHover = function(state)
-                if state == "true" then
-                    activityHoverIndex = i
-                elseif activityHoverIndex == i then
-                    activityHoverIndex = nil
-                else
-                    return
-                end
-                render()
-            end,
-        })
-    end
-    return ui.row({ key = "activity-hits", gap = 1 }, segments)
-end
-
--- A small trend graph of pending-update counts across recent checks, plus
--- when the last update ran (or, while hovering a point, that point's own
--- description). Off entirely when show_activity_graph is off, and hidden
--- until there is enough history to draw a line.
-local function activitySection()
-    if snapshot == nil or noctalia.getConfig("show_activity_graph") ~= true then
-        return nil
-    end
-    local history = type(snapshot.history) == "table" and snapshot.history or {}
-    if #history < 2 then
-        return nil
-    end
-
-    local hoveredEntry = activityHoverIndex ~= nil and history[activityHoverIndex] or nil
-    local caption
-    if hoveredEntry ~= nil then
-        caption = describeEntry(hoveredEntry)
-    else
-        local lastUpdateAt = tonumber(snapshot.lastUpdateAt)
-        if lastUpdateAt == nil then
-            caption = tr("activity.never_updated")
-        else
-            local days = math.floor((os.time() - lastUpdateAt) / 86400)
-            caption = days <= 0 and tr("activity.updated_today")
-                or noctalia.trp("activity.updated_days_ago", days, { count = days })
-        end
-    end
-
-    return ui.column({ key = "activity", gap = 4 }, {
-        ui.row({ justify = "space_between", align = "center" }, {
-            ui.label({ text = tr("activity.title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant" }),
-            ui.label({ text = caption, fontSize = 10, color = "on_surface_variant" }),
-        }),
-        ui.graph({
-            values = padGraphLookbehind(upsampleLinear(activityValues(history), ACTIVITY_GRAPH_SUBDIVISIONS)),
-            color = "primary",
-            fillOpacity = 0.15,
-            lineWidth = 2,
-            height = 36,
-        }),
-        activityHoverRow(history),
-    })
-end
-
 local function body()
     local children = {}
 
-    local rows = sourceRows()
-    if #rows > 0 then
-        table.insert(children, ui.scroll({ key = "sources", flexGrow = 1, gap = 3 }, rows))
+    -- The middle of the panel: the live log while updating (and after a
+    -- failure), the package list otherwise.
+    if phaseOf() == "running" or (runFailed() and #logLines() > 0) then
+        table.insert(children, logSection())
     else
-        table.insert(children, ui.spacer({ key = "filler", flexGrow = 1 }))
-    end
+        local rows = sourceRows()
+        for _, row in ipairs(ignoredRows()) do
+            table.insert(rows, row)
+        end
+        if #rows > 0 then
+            table.insert(children, ui.scroll({ key = "sources", flexGrow = 1, gap = 3 }, rows))
+        else
+            table.insert(children, ui.spacer({ key = "filler", flexGrow = 1 }))
+        end
 
-    if listOpen then
-        table.insert(children, ui.label({
-            key = "hover-detail",
-            text = hoverText ~= "" and hoverText or tr("hover_hint"),
-            fontSize = 11,
-            color = hoverText ~= "" and "on_surface" or "on_surface_variant",
-            maxLines = 1,
-        }))
+        if listOpen then
+            table.insert(children, ui.label({
+                key = "hover-detail",
+                text = hoverText ~= "" and hoverText or tr("hover_hint"),
+                fontSize = 11,
+                color = hoverText ~= "" and "on_surface" or "on_surface_variant",
+                maxLines = 1,
+            }))
+        end
     end
 
     for _, line in ipairs(extras()) do
         table.insert(children, line)
     end
 
-    local clean = cleanSources()
-    if #clean > 0 then
-        table.insert(children, ui.label({
-            text = tr("up_to_date", { sources = table.concat(clean, ", ") }),
-            fontSize = 11,
-            color = "on_surface_variant",
-            maxLines = 2,
-        }))
-    end
-
-    local activity = activitySection()
-    if activity ~= nil then
-        table.insert(children, activity)
+    if not busy() then
+        local clean = cleanSources()
+        if #clean > 0 then
+            table.insert(children, ui.label({
+                text = tr("up_to_date", { sources = table.concat(clean, ", ") }),
+                fontSize = 11,
+                color = "on_surface_variant",
+                maxLines = 2,
+            }))
+        end
     end
 
     return children
@@ -516,7 +564,7 @@ local function footerCaption()
         return nil
     end
     local parts = { tr("caption_checked", { time = snapshot.checkedAt }) }
-    local ignored = tonumber(snapshot.ignoredCount) or 0
+    local ignored = #ignoredEntries()
     if ignored > 0 then
         table.insert(parts, noctalia.trp("caption_ignored", ignored, {}))
     end
@@ -528,16 +576,16 @@ render = function()
 
     local text, color = headline()
     local phase = phaseOf()
-    local hasUpdates = totalOf() > 0 and (phase == "ready" or phase == "running")
+    local hasUpdates = totalOf() > 0 and phase == "ready"
 
     local children = {
         ui.row({ gap = 8, align = "center" }, {
             ui.label({ text = tr("title"), fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
             ui.button({
-                key = "header-check" .. (checking() and "-off" or ""),
+                key = "header-check" .. (busy() and "-off" or ""),
                 glyph = "refresh",
                 variant = "ghost",
-                enabled = not checking() and phase ~= "missing",
+                enabled = not busy() and phase ~= "missing",
                 tooltip = tr("tip_check"),
                 onClick = function()
                     request("check")
@@ -564,32 +612,36 @@ render = function()
     end
 
     if phase ~= "missing" then
-        table.insert(children, ui.row({ gap = 8, align = "center" }, {
-            ui.button({
-                key = "check" .. (checking() and "-off" or ""),
-                glyph = "refresh", text = tr("action_check"), variant = "ghost", enabled = not checking(), flexGrow = 1,
+        local footer = {}
+        if runFailed() then
+            table.insert(footer, ui.button({
+                key = "retry-terminal",
+                glyph = "terminal", text = tr("action_run_terminal"), variant = "ghost", flexGrow = 1,
+                tooltip = tr("tip_run_terminal"),
                 onClick = function()
-                    request("check")
+                    request("update_terminal")
                 end,
-            }),
-            ui.button({
-                key = "dismiss" .. (hasUpdates and "" or "-off"),
-                text = tr("action_dismiss"), variant = "ghost", enabled = hasUpdates,
-                onClick = function()
-                    request("dismiss")
-                    panel.close()
-                end,
-            }),
-            ui.button({
-                key = "update" .. (hasUpdates and not busy() and "" or "-off"),
-                glyph = "download", text = tr("action_update"), variant = "primary", enabled = hasUpdates and not busy(),
-                tooltip = tr("tip_update"),
-                onClick = function()
-                    request("update")
-                    panel.close()
-                end,
-            }),
+            }))
+        end
+        table.insert(footer, ui.button({
+            key = "dismiss" .. (hasUpdates and "" or "-off"),
+            text = tr("action_dismiss"), variant = "ghost", enabled = hasUpdates,
+            onClick = function()
+                request("dismiss")
+                panel.close()
+            end,
         }))
+        table.insert(footer, ui.button({
+            key = "update" .. (hasUpdates and "" or "-off"),
+            glyph = "download", text = tr("action_update"), variant = "primary", enabled = hasUpdates,
+            tooltip = tr("tip_update"),
+            onClick = function()
+                -- The panel stays open: the log section takes over so the
+                -- run can be watched live.
+                request("update")
+            end,
+        }))
+        table.insert(children, ui.row({ gap = 8, align = "center", justify = "end" }, footer))
     end
 
     panel.render(ui.column({ flexGrow = 1, gap = 10, align = "stretch" }, children))
@@ -600,7 +652,6 @@ function onOpen(_context)
     expanded = {}
     hoverKey = nil
     hoverText = ""
-    activityHoverIndex = nil
     render()
 end
 
@@ -612,7 +663,6 @@ noctalia.state.watch(STATE_KEY, function(value)
         expanded = {}
         hoverKey = nil
         hoverText = ""
-        activityHoverIndex = nil
     end
     snapshot = value
     render()

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -4,11 +4,11 @@
 -- actions this panel emits, so closing the panel never interrupts a check or
 -- a run in progress.
 --
--- One click on "Update" starts the background run: pkexec raises the polkit
--- password dialog, everything else is non-interactive. While it runs, the
--- package list gives way to a live tail of the update log plus a progress
--- bar. A failed run keeps its log on screen and offers a terminal fallback
--- where prompts work normally.
+-- "Update" follows the update_mode setting: a terminal window (default,
+-- like the original plugin) or a non-interactive background run. Either
+-- way the package list gives way to a live tail of the update log plus a
+-- progress bar while it runs. A failed background run keeps its log on
+-- screen and offers a terminal retry where prompts work normally.
 
 local STATE_KEY = "arch_state"
 local REQUEST_KEY = "arch_request"
@@ -18,6 +18,9 @@ local expanded = {} -- source key -> the package list is open
 local hoverKey = nil -- package row currently under the pointer
 local hoverText = "" -- what the detail line shows
 local listOpen = false -- at least one source is expanded this render
+local openedRunAt = nil -- history run whose package list replaces the sources
+local armedKey = nil -- rollback button waiting for its confirming second click
+local activityHoverIndex = nil -- activity graph point currently under the pointer
 
 local render
 
@@ -25,10 +28,20 @@ local function tr(key, args)
     return noctalia.tr(key, args)
 end
 
-local function request(action, pkg)
+-- extra: a package name string, or a table merged into the request payload
+-- (pkg/version/at for the rollback family).
+local function request(action, extra)
     local prev = noctalia.state.get(REQUEST_KEY)
     local nonce = (type(prev) == "table" and tonumber(prev.nonce) or 0) + 1
-    noctalia.state.set(REQUEST_KEY, { nonce = nonce, action = action, pkg = pkg })
+    local payload = { nonce = nonce, action = action }
+    if type(extra) == "table" then
+        for key, value in pairs(extra) do
+            payload[key] = value
+        end
+    elseif extra ~= nil then
+        payload.pkg = extra
+    end
+    noctalia.state.set(REQUEST_KEY, payload)
 end
 
 local function shellQuote(value)
@@ -108,6 +121,12 @@ local function headline()
         end
         return tr("status_checking"), "secondary"
     elseif phase == "running" then
+        if snapshot ~= nil and snapshot.runKind == "rollback" then
+            return tr("status_rolling_back"), "secondary"
+        end
+        if snapshot ~= nil and snapshot.runMode == "terminal" then
+            return tr("status_running_terminal"), "secondary"
+        end
         return tr("status_running"), "secondary"
     elseif phase == "clean" then
         return tr("status_clean"), "on_surface"
@@ -386,6 +405,366 @@ local function ignoredRows()
     return rows
 end
 
+-- ── Activity graph (the upstream feature, opt-in) ───────────────────────────
+
+-- Normalizes the pending-count history to 0..1 for ui.graph, relative to the
+-- min/max in the window (not a fixed scale, since pending counts vary wildly
+-- between systems). A flat window (min == max, e.g. every check so far found
+-- the same count) centers the line at 0.5 instead of pinning it to the top
+-- edge, where it would be indistinguishable from the box border.
+local function activityValues(history)
+    local minN, maxN = tonumber(history[1].n) or 0, tonumber(history[1].n) or 0
+    for _, entry in ipairs(history) do
+        local n = tonumber(entry.n) or 0
+        if n < minN then
+            minN = n
+        end
+        if n > maxN then
+            maxN = n
+        end
+    end
+    local range = maxN - minN
+    local values = {}
+    for _, entry in ipairs(history) do
+        local n = tonumber(entry.n) or 0
+        table.insert(values, range > 0 and (n - minN) / range or 0.5)
+    end
+    return values
+end
+
+local ACTIVITY_GRAPH_SUBDIVISIONS = 8
+
+local function upsampleLinear(values, subdivisions)
+    if #values < 2 or subdivisions <= 1 then
+        return values
+    end
+    local out = {}
+    for i = 1, #values - 1 do
+        local a, b = values[i], values[i + 1]
+        for s = 0, subdivisions - 1 do
+            table.insert(out, a + (b - a) * (s / subdivisions))
+        end
+    end
+    table.insert(out, values[#values])
+    return out
+end
+
+local function padGraphLookbehind(values)
+    if #values == 0 then
+        return values
+    end
+    local out = { values[1], values[1] }
+    for _, v in ipairs(values) do
+        table.insert(out, v)
+    end
+    return out
+end
+
+-- "2 hours ago", "3 days ago", etc. nil for entries migrated from the old
+-- history format, which never recorded a timestamp.
+local function relativeTime(at)
+    local t = tonumber(at)
+    if t == nil then
+        return nil
+    end
+    local diff = os.time() - t
+    if diff < 60 then
+        return tr("activity.just_now")
+    elseif diff < 3600 then
+        local m = math.floor(diff / 60)
+        return noctalia.trp("activity.minutes_ago", m, { count = m })
+    elseif diff < 86400 then
+        local h = math.floor(diff / 3600)
+        return noctalia.trp("activity.hours_ago", h, { count = h })
+    else
+        local d = math.floor(diff / 86400)
+        return noctalia.trp("activity.days_ago", d, { count = d })
+    end
+end
+
+-- "Updated · 2 hours ago" for the check that verified an update run, else
+-- "3 pending updates · 2 hours ago". Shared by the hover tooltip and the
+-- top-right caption so both describe a point the same way.
+local function describeEntry(entry)
+    local n = tonumber(entry.n) or 0
+    local text = entry.afterUpdate == true and tr("activity.updated")
+        or noctalia.trp("activity.pending_at", n, { count = n })
+    local when = relativeTime(entry.at)
+    if when ~= nil then
+        text = text .. " · " .. when
+    end
+    return text
+end
+
+-- ui.graph takes no pointer props of its own and the framework has no
+-- overlay control, so per-point hover cannot live on the line itself: it is
+-- a row of hit targets right under it, drawn as an axis of small dots (the
+-- hovered one lights up in the accent color) so the interactivity is
+-- visible without the ghost-button hover flash.
+--
+-- Real points sit at (k-1)/(#history-1) of the width (see
+-- padGraphLookbehind), i.e. #history-1 equal gaps, not #history equal slots
+-- - so this builds one equal-width segment per gap rather than per entry,
+-- ending each segment (and its dot) exactly on the point at its right edge.
+-- That leaves entry 1 (at the left edge, with no gap before it) without its
+-- own hover zone, but keeps every other spike landing right at the end of
+-- its segment instead of drifting toward the start of an oversized one.
+local function activityHoverRow(history)
+    local segments = {}
+    for i = 2, #history do
+        local hovered = activityHoverIndex == i
+        segments[i - 1] = ui.row({
+            key = "activity-hit-" .. i .. (hovered and "-on" or ""),
+            flexGrow = 1,
+            height = 12,
+            align = "center",
+            justify = "end",
+            onHover = function(state)
+                if state == "true" then
+                    activityHoverIndex = i
+                elseif activityHoverIndex == i then
+                    activityHoverIndex = nil
+                else
+                    return
+                end
+                render()
+            end,
+        }, {
+            ui.box({
+                width = hovered and 7 or 5,
+                height = hovered and 7 or 5,
+                radius = 4,
+                fill = hovered and "primary" or "outline/0.6",
+            }),
+        })
+    end
+    return ui.row({ key = "activity-hits", gap = 1 }, segments)
+end
+
+-- A small trend graph of pending-update counts across recent checks, plus
+-- when the last update ran (or, while hovering a point, that point's own
+-- description). Off entirely when show_activity_graph is off, and hidden
+-- until there is enough history to draw a line.
+local function activitySection()
+    if snapshot == nil or noctalia.getConfig("show_activity_graph") ~= true then
+        return nil
+    end
+    local history = type(snapshot.activity) == "table" and snapshot.activity or {}
+    if #history < 2 then
+        return nil
+    end
+
+    local hoveredEntry = activityHoverIndex ~= nil and history[activityHoverIndex] or nil
+    local caption
+    if hoveredEntry ~= nil then
+        caption = describeEntry(hoveredEntry)
+    else
+        local lastUpdateAt = tonumber(snapshot.lastUpdateAt)
+        if lastUpdateAt == nil then
+            caption = tr("activity.never_updated")
+        else
+            local days = math.floor((os.time() - lastUpdateAt) / 86400)
+            caption = days <= 0 and tr("activity.updated_today")
+                or noctalia.trp("activity.updated_days_ago", days, { count = days })
+        end
+    end
+
+    return ui.column({ key = "activity", gap = 4 }, {
+        ui.row({ justify = "space_between", align = "center" }, {
+            ui.label({ text = tr("activity.title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant" }),
+            ui.label({ text = caption, fontSize = 10, color = "on_surface_variant" }),
+        }),
+        ui.graph({
+            values = padGraphLookbehind(upsampleLinear(activityValues(history), ACTIVITY_GRAPH_SUBDIVISIONS)),
+            color = "primary",
+            fillOpacity = 0.15,
+            lineWidth = 2,
+            height = 36,
+        }),
+        activityHoverRow(history),
+    })
+end
+
+-- ── Run history and rollback ─────────────────────────────────────────────────
+
+local function historyRuns()
+    if snapshot == nil or type(snapshot.history) ~= "table" then
+        return {}
+    end
+    return snapshot.history -- newest first
+end
+
+local function findHistoryRun(at)
+    for _, run in ipairs(historyRuns()) do
+        if tonumber(run.at) == tonumber(at) then
+            return run
+        end
+    end
+    return nil
+end
+
+local function describeRun(run)
+    local text = os.date("%d.%m %H:%M", tonumber(run.at) or 0)
+        .. " · " .. noctalia.trp("run_packages", run.n or 0, { count = run.n or 0 })
+    if run.rollback == true then
+        text = text .. " · " .. tr("history_rollback_tag")
+    end
+    return text
+end
+
+-- The footer strip: one equal-width segment per recorded run, oldest on the
+-- left. Hover describes the run, click opens its package list.
+local function historySection()
+    local runs = historyRuns()
+    if #runs == 0 then
+        return nil
+    end
+    local segments = {}
+    for i = #runs, 1, -1 do
+        local run = runs[i]
+        table.insert(segments, ui.button({
+            key = "run-" .. tostring(run.at),
+            -- primary: painted in the theme's accent color, so the strip is
+            -- visible at rest (ghost would only show on hover)
+            variant = "primary",
+            flexGrow = 1,
+            height = 10,
+            tooltip = describeRun(run) .. "\n" .. tr("tip_history_segment"),
+            onClick = function()
+                openedRunAt = run.at
+                armedKey = nil
+                request("probe_run", { at = run.at })
+                render()
+            end,
+        }))
+    end
+    local header = {
+        ui.label({ text = tr("history_title"), fontSize = 11, fontWeight = "bold", color = "on_surface_variant", flexGrow = 1 }),
+    }
+    if snapshot ~= nil and snapshot.checkedAt ~= nil and snapshot.checkedAt ~= "" then
+        table.insert(header, ui.label({
+            text = tr("caption_checked", { time = snapshot.checkedAt }),
+            fontSize = 10,
+            color = "on_surface_variant",
+        }))
+    end
+    return ui.column({ key = "history", gap = 3 }, {
+        ui.row({ key = "history-head", gap = 6, align = "center" }, header),
+        ui.row({ key = "history-segments", gap = 2 }, segments),
+    })
+end
+
+local function probeFor(run)
+    if snapshot ~= nil and type(snapshot.probe) == "table" and tonumber(snapshot.probe.at) == tonumber(run.at) then
+        return snapshot.probe.pkgs
+    end
+    return nil
+end
+
+-- Two-click rollback: the first click arms the button (it turns into a
+-- confirm label), the second sends the request. Anything else re-renders
+-- the armed state away.
+local function rollbackButton(key, tooltip, onConfirm)
+    if armedKey == key then
+        return ui.button({
+            key = key .. "-armed",
+            text = tr("rollback_confirm"), variant = "primary", controlSize = "sm",
+            tooltip = tooltip,
+            onClick = function()
+                armedKey = nil
+                onConfirm()
+            end,
+        })
+    end
+    return ui.button({
+        key = key,
+        glyph = "undo", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+        tooltip = tooltip,
+        onClick = function()
+            armedKey = key
+            render()
+        end,
+    })
+end
+
+local function rollbackRow(run, index, item, probePkgs)
+    local key = "rb-" .. tostring(run.at) .. "-" .. index
+    local info = probePkgs ~= nil and probePkgs[item.name] or nil
+    local children = {}
+
+    if item.source == "flatpak" then
+        table.insert(children, ui.glyph({ name = "app-window", size = 12, color = "on_surface_variant" }))
+    elseif info ~= nil and info.cache ~= true then
+        table.insert(children, ui.button({
+            key = key .. "-miss",
+            glyph = "undo", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+            enabled = false,
+            tooltip = tr("rollback_missing"),
+            onClick = function() end,
+        }))
+    else
+        local tooltip = tr("tip_rollback", { version = tostring(item.from or "") })
+        if info ~= nil and (info.req or 0) > 0 then
+            tooltip = tooltip .. "\n" .. noctalia.trp("rollback_required_by", info.req, { count = info.req })
+        end
+        table.insert(children, rollbackButton(key, tooltip, function()
+            request("rollback", { pkg = item.name, version = item.from, at = run.at })
+        end))
+    end
+
+    table.insert(children, ui.label({ text = item.name, fontSize = 11, color = "on_surface", flexGrow = 1, maxLines = 1 }))
+    if item.from ~= nil and item.from ~= "" then
+        table.insert(children, ui.label({
+            text = item.from, fontSize = 11, color = "on_surface_variant", maxWidth = VERSION_WIDTH, maxLines = 1,
+        }))
+    end
+    table.insert(children, ui.label({ text = "→", fontSize = 11, color = "on_surface_variant" }))
+    table.insert(children, ui.label({
+        text = tostring(item.to or ""), fontSize = 11, color = "primary", maxWidth = VERSION_WIDTH, maxLines = 1,
+    }))
+    return ui.row({ key = key .. "-row", gap = 6, align = "center" }, children)
+end
+
+-- The opened run: header with a back button and a whole-run rollback, then
+-- one row per package showing the run's from -> to and a rollback control.
+local function runViewRows()
+    local run = findHistoryRun(openedRunAt)
+    if run == nil then
+        openedRunAt = nil
+        return nil
+    end
+    local probePkgs = probeFor(run)
+    local rows = {}
+    local header = {
+        ui.button({
+            glyph = "chevron-left", variant = "ghost", controlSize = "sm", width = 22, height = 22, glyphSize = 12,
+            tooltip = tr("action_back"),
+            onClick = function()
+                openedRunAt = nil
+                armedKey = nil
+                render()
+            end,
+        }),
+        ui.label({ text = describeRun(run), fontSize = 12, fontWeight = "bold", color = "on_surface", flexGrow = 1, maxLines = 1 }),
+    }
+    local rollable = 0
+    for _, item in ipairs(run.packages or {}) do
+        if item.source ~= "flatpak" then
+            rollable += 1
+        end
+    end
+    if rollable > 0 and run.rollback ~= true then
+        table.insert(header, rollbackButton("rb-all-" .. tostring(run.at), tr("tip_rollback_run"), function()
+            request("rollback_run", { at = run.at })
+        end))
+    end
+    table.insert(rows, ui.row({ key = "run-head", gap = 6, align = "center" }, header))
+    for index, item in ipairs(run.packages or {}) do
+        table.insert(rows, rollbackRow(run, index, item, probePkgs))
+    end
+    return rows
+end
+
 -- Live tail of the update log, with a progress bar while packages are being
 -- processed. Shown during a run and kept on screen after a failed one.
 local function logSection()
@@ -429,12 +808,14 @@ local function logSection()
     table.insert(children, ui.column({ key = "log-lines", gap = 2, flexGrow = 1 }, rows))
 
     if snapshot ~= nil and type(snapshot.logPath) == "string" and snapshot.logPath ~= "" then
-        local path = snapshot.logPath
         table.insert(children, ui.row({ key = "log-actions", gap = 6 }, {
             ui.button({
                 text = tr("action_open_log"), variant = "ghost", controlSize = "sm",
+                -- Opened by the service in a terminal pager: xdg-open on a
+                -- text file dies silently when the default handler is a
+                -- terminal editor.
                 onClick = function()
-                    openUrl("file://" .. path)
+                    request("open_log")
                 end,
             }),
         }))
@@ -468,8 +849,15 @@ local function extras()
         }))
     end
 
-    -- Offered until the polkit keep-authorization rule is installed.
-    if snapshot.polkitRule == false and phaseOf() ~= "running" and noctalia.getConfig("hide_polkit_hint") ~= true then
+    -- Offered until the polkit keep-authorization rule is installed. Only in
+    -- background mode: a terminal run goes through sudo, so the repeated
+    -- polkit prompts the rule solves never happen there.
+    if
+        snapshot.polkitRule == false
+        and noctalia.getConfig("update_mode") == "background"
+        and phaseOf() ~= "running"
+        and noctalia.getConfig("hide_polkit_hint") ~= true
+    then
         table.insert(lines, ui.row({ key = "polkit", gap = 6, align = "center" }, {
             ui.glyph({ name = "shield", size = 13, color = "on_surface_variant" }),
             ui.label({
@@ -515,10 +903,15 @@ local function body()
     local children = {}
 
     -- The middle of the panel: the live log while updating (and after a
-    -- failure), the package list otherwise.
+    -- failure), an opened history run, or the package list.
     if phaseOf() == "running" or (runFailed() and #logLines() > 0) then
         table.insert(children, logSection())
     else
+        local runRows = openedRunAt ~= nil and runViewRows() or nil
+        if runRows ~= nil then
+            table.insert(children, ui.scroll({ key = "run-view", flexGrow = 1, gap = 4 }, runRows))
+            return children
+        end
         local rows = sourceRows()
         for _, row in ipairs(ignoredRows()) do
             table.insert(rows, row)
@@ -605,15 +998,31 @@ render = function()
         table.insert(children, node)
     end
 
-    local caption = footerCaption()
-    if caption ~= nil then
+    -- Both footers hide while a check or run is on screen, so neither ever
+    -- competes with the live log for space.
+    local activity = not busy() and activitySection() or nil
+    local history = not busy() and historySection() or nil
+    if activity ~= nil or history ~= nil then
         table.insert(children, ui.separator({}))
-        table.insert(children, ui.label({ text = caption, fontSize = 11, color = "on_surface_variant", maxLines = 2 }))
+        if activity ~= nil then
+            table.insert(children, activity)
+        end
+        if history ~= nil then
+            table.insert(children, history)
+        end
+    else
+        local caption = footerCaption()
+        if caption ~= nil then
+            table.insert(children, ui.separator({}))
+            table.insert(children, ui.label({ text = caption, fontSize = 11, color = "on_surface_variant", maxLines = 2 }))
+        end
     end
 
     if phase ~= "missing" then
         local footer = {}
-        if runFailed() then
+        -- Not offered after a failed rollback: re-running the *update*
+        -- command in a terminal is not a retry of the rollback.
+        if runFailed() and (snapshot == nil or snapshot.runKind ~= "rollback") then
             table.insert(footer, ui.button({
                 key = "retry-terminal",
                 glyph = "terminal", text = tr("action_run_terminal"), variant = "ghost", flexGrow = 1,
@@ -631,13 +1040,16 @@ render = function()
                 panel.close()
             end,
         }))
+        local backgroundMode = noctalia.getConfig("update_mode") == "background"
         table.insert(footer, ui.button({
             key = "update" .. (hasUpdates and "" or "-off"),
-            glyph = "download", text = tr("action_update"), variant = "primary", enabled = hasUpdates,
-            tooltip = tr("tip_update"),
+            glyph = backgroundMode and "download" or "terminal",
+            text = tr("action_update"), variant = "primary", enabled = hasUpdates,
+            tooltip = backgroundMode and tr("tip_update") or tr("tip_update_terminal"),
             onClick = function()
                 -- The panel stays open: the log section takes over so the
-                -- run can be watched live.
+                -- run can be watched live (the log is tee'd from the
+                -- terminal too).
                 request("update")
             end,
         }))
@@ -652,6 +1064,9 @@ function onOpen(_context)
     expanded = {}
     hoverKey = nil
     hoverText = ""
+    openedRunAt = nil
+    armedKey = nil
+    activityHoverIndex = nil
     render()
 end
 
@@ -663,6 +1078,10 @@ noctalia.state.watch(STATE_KEY, function(value)
         expanded = {}
         hoverKey = nil
         hoverText = ""
+    end
+    if value.phase == "running" and (snapshot == nil or snapshot.phase ~= "running") then
+        openedRunAt = nil
+        armedKey = nil
     end
     snapshot = value
     render()

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,12 +1,12 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "2.0.0"
+version = "2.4.0"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"
 icon = "package"
-description = "Check pacman, AUR and Flatpak updates, then upgrade in the background with a live log and one polkit password prompt."
-dependencies = ["pacman-contrib", "awk", "flatpak", "pacman", "paru", "pkexec", "sed", "sh", "sudo", "tail", "test", "uname", "xdg-open", "yay"]
+description = "Check pacman, AUR and Flatpak updates, then upgrade in a terminal or in the background, with run history and rollback."
+dependencies = ["pacman-contrib", "awk", "date", "flatpak", "grep", "head", "install", "less", "pacman", "paru", "pkexec", "rm", "sed", "sh", "sudo", "tail", "tee", "test", "uname", "wc", "xdg-open", "yay"]
 tags = ["arch", "bar", "panel", "launcher", "system", "utility"]
 
 # ── General ──────────────────────────────────────────────────────────────────
@@ -86,7 +86,42 @@ label_key = "settings.check_reboot_needed.label"
 description_key = "settings.check_reboot_needed.description"
 default = true
 
+[[setting]]
+key = "show_activity_graph"
+type = "bool"
+label_key = "settings.show_activity_graph.label"
+description_key = "settings.show_activity_graph.description"
+default = false
+
+[[setting]]
+key = "activity_history_length"
+type = "int"
+label_key = "settings.activity_history_length.label"
+description_key = "settings.activity_history_length.description"
+default = 10
+min = 3
+max = 30
+visible_when = { key = "show_activity_graph", values = ["true"] }
+
 # ── Update run ───────────────────────────────────────────────────────────────
+
+[[setting]]
+key = "update_mode"
+type = "select"
+label_key = "settings.update_mode.label"
+description_key = "settings.update_mode.description"
+default = "terminal"
+options = [
+  { value = "terminal", label_key = "settings.update_mode.options.terminal" },
+  { value = "background", label_key = "settings.update_mode.options.background" },
+]
+
+[[setting]]
+key = "rollback_auto_ignore"
+type = "bool"
+label_key = "settings.rollback_auto_ignore.label"
+description_key = "settings.rollback_auto_ignore.description"
+default = false
 
 [[setting]]
 key = "hide_polkit_hint"

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "1.1.0"
+version = "1.1.1"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,12 +1,12 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "1.1.1"
+version = "2.0.0"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"
 icon = "package"
-description = "Check pacman, AUR and Flatpak updates, get an Arch news and reboot heads-up, then upgrade from a terminal."
-dependencies = ["pacman-contrib", "awk", "flatpak", "pacman", "paru", "sed", "sh", "sudo", "test", "uname", "xdg-open", "yay"]
+description = "Check pacman, AUR and Flatpak updates, then upgrade in the background with a live log and one polkit password prompt."
+dependencies = ["pacman-contrib", "awk", "flatpak", "pacman", "paru", "pkexec", "sed", "sh", "sudo", "tail", "test", "uname", "xdg-open", "yay"]
 tags = ["arch", "bar", "panel", "launcher", "system", "utility"]
 
 # ── General ──────────────────────────────────────────────────────────────────
@@ -63,7 +63,7 @@ label_key = "settings.notify_on_updates.label"
 description_key = "settings.notify_on_updates.description"
 default = true
 
-# ── Extras (not in the v4 plugin) ───────────────────────────────────────────
+# ── Extras ───────────────────────────────────────────────────────────────────
 
 [[setting]]
 key = "show_download_size"
@@ -86,26 +86,23 @@ label_key = "settings.check_reboot_needed.label"
 description_key = "settings.check_reboot_needed.description"
 default = true
 
-# ── Activity ─────────────────────────────────────────────────────────────────
-
-[[setting]]
-key = "show_activity_graph"
-type = "bool"
-label_key = "settings.show_activity_graph.label"
-description_key = "settings.show_activity_graph.description"
-default = true
-
-[[setting]]
-key = "activity_history_length"
-type = "int"
-label_key = "settings.activity_history_length.label"
-description_key = "settings.activity_history_length.description"
-default = 10
-min = 3
-max = 30
-visible_when = { key = "show_activity_graph", values = ["true"] }
-
 # ── Update run ───────────────────────────────────────────────────────────────
+
+[[setting]]
+key = "hide_polkit_hint"
+type = "bool"
+label_key = "settings.hide_polkit_hint.label"
+description_key = "settings.hide_polkit_hint.description"
+default = false
+
+[[setting]]
+key = "log_lines"
+type = "int"
+label_key = "settings.log_lines.label"
+description_key = "settings.log_lines.description"
+default = 14
+min = 6
+max = 30
 
 [[setting]]
 key = "terminal"
@@ -113,13 +110,6 @@ type = "string"
 label_key = "settings.terminal.label"
 description_key = "settings.terminal.description"
 default = ""
-
-[[setting]]
-key = "assume_yes"
-type = "bool"
-label_key = "settings.assume_yes.label"
-description_key = "settings.assume_yes.description"
-default = false
 advanced = true
 
 [[setting]]

--- a/arch-updater/polkit/49-arch-updater-pacman.rules
+++ b/arch-updater/polkit/49-arch-updater-pacman.rules
@@ -1,0 +1,25 @@
+/* One polkit password per update run instead of one per pacman transaction.
+ *
+ * paru runs `pkexec pacman ...` separately for the database sync and for
+ * every install transaction, and plain pkexec re-authenticates each time.
+ * AUTH_ADMIN_KEEP caches a successful authentication for ~5 minutes (same
+ * idea as sudo's timestamp), so one password covers the whole run. A build
+ * that takes longer than 5 minutes between transactions may still prompt
+ * again.
+ *
+ * Scope: only pkexec launching /usr/bin/pacman, only for an active local
+ * session of a wheel member.
+ *
+ * Install (root required):
+ *   sudo install -Dm644 polkit/49-arch-updater-pacman.rules /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
+ * Remove:
+ *   sudo rm /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
+ */
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" &&
+        action.lookup("program") == "/usr/bin/pacman" &&
+        subject.active && subject.local &&
+        subject.isInGroup("wheel")) {
+        return polkit.Result.AUTH_ADMIN_KEEP;
+    }
+});

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -1,33 +1,44 @@
 --!nonstrict
 -- arch-updater singleton engine. Checks pacman, the AUR helper and Flatpak,
--- publishes the result as shared state, and runs the update in a terminal.
+-- publishes the result as shared state, and runs the update in the
+-- BACKGROUND: one click, pkexec (polkit) asks for the password, the run is
+-- fully non-interactive (--noconfirm and friends) and its log streams into
+-- the panel.
 --
 --   state    "arch_state"   = { nonce, phase, step, total, pacman, aur,
 --                                flatpak, downloadSizeMiB, rebootRecommended,
---                                newsUnread, newsLatestTitle, err,
---                                checkedAt, ignoredCount, history, lastUpdateAt }
---   requests "arch_request" = { nonce, action }  -- check|update|dismiss
+--                                newsUnread, newsLatestTitle, err, checkedAt,
+--                                ignoredCount, ignoredPending, ignoredDynamic,
+--                                ignoredConfig, logTail, logPath, runExit,
+--                                progress = { done, total } }
+--   requests "arch_request" = { nonce, action, pkg }
+--                              -- check|update|update_terminal|dismiss|open_news
+--                              -- |ignore|unignore (pkg = package name)
 --
--- Checking runs pacman, then the AUR helper, then Flatpak, then (if pacman
--- has pending packages) a `pacman -Si` pass for the download size.
---
--- Update never runs in the background. runUpdate() opens a terminal so
--- pacman/the AUR helper can prompt and sudo can ask for a password, then
--- polls for the process to end and re-checks automatically.
+-- The update run is spawned fully detached (double-fork + setsid), writing to
+-- <plugin data dir>/update.log; it survives a shell restart. The engine polls
+-- the log every RUN_POLL_SECONDS with `tail` and finishes when the runner's
+-- "::EXIT <code>" marker appears. If a run cannot proceed non-interactively
+-- it exits non-zero without touching the system, and the panel offers a
+-- terminal fallback ("update_terminal") where prompts work normally.
 
 local STATE_KEY = "arch_state"
 local REQUEST_KEY = "arch_request"
 local NEWS_FILE = "news_state.json"
+local IGNORE_FILE = "ignore.json"
 local NEWS_URL = "https://archlinux.org/feeds/news/"
 local NEWS_PAGE = "https://archlinux.org/news/"
-local HISTORY_FILE = "history_state.json"
+local LOG_FILE = "update.log"
+local POLKIT_RULE_NAME = "49-arch-updater-pacman.rules"
+local POLKIT_RULE_PATH = "/etc/polkit-1/rules.d/49-arch-updater-pacman.rules"
 
 local CHECK_TIMEOUT_MS = 45000 -- pacman/AUR/flatpak checks: each may sync a mirror
 local SIZE_TIMEOUT_MS = 20000 -- pacman -Si: local db, no mirror sync
-local FAST_TIMEOUT_MS = 5000 -- reboot check: local filesystem only
+local FAST_TIMEOUT_MS = 5000 -- log tail / reboot check: local filesystem only
 local NEWS_RECHECK_HOURS = 6
 local RUN_POLL_SECONDS = 2
-local RUN_GRACE_SECONDS = 12
+local RUN_STALE_LIMIT_S = 1800 -- no log growth for this long = the run is stuck
+local RUN_RESUME_MAX_AGE_S = 6 * 3600 -- older unfinished logs are not resumed
 local AUTO_CHECK_DELAY = 10 -- ticks before an enabled auto-check's first run
 local MAX_LISTED = 300 -- packages kept per source for the panel's expandable list
 
@@ -46,22 +57,26 @@ local checkedAt = ""
 local stateNonce = 0
 local lastRequestNonce = 0
 
-local runTicks = 0
-local runSeen = false
 local runPollTicks = 0
-local updateProcessName = "pacman"
+local runExit = nil -- exit code of the last background run, nil while unknown
+local runDone = 0 -- progress: package lines seen in the log so far
+local runTotal = 0 -- progress: pending count when the run started
+local runStaleS = 0 -- seconds without log growth during a run
+local logTail = {} -- last log lines for the panel
+local lastTailText = ""
 local sinceCheck = 0
 local startupTicks = 0
 local sinceNewsCheck = 0
 local newsStateLoaded = false
 local newsDirty = false
-local history = {} -- { n, at, afterUpdate } per check, oldest first, trimmed to activity_history_length
-local lastUpdateAt = nil -- os.time() of the last update run that finished
-local historyStateLoaded = false
-local checkIsPostUpdate = false -- next finished check followed an update run
+local ignoredPending = {} -- ignored packages that had a pending update in the last check
+local dynamicIgnore = nil -- panel-managed ignore list, persisted in IGNORE_FILE
+local polkitRuleInstalled = nil -- nil until the async check ran, then boolean
+local polkitInstallBusy = false
 
 local startCheck
 local checkNews
+local finishRun
 
 local function cfg(key)
     return noctalia.getConfig(key)
@@ -79,10 +94,67 @@ local function shellQuote(value)
     return "'" .. value:gsub("'", "'\\''") .. "'"
 end
 
+local function logPath()
+    local dir, err = noctalia.pluginDataDir()
+    if dir == nil then
+        noctalia.log("arch-updater: cannot resolve plugin data dir: " .. tostring(err))
+        return nil
+    end
+    return dir .. "/" .. LOG_FILE
+end
+
 -- Package names reach the command line (--ignore, pacman -Si), so only
 -- pacman's own name grammar is accepted. Anything else is dropped with a log
 -- line instead of being quoted.
-local function ignoreList()
+local function validName(name)
+    return name:match("^[a-zA-Z0-9._+-]+$") ~= nil
+end
+
+-- Two plugin-side ignore sources: the "ignore_packages" setting and a
+-- panel-managed list in IGNORE_FILE (the panel cannot write settings).
+-- pacman.conf's IgnorePkg arrives from the checkers as "[ignored]" lines
+-- and is displayed only, never managed here.
+local function ignorePath()
+    local dir, err = noctalia.pluginDataDir()
+    if dir == nil then
+        noctalia.log("arch-updater: cannot resolve plugin data dir: " .. tostring(err))
+        return nil
+    end
+    return dir .. "/" .. IGNORE_FILE
+end
+
+local function loadDynamicIgnore()
+    if dynamicIgnore ~= nil then
+        return
+    end
+    dynamicIgnore = {}
+    local path = ignorePath()
+    local encoded = path ~= nil and noctalia.readFile(path) or nil
+    local ok, decoded = pcall(function()
+        return encoded ~= nil and noctalia.json.decode(encoded) or nil
+    end)
+    if ok and type(decoded) == "table" and type(decoded.packages) == "table" then
+        for _, entry in ipairs(decoded.packages) do
+            local name = trim(tostring(entry))
+            if validName(name) then
+                table.insert(dynamicIgnore, name)
+            end
+        end
+    end
+end
+
+local function saveDynamicIgnore()
+    local path = ignorePath()
+    if path == nil then
+        return
+    end
+    local encoded = noctalia.json.encode({ packages = dynamicIgnore })
+    if encoded ~= nil then
+        noctalia.writeFile(path, encoded)
+    end
+end
+
+local function configIgnoreList()
     local raw = cfg("ignore_packages")
     if type(raw) ~= "table" then
         return {}
@@ -90,10 +162,29 @@ local function ignoreList()
     local names = {}
     for _, entry in ipairs(raw) do
         local name = trim(tostring(entry))
-        if name:match("^[a-zA-Z0-9._+-]+$") ~= nil then
+        if validName(name) then
             table.insert(names, name)
         elseif name ~= "" then
             noctalia.log("arch-updater: ignoring invalid package name '" .. name .. "'")
+        end
+    end
+    return names
+end
+
+local function ignoreList()
+    loadDynamicIgnore()
+    local names = {}
+    local seen = {}
+    for _, name in ipairs(configIgnoreList()) do
+        if not seen[name] then
+            seen[name] = true
+            table.insert(names, name)
+        end
+    end
+    for _, name in ipairs(dynamicIgnore) do
+        if not seen[name] then
+            seen[name] = true
+            table.insert(names, name)
         end
     end
     return names
@@ -110,7 +201,9 @@ end
 -- ── Parsing ──────────────────────────────────────────────────────────────────
 
 -- One "name oldver -> newver" line per package: checkupdates' format, which
--- yay -Qua and paru -Qua also use.
+-- yay -Qua and paru -Qua also use. A trailing "[ignored]" is pacman.conf's
+-- IgnorePkg: the run skips those, so they go to ignoredPending instead of
+-- the pending count.
 local function parseVersionLines(output, ignored)
     local items = {}
     local n = 0
@@ -119,10 +212,17 @@ local function parseVersionLines(output, ignored)
         for token in line:gmatch("%S+") do
             table.insert(parts, token)
         end
-        if #parts >= 4 and not ignored[parts[1]] then
-            n += 1
-            if #items < MAX_LISTED then
-                table.insert(items, { name = parts[1], from = parts[2], to = parts[4] })
+        if #parts >= 4 then
+            local name, from, to = parts[1], parts[2], parts[4]
+            if parts[#parts] == "[ignored]" then
+                table.insert(ignoredPending, { name = name, from = from, to = to, source = "system" })
+            elseif ignored[name] then
+                table.insert(ignoredPending, { name = name, from = from, to = to, source = "plugin" })
+            else
+                n += 1
+                if #items < MAX_LISTED then
+                    table.insert(items, { name = name, from = from, to = to })
+                end
             end
         end
     end
@@ -140,10 +240,14 @@ local function parseTabLines(output, ignored)
             table.insert(fields, field)
         end
         local name = fields[1] or ""
-        if name ~= "" and not ignored[name] then
-            n += 1
-            if #items < MAX_LISTED then
-                table.insert(items, { name = name, from = fields[2] or "", to = fields[3] or "" })
+        if name ~= "" then
+            if ignored[name] then
+                table.insert(ignoredPending, { name = name, from = fields[2] or "", to = fields[3] or "", source = "plugin" })
+            else
+                n += 1
+                if #items < MAX_LISTED then
+                    table.insert(items, { name = name, from = fields[2] or "", to = fields[3] or "" })
+                end
             end
         end
     end
@@ -204,9 +308,15 @@ local function publish()
         err = errMsg,
         checkedAt = checkedAt,
         ignoredCount = #ignoreList(),
-        history = history,
-        lastUpdateAt = lastUpdateAt,
-        flatpakEnabled = cfg("flatpak_enabled") == true,
+        ignoredPending = ignoredPending,
+        ignoredDynamic = dynamicIgnore or {},
+        ignoredConfig = configIgnoreList(),
+        polkitRule = polkitRuleInstalled,
+        flatpakEnabled = cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak"),
+        logTail = logTail,
+        logPath = logPath(),
+        runExit = runExit,
+        progress = { done = runDone, total = runTotal },
     })
 end
 
@@ -216,7 +326,6 @@ local checkFlatpak
 local checkSize
 local checkReboot
 local finishCheck
-local recordCheck
 
 local function failCheck(message)
     phase = "error"
@@ -383,7 +492,7 @@ local function checkAur(ignored)
 end
 
 startCheck = function()
-    if phase == "checking" then
+    if phase == "checking" or phase == "running" then
         return
     end
     if not noctalia.commandExists("checkupdates") then
@@ -397,6 +506,7 @@ startCheck = function()
     errMsg = nil
     sources = { pacman = { n = 0, items = {} }, aur = { n = 0, items = {}, helper = "" }, flatpak = { n = 0, items = {} } }
     downloadSizeMiB = nil
+    ignoredPending = {}
     step = tr("source.pacman")
     publish()
 
@@ -431,7 +541,6 @@ finishCheck = function()
     phase = total > 0 and "ready" or "clean"
     checkedAt = noctalia.formatTime("%H:%M")
     sinceCheck = 0
-    recordCheck()
     publish()
     if total > 0 and cfg("notify_on_updates") == true then
         noctalia.notify(tr("title"), noctalia.trp("notify_updates", total, { count = total }))
@@ -473,92 +582,6 @@ local function saveNewsState()
     if encoded ~= nil then
         noctalia.writeFile(path, encoded)
     end
-end
-
--- ── Activity history ─────────────────────────────────────────────────────────
-
-local function historyStatePath()
-    local dir, err = noctalia.pluginDataDir()
-    if dir == nil then
-        noctalia.log("arch-updater: cannot resolve plugin data dir: " .. tostring(err))
-        return nil
-    end
-    return dir .. "/" .. HISTORY_FILE
-end
-
-local function loadHistoryState()
-    if historyStateLoaded then
-        return
-    end
-    historyStateLoaded = true
-    local path = historyStatePath()
-    local encoded = path ~= nil and noctalia.readFile(path) or nil
-    local ok, decoded = pcall(function()
-        return encoded ~= nil and noctalia.json.decode(encoded) or nil
-    end)
-    if ok and type(decoded) == "table" then
-        if type(decoded.history) == "table" then
-            -- Migrates the old format (a plain array of counts) to entries with
-            -- a timestamp and an afterUpdate flag, both unknown for old data.
-            local migrated = {}
-            for _, entry in ipairs(decoded.history) do
-                if type(entry) == "table" then
-                    table.insert(migrated, {
-                        n = tonumber(entry.n) or 0,
-                        at = tonumber(entry.at),
-                        afterUpdate = entry.afterUpdate == true,
-                    })
-                elseif type(entry) == "number" then
-                    table.insert(migrated, { n = entry, at = nil, afterUpdate = false })
-                end
-            end
-            history = migrated
-        end
-        if type(decoded.lastUpdateAt) == "number" then
-            lastUpdateAt = decoded.lastUpdateAt
-        end
-    end
-end
-
-local function saveHistoryState()
-    local path = historyStatePath()
-    if path == nil then
-        return
-    end
-    local encoded = noctalia.json.encode({ history = history, lastUpdateAt = lastUpdateAt })
-    if encoded ~= nil then
-        noctalia.writeFile(path, encoded)
-    end
-end
-
--- Appends the current total to the activity history, trimmed to the
--- configured length. A no-op when the graph is turned off, so disabling it
--- also stops collecting data, not just hides it.
-recordCheck = function()
-    local wasPostUpdate = checkIsPostUpdate
-    checkIsPostUpdate = false
-    if cfg("show_activity_graph") ~= true then
-        return
-    end
-    loadHistoryState()
-    table.insert(history, { n = total, at = os.time(), afterUpdate = wasPostUpdate })
-    local maxLen = math.max(3, math.min(30, tonumber(cfg("activity_history_length")) or 10))
-    while #history > maxLen do
-        table.remove(history, 1)
-    end
-    saveHistoryState()
-end
-
--- Marks the check that follows as the one that verifies an update run, so its
--- history entry can say "Updated" instead of just a pending count.
-local function recordUpdateRun()
-    checkIsPostUpdate = true
-    if cfg("show_activity_graph") ~= true then
-        return
-    end
-    loadHistoryState()
-    lastUpdateAt = os.time()
-    saveHistoryState()
 end
 
 local HTML_ENTITIES = {
@@ -649,7 +672,164 @@ local function openNews()
     noctalia.runAsync("xdg-open " .. shellQuote(NEWS_PAGE) .. " >/dev/null 2>&1")
 end
 
--- ── Updating ─────────────────────────────────────────────────────────────────
+-- ── Polkit rule ──────────────────────────────────────────────────────────────
+
+-- Without this rule pkexec re-authenticates every pacman transaction of a
+-- run (db sync + each install batch = several password dialogs); with it
+-- one password covers the whole run. Embedded because the plugin's own
+-- directory is not exposed to Lua; keep in sync with polkit/*.rules.
+local POLKIT_RULE = [=[/* Installed by the arch-updater Noctalia plugin (one password per update
+ * run instead of one per pacman transaction). Authentication is kept for
+ * ~5 minutes, like sudo's timestamp. Scope: only pkexec launching
+ * /usr/bin/pacman, only for an active local session of a wheel member.
+ * Remove: sudo rm /etc/polkit-1/rules.d/49-arch-updater-pacman.rules
+ */
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" &&
+        action.lookup("program") == "/usr/bin/pacman" &&
+        subject.active && subject.local &&
+        subject.isInGroup("wheel")) {
+        return polkit.Result.AUTH_ADMIN_KEEP;
+    }
+});
+]=]
+
+-- /etc/polkit-1/rules.d is 750 root:polkitd on Arch, so an unprivileged
+-- `test -f` cannot see the rule. Three answers: file visible (yes),
+-- directory readable without the file (no), directory opaque — then a
+-- marker written on successful install is the best available memory. Worst
+-- case is a missing hint, never a broken update.
+local function polkitMarkerPath()
+    local dir = noctalia.pluginDataDir()
+    return dir ~= nil and (dir .. "/polkit_rule_installed") or nil
+end
+
+local function checkPolkitRule()
+    local cmd = "if [ -f " .. POLKIT_RULE_PATH .. " ]; then echo yes;"
+        .. " elif [ -r /etc/polkit-1/rules.d ]; then echo no;"
+        .. " else echo opaque; fi"
+    noctalia.runAsync(cmd, function(result)
+        local answer = trim(result.stdout or "")
+        if answer == "yes" then
+            polkitRuleInstalled = true
+        elseif answer == "no" then
+            polkitRuleInstalled = false
+            local marker = polkitMarkerPath()
+            if marker ~= nil then
+                noctalia.runAsync("rm -f " .. shellQuote(marker))
+            end
+        elseif answer == "opaque" then
+            local marker = polkitMarkerPath()
+            polkitRuleInstalled = marker ~= nil and noctalia.readFile(marker) ~= nil
+        else
+            return
+        end
+        publish()
+    end, FAST_TIMEOUT_MS)
+end
+
+-- The rule text is staged in the data dir because pkexec needs a file
+-- path; polkit picks up rules.d changes on the fly.
+local function installPolkitRule()
+    if polkitInstallBusy or not noctalia.commandExists("pkexec") then
+        return
+    end
+    local dir = noctalia.pluginDataDir()
+    if dir == nil then
+        return
+    end
+    local staged = dir .. "/" .. POLKIT_RULE_NAME
+    noctalia.writeFile(staged, POLKIT_RULE)
+    polkitInstallBusy = true
+    local cmd = "pkexec install -Dm644 -o root -g root " .. shellQuote(staged) .. " " .. POLKIT_RULE_PATH
+    local started = noctalia.runAsync(cmd, function(result)
+        polkitInstallBusy = false
+        if result.exitCode == 0 then
+            -- Recorded in the marker because rules.d is opaque to the user.
+            local marker = polkitMarkerPath()
+            if marker ~= nil then
+                noctalia.writeFile(marker, "1")
+            end
+            polkitRuleInstalled = true
+            publish()
+            noctalia.notify(tr("title"), tr("notify_polkit_ok"))
+        elseif result.exitCode ~= 126 then
+            -- 126 = the polkit dialog was dismissed; anything else failed.
+            noctalia.notifyError(tr("title"), tr("err_polkit_install"))
+            checkPolkitRule()
+        end
+    end, 120000)
+    if not started then
+        polkitInstallBusy = false
+    end
+end
+
+-- ── Updating (background) ────────────────────────────────────────────────────
+
+-- The core upgrade command, fully non-interactive. pkexec raises the polkit
+-- password dialog; --noconfirm answers every remaining question with its
+-- default. AUR helpers run as the user and escalate through pkexec themselves
+-- (--sudo pkexec), so no terminal and no sudo tty are ever needed.
+local function buildBackgroundCommand()
+    local override = trim(cfg("update_cmd"))
+    if override ~= "" then
+        return override
+    end
+
+    local ignored = ignoreList()
+    local ignoreFlag = #ignored > 0 and (" --ignore " .. table.concat(ignored, ",")) or ""
+    local quietFlags = " --noconfirm --noprogressbar --color never"
+
+    local helper = resolveAurHelper()
+    local parts = {}
+    if helper ~= nil and helper ~= "custom" and noctalia.commandExists(helper) then
+        local autoAnswers = helper == "paru" and " --skipreview"
+            or " --answerdiff None --answerclean None --answeredit None"
+        table.insert(parts, helper .. " -Syu --sudo pkexec" .. autoAnswers .. quietFlags .. ignoreFlag)
+    else
+        table.insert(parts, "pkexec pacman -Syu" .. quietFlags .. ignoreFlag)
+    end
+
+    if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
+        if #ignored > 0 then
+            -- Same ignore list as pacman/AUR: filter ignored refs out of the
+            -- pending Flatpak list before updating, so an app hidden from the
+            -- panel's count can't still slip in through a bare `flatpak update`.
+            local skipList = shellQuote(table.concat(ignored, "\n"))
+            table.insert(
+                parts,
+                "{ flatpak_refs=$(flatpak remote-ls --updates --columns=application 2>/dev/null | awk -v ignore="
+                    .. skipList
+                    .. [=[ 'BEGIN { n = split(ignore, arr, "\n"); for (i = 1; i <= n; i++) skip[arr[i]] = 1 } !($0 in skip)'); ]=]
+                    .. [[if [ -n "$flatpak_refs" ]; then flatpak update -y --noninteractive $flatpak_refs; fi; }]]
+            )
+        else
+            table.insert(parts, "flatpak update -y --noninteractive")
+        end
+    end
+
+    return table.concat(parts, " && ")
+end
+
+-- Interactive variant for the terminal fallback: no --noconfirm, prompts and
+-- the PKGBUILD review work as usual. Output is tee'd into the same log so the
+-- engine still sees the "::EXIT" marker and re-checks when the run ends.
+local function buildTerminalCommand()
+    local ignored = ignoreList()
+    local ignoreFlag = #ignored > 0 and (" --ignore " .. table.concat(ignored, ",")) or ""
+
+    local helper = resolveAurHelper()
+    local parts = {}
+    if helper ~= nil and helper ~= "custom" and noctalia.commandExists(helper) then
+        table.insert(parts, helper .. " -Syu" .. ignoreFlag)
+    else
+        table.insert(parts, "sudo pacman -Syu" .. ignoreFlag)
+    end
+    if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
+        table.insert(parts, "flatpak update")
+    end
+    return table.concat(parts, " && ")
+end
 
 -- Uses Noctalia's terminal discovery ($TERMINAL, then the usual emulators)
 -- unless a terminal is configured.
@@ -664,53 +844,18 @@ local function launchTerminal(cmd)
     return noctalia.runAsync(term .. " " .. separator .. " sh -lc " .. shellQuote(cmd))
 end
 
--- Builds the update command from the AUR helper, ignore list and Flatpak
--- settings. "update_cmd" overrides it outright, for cases the built default
--- doesn't cover.
-local function buildUpdateCommand()
-    local override = trim(cfg("update_cmd"))
-    if override ~= "" then
-        updateProcessName = "pacman"
-        return override
-    end
-
-    local ignored = ignoreList()
-    local ignoreFlag = #ignored > 0 and (" --ignore " .. table.concat(ignored, ",")) or ""
-    local yesFlag = cfg("assume_yes") == true and " --noconfirm" or ""
-
-    local helper = resolveAurHelper()
-    local parts = {}
-    if helper ~= nil and helper ~= "custom" and noctalia.commandExists(helper) then
-        table.insert(parts, helper .. " -Syu" .. yesFlag .. ignoreFlag)
-        updateProcessName = helper
-    else
-        table.insert(parts, "sudo pacman -Syu" .. yesFlag .. ignoreFlag)
-        updateProcessName = "pacman"
-    end
-
-    if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
-        local flatpakYes = cfg("assume_yes") == true and " -y" or ""
-        if #ignored > 0 then
-            -- Same ignore list as pacman/AUR: filter ignored refs out of the
-            -- pending Flatpak list before updating, so an app hidden from the
-            -- panel's count can't still slip in through a bare `flatpak update`.
-            local skipList = shellQuote(table.concat(ignored, "\n"))
-            table.insert(
-                parts,
-                "flatpak_refs=$(flatpak remote-ls --updates --columns=application 2>/dev/null | awk -v ignore="
-                    .. skipList
-                    .. [=[ 'BEGIN { n = split(ignore, arr, "\n"); for (i = 1; i <= n; i++) skip[arr[i]] = 1 } !($0 in skip)'); ]=]
-                    .. [[if [ -n "$flatpak_refs" ]; then flatpak update]]
-                    .. flatpakYes
-                    .. [[ $flatpak_refs; fi]]
-            )
-        else
-            table.insert(parts, "flatpak update" .. flatpakYes)
-        end
-    end
-
-    table.insert(parts, "echo; echo " .. shellQuote(tr("run.press_key")) .. "; read -n 1")
-    return table.concat(parts, "; ")
+local function beginRun()
+    phase = "running"
+    errMsg = nil
+    step = ""
+    runExit = nil
+    runDone = 0
+    runTotal = total
+    runStaleS = 0
+    runPollTicks = 0
+    logTail = {}
+    lastTailText = ""
+    publish()
 end
 
 local function runUpdate()
@@ -723,62 +868,262 @@ local function runUpdate()
         publish()
         return
     end
-    if not launchTerminal(buildUpdateCommand()) then
+    if not noctalia.commandExists("pkexec") then
+        phase = "error"
+        errMsg = tr("err_no_pkexec")
+        publish()
+        noctalia.notifyError(tr("title"), tr("err_no_pkexec"))
+        return
+    end
+    local path = logPath()
+    if path == nil then
+        phase = "error"
+        errMsg = tr("err_spawn")
+        publish()
+        return
+    end
+
+    -- "::START <epoch>" lets a restarted engine tell a live run from a stale
+    -- log; "::EXIT <code>" is the completion marker the poller waits for.
+    local quoted = shellQuote(path)
+    local script = "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+        .. "; { " .. buildBackgroundCommand() .. " ; } >> " .. quoted .. " 2>&1"
+        .. "; printf '::EXIT %s\\n' \"$?\" >> " .. quoted
+
+    if not noctalia.runAsync(script) then
+        phase = "error"
+        errMsg = tr("err_spawn")
+        publish()
+        return
+    end
+    beginRun()
+end
+
+local function runUpdateTerminal()
+    if phase == "running" or phase == "checking" then
+        return
+    end
+    local path = logPath()
+    if path == nil then
+        return
+    end
+    local quoted = shellQuote(path)
+    local wrapped = "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+        .. "; { " .. buildTerminalCommand() .. "; printf '::EXIT %s\\n' \"$?\" ; } 2>&1 | tee -a " .. quoted
+        .. "; echo; echo " .. shellQuote(tr("run.press_key")) .. "; read -n 1"
+    if not launchTerminal(wrapped) then
         phase = "error"
         errMsg = tr("err_no_terminal")
         publish()
         noctalia.notifyError(tr("title"), tr("err_no_terminal"))
         return
     end
-    phase = "running"
-    errMsg = nil
-    step = ""
-    runTicks = 0
-    runPollTicks = 0
-    runSeen = false
-    publish()
+    beginRun()
 end
 
--- Polls for the update process. Seeing it then losing it means the run
--- ended, and triggers a re-check. Never seeing it within the grace period
--- re-checks anyway instead of sitting in "running" forever.
-local function pollRun()
-    runPollTicks += 1
-    if runPollTicks < RUN_POLL_SECONDS then
+finishRun = function(code)
+    runExit = code
+    runStaleS = 0
+    if code == 0 then
+        noctalia.notify(tr("title"), tr("notify_run_ok"))
+        phase = "clean"
+        publish()
+        startCheck() -- verify: phase becomes checking, then clean/ready
+    else
+        phase = "error"
+        errMsg = tr("err_run_failed", { code = tostring(code) })
+        publish()
+        noctalia.notifyError(tr("title"), errMsg)
+    end
+end
+
+local function stripAnsi(line)
+    return (line:gsub("\27%[[%d;]*[A-Za-z]", ""):gsub("\r", ""))
+end
+
+local function isProgressLine(line)
+    return line:match("^upgrading ") ~= nil
+        or line:match("^installing ") ~= nil
+        or line:match("^reinstalling ") ~= nil
+        or line:match("^downgrading ") ~= nil
+end
+
+-- One `tail` per poll: the last screenful for display plus a full-file
+-- progress count, so the bar doesn't reset when early lines scroll out of
+-- the tail window.
+local function pollRunLog()
+    local path = logPath()
+    if path == nil then
         return
     end
-    runPollTicks = 0
-    noctalia.processMatches(function(matched)
+    local keep = math.max(6, math.min(30, tonumber(cfg("log_lines")) or 14))
+    local quoted = shellQuote(path)
+    local cmd = "tail -n " .. tostring(keep + 8) .. " " .. quoted .. " 2>/dev/null"
+        .. "; printf '::COUNT %s\\n' \"$(grep -cE '^(upgrading|installing|reinstalling|downgrading) ' " .. quoted .. " 2>/dev/null)\""
+    local started = noctalia.runAsync(cmd, function(result)
         if phase ~= "running" then
             return
         end
-        if matched then
-            runSeen = true
+        local text = result.stdout or ""
+        if text == lastTailText then
+            runStaleS += RUN_POLL_SECONDS
+            if runStaleS >= RUN_STALE_LIMIT_S then
+                finishRun(-1)
+            end
             return
         end
-        if runSeen or runTicks >= RUN_GRACE_SECONDS then
-            recordUpdateRun()
-            startCheck()
+        lastTailText = text
+        runStaleS = 0
+
+        local lines = {}
+        local exitCode = nil
+        for line in text:gmatch("[^\n]+") do
+            local exitMatch = line:match("^::EXIT (%-?%d+)")
+            local countMatch = line:match("^::COUNT (%d+)")
+            if exitMatch ~= nil then
+                exitCode = tonumber(exitMatch)
+            elseif countMatch ~= nil then
+                runDone = tonumber(countMatch) or runDone
+            elseif line:match("^::START ") == nil then
+                line = stripAnsi(line)
+                if trim(line) ~= "" then
+                    table.insert(lines, line)
+                end
+            end
         end
-    end, updateProcessName)
+        local tail = {}
+        for i = math.max(1, #lines - keep + 1), #lines do
+            table.insert(tail, lines[i])
+        end
+        logTail = tail
+
+        if exitCode ~= nil then
+            finishRun(exitCode)
+        else
+            publish()
+        end
+    end, FAST_TIMEOUT_MS)
+    if not started then
+        noctalia.log("arch-updater: could not poll the update log")
+    end
+end
+
+-- A fresh engine (login, shell restart) re-attaches to an unfinished run:
+-- the detached updater survives Noctalia, so an update.log with a recent
+-- ::START and no ::EXIT means it is still going.
+local function resumeRunIfActive()
+    local path = logPath()
+    if path == nil then
+        return
+    end
+    local quoted = shellQuote(path)
+    local cmd = "head -n 1 " .. quoted .. " 2>/dev/null; tail -n 3 " .. quoted .. " 2>/dev/null"
+    local started = noctalia.runAsync(cmd, function(result)
+        if phase ~= "idle" then
+            return
+        end
+        local text = result.stdout or ""
+        local startedAt = tonumber(text:match("::START (%d+)"))
+        if startedAt == nil then
+            return
+        end
+        if text:match("::EXIT %-?%d+") ~= nil then
+            return
+        end
+        if os.time() - startedAt > RUN_RESUME_MAX_AGE_S then
+            return
+        end
+        beginRun()
+    end, FAST_TIMEOUT_MS)
+    if not started then
+        noctalia.log("arch-updater: could not inspect the update log")
+    end
 end
 
 -- ── Requests, lifecycle ──────────────────────────────────────────────────────
 
-local function handle(action)
+-- Persists in IGNORE_FILE and takes effect immediately by moving the
+-- package out of the current snapshot; n is only decremented when the
+-- package was actually listed (entries beyond MAX_LISTED have no name).
+local function addIgnore(pkg)
+    local name = trim(tostring(pkg or ""))
+    if not validName(name) then
+        return
+    end
+    loadDynamicIgnore()
+    for _, existing in ipairs(ignoreList()) do
+        if existing == name then
+            return
+        end
+    end
+    table.insert(dynamicIgnore, name)
+    saveDynamicIgnore()
+    for _, entry in ipairs({ sources.pacman, sources.aur, sources.flatpak }) do
+        for index, item in ipairs(entry.items or {}) do
+            if item.name == name then
+                table.remove(entry.items, index)
+                entry.n = math.max(0, (entry.n or 0) - 1)
+                table.insert(ignoredPending, { name = item.name, from = item.from, to = item.to, source = "plugin" })
+                break
+            end
+        end
+    end
+    total = sources.pacman.n + sources.aur.n + sources.flatpak.n
+    if phase == "ready" and total == 0 then
+        phase = "clean"
+    end
+    publish()
+end
+
+-- Only the panel-managed list is editable here; settings entries and
+-- pacman.conf's IgnorePkg are managed where they live.
+local function removeIgnore(pkg)
+    local name = trim(tostring(pkg or ""))
+    if name == "" then
+        return
+    end
+    loadDynamicIgnore()
+    local found = false
+    for index, existing in ipairs(dynamicIgnore) do
+        if existing == name then
+            table.remove(dynamicIgnore, index)
+            found = true
+            break
+        end
+    end
+    if not found then
+        return
+    end
+    saveDynamicIgnore()
+    -- A recheck brings the package's pending update (if any) back.
+    if phase ~= "running" and phase ~= "checking" then
+        startCheck()
+    else
+        publish()
+    end
+end
+
+local function handle(action, pkg)
     if action == "check" then
-        -- Also works as a manual unstick: if the process-poll heuristic in
-        -- pollRun() ever misses the update finishing, this forces a re-check
-        -- instead of leaving the UI stuck on "running".
         startCheck()
     elseif action == "update" then
         runUpdate()
+    elseif action == "update_terminal" then
+        runUpdateTerminal()
+    elseif action == "ignore" then
+        addIgnore(pkg)
+    elseif action == "unignore" then
+        removeIgnore(pkg)
+    elseif action == "polkit_install" then
+        installPolkitRule()
     elseif action == "dismiss" then
         sources.pacman = { n = 0, items = {} }
         sources.aur = { n = 0, items = {}, helper = sources.aur.helper }
         sources.flatpak = { n = 0, items = {} }
         total = 0
         downloadSizeMiB = nil
+        runExit = nil
+        logTail = {}
         phase = "clean"
         publish()
     elseif action == "open_news" then
@@ -795,21 +1140,32 @@ noctalia.state.watch(REQUEST_KEY, function(value)
         return
     end
     lastRequestNonce = nonce
-    handle(value.action)
+    handle(value.action, value.pkg)
 end)
 
 -- Scriptable control:
 --   noctalia msg plugin yuuto/arch-updater:service all check
 --   noctalia msg plugin yuuto/arch-updater:service all update
+--   noctalia msg plugin yuuto/arch-updater:service all update_terminal
 --   noctalia msg plugin yuuto/arch-updater:service all dismiss
-function onIpc(event, _payload)
-    handle(event)
+--   noctalia msg plugin yuuto/arch-updater:service all ignore:NAME
+--   noctalia msg plugin yuuto/arch-updater:service all unignore:NAME
+function onIpc(event, payload)
+    local action, arg = tostring(event):match("^(%w+):(.+)$")
+    if action ~= nil then
+        handle(action, arg)
+    else
+        handle(event, payload)
+    end
 end
 
 function update()
     if phase == "running" then
-        runTicks += 1
-        pollRun()
+        runPollTicks += 1
+        if runPollTicks >= RUN_POLL_SECONDS then
+            runPollTicks = 0
+            pollRunLog()
+        end
     elseif phase ~= "checking" then
         local hours = tonumber(cfg("auto_check_hours")) or 0
         if hours > 0 then
@@ -832,8 +1188,7 @@ function update()
         -- Fires once at startup (== AUTO_CHECK_DELAY), then every
         -- NEWS_RECHECK_HOURS. Resetting back to AUTO_CHECK_DELAY (not 0)
         -- keeps the "== AUTO_CHECK_DELAY" branch from re-firing every 10
-        -- seconds, which would trip the health watchdog and get the whole
-        -- plugin auto-disabled.
+        -- seconds.
         if sinceNewsCheck == AUTO_CHECK_DELAY or sinceNewsCheck >= NEWS_RECHECK_HOURS * 3600 + AUTO_CHECK_DELAY then
             if sinceNewsCheck > AUTO_CHECK_DELAY then
                 sinceNewsCheck = AUTO_CHECK_DELAY
@@ -853,5 +1208,6 @@ if not noctalia.commandExists("checkupdates") then
     phase = "missing"
     errMsg = tr("err_no_checkupdates")
 end
-loadHistoryState() -- so the graph shows prior sessions' data before the first check runs
 publish()
+resumeRunIfActive()
+checkPolkitRule()

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -829,8 +829,15 @@ function update()
 
     if cfg("check_arch_news") == true then
         sinceNewsCheck += 1
-        if sinceNewsCheck >= NEWS_RECHECK_HOURS * 3600 or sinceNewsCheck == AUTO_CHECK_DELAY then
-            sinceNewsCheck = 0
+        -- Fires once at startup (== AUTO_CHECK_DELAY), then every
+        -- NEWS_RECHECK_HOURS. Resetting back to AUTO_CHECK_DELAY (not 0)
+        -- keeps the "== AUTO_CHECK_DELAY" branch from re-firing every 10
+        -- seconds, which would trip the health watchdog and get the whole
+        -- plugin auto-disabled.
+        if sinceNewsCheck == AUTO_CHECK_DELAY or sinceNewsCheck >= NEWS_RECHECK_HOURS * 3600 + AUTO_CHECK_DELAY then
+            if sinceNewsCheck > AUTO_CHECK_DELAY then
+                sinceNewsCheck = AUTO_CHECK_DELAY
+            end
             checkNews()
         end
     end

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -9,23 +9,36 @@
 --                                flatpak, downloadSizeMiB, rebootRecommended,
 --                                newsUnread, newsLatestTitle, err, checkedAt,
 --                                ignoredCount, ignoredPending, ignoredDynamic,
---                                ignoredConfig, logTail, logPath, runExit,
+--                                ignoredConfig, history, activity, lastUpdateAt,
+--                                logTail, logPath, runExit,
 --                                progress = { done, total } }
 --   requests "arch_request" = { nonce, action, pkg }
---                              -- check|update|update_terminal|dismiss|open_news
+--                              -- check|update|update_background|update_terminal
+--                              -- |dismiss|open_news
 --                              -- |ignore|unignore (pkg = package name)
+--
+-- "update" follows the update_mode setting: "terminal" (default, like the
+-- original plugin) opens a terminal window where prompts and the PKGBUILD
+-- review work as usual; "background" runs non-interactively as described
+-- above. Both write to the same log, so the panel's live tail, the progress
+-- bar and the history strip work in either mode.
 --
 -- The update run is spawned fully detached (double-fork + setsid), writing to
 -- <plugin data dir>/update.log; it survives a shell restart. The engine polls
 -- the log every RUN_POLL_SECONDS with `tail` and finishes when the runner's
--- "::EXIT <code>" marker appears. If a run cannot proceed non-interactively
--- it exits non-zero without touching the system, and the panel offers a
--- terminal fallback ("update_terminal") where prompts work normally.
+-- "::EXIT <code>" marker appears. If a background run cannot proceed
+-- non-interactively it exits non-zero without touching the system, and the
+-- panel offers a terminal retry where prompts work normally.
 
 local STATE_KEY = "arch_state"
 local REQUEST_KEY = "arch_request"
 local NEWS_FILE = "news_state.json"
 local IGNORE_FILE = "ignore.json"
+local RUNS_FILE = "runs.json"
+local RUN_META_FILE = "run_meta.json"
+local ACTIVITY_FILE = "history_state.json" -- upstream's activity-graph data, name kept for compatibility
+local MAX_RUNS = 15 -- update runs kept for the history strip / rollback
+local MAX_RUN_PACKAGES = 100 -- per-run package list cap (storage and state)
 local NEWS_URL = "https://archlinux.org/feeds/news/"
 local NEWS_PAGE = "https://archlinux.org/news/"
 local LOG_FILE = "update.log"
@@ -37,7 +50,7 @@ local SIZE_TIMEOUT_MS = 20000 -- pacman -Si: local db, no mirror sync
 local FAST_TIMEOUT_MS = 5000 -- log tail / reboot check: local filesystem only
 local NEWS_RECHECK_HOURS = 6
 local RUN_POLL_SECONDS = 2
-local RUN_STALE_LIMIT_S = 1800 -- no log growth for this long = the run is stuck
+local RUN_STALE_LIMIT_S = 1800 -- no log growth for this long = the background run is stuck
 local RUN_RESUME_MAX_AGE_S = 6 * 3600 -- older unfinished logs are not resumed
 local AUTO_CHECK_DELAY = 10 -- ticks before an enabled auto-check's first run
 local MAX_LISTED = 300 -- packages kept per source for the panel's expandable list
@@ -66,6 +79,7 @@ local logTail = {} -- last log lines for the panel
 local lastTailText = ""
 local sinceCheck = 0
 local startupTicks = 0
+local resumeProbed = false -- resumeRunIfActive's log probe has answered
 local sinceNewsCheck = 0
 local newsStateLoaded = false
 local newsDirty = false
@@ -73,6 +87,15 @@ local ignoredPending = {} -- ignored packages that had a pending update in the l
 local dynamicIgnore = nil -- panel-managed ignore list, persisted in IGNORE_FILE
 local polkitRuleInstalled = nil -- nil until the async check ran, then boolean
 local polkitInstallBusy = false
+local runsHistory = nil -- lazy-loaded array of {at, rollback, packages}, newest last
+local activityHistory = {} -- activity graph: { n, at, afterUpdate } per check, oldest first
+local activityLastUpdateAt = nil -- os.time() of the last update run that finished
+local activityLoaded = false
+local checkIsPostUpdate = false -- next finished check followed an update run
+local runKind = "update" -- update|rollback: what the current run does
+local runMode = "background" -- background|terminal: how the current run was launched
+local runPackages = nil -- packages of the current run, for the history entry
+local probeResult = nil -- cache/required-by info for one run, {at, pkgs}
 
 local startCheck
 local checkNews
@@ -198,6 +221,207 @@ local function ignoreSet()
     return set
 end
 
+-- Appends to the panel-managed list without touching the current snapshot;
+-- used in bulk after a rollback when rollback_auto_ignore is on.
+local function addIgnoreName(name)
+    name = trim(tostring(name or ""))
+    if not validName(name) then
+        return
+    end
+    loadDynamicIgnore()
+    for _, existing in ipairs(ignoreList()) do
+        if existing == name then
+            return
+        end
+    end
+    table.insert(dynamicIgnore, name)
+    saveDynamicIgnore()
+end
+
+-- ── Run history ──────────────────────────────────────────────────────────────
+
+-- One entry per finished background run: when it ran, whether it was a
+-- rollback, and the "name from -> to" list it applied. This is what the
+-- panel's history strip shows and what rollback resolves versions from.
+local function runsPath()
+    local dir = noctalia.pluginDataDir()
+    return dir ~= nil and (dir .. "/" .. RUNS_FILE) or nil
+end
+
+local function loadRuns()
+    if runsHistory ~= nil then
+        return
+    end
+    runsHistory = {}
+    local path = runsPath()
+    local encoded = path ~= nil and noctalia.readFile(path) or nil
+    local ok, decoded = pcall(function()
+        return encoded ~= nil and noctalia.json.decode(encoded) or nil
+    end)
+    if ok and type(decoded) == "table" and type(decoded.runs) == "table" then
+        for _, entry in ipairs(decoded.runs) do
+            if type(entry) == "table" and tonumber(entry.at) ~= nil and type(entry.packages) == "table" then
+                table.insert(runsHistory, entry)
+            end
+        end
+    end
+end
+
+local function saveRuns()
+    local path = runsPath()
+    if path == nil then
+        return
+    end
+    local encoded = noctalia.json.encode({ runs = runsHistory })
+    if encoded ~= nil then
+        noctalia.writeFile(path, encoded)
+    end
+end
+
+local historyState = nil -- cached newest-first copy for publish()
+
+local function historyForState()
+    if historyState == nil then
+        loadRuns()
+        historyState = {}
+        for i = #runsHistory, 1, -1 do
+            local entry = runsHistory[i]
+            table.insert(historyState, {
+                at = entry.at,
+                rollback = entry.rollback == true,
+                n = #entry.packages,
+                packages = entry.packages,
+            })
+        end
+    end
+    return historyState
+end
+
+local function recordRun(kind, packages)
+    if type(packages) ~= "table" or #packages == 0 then
+        return
+    end
+    loadRuns()
+    table.insert(runsHistory, { at = os.time(), rollback = kind == "rollback", packages = packages })
+    while #runsHistory > MAX_RUNS do
+        table.remove(runsHistory, 1)
+    end
+    historyState = nil
+    saveRuns()
+end
+
+local function findRun(at)
+    loadRuns()
+    for _, entry in ipairs(runsHistory) do
+        if tonumber(entry.at) == tonumber(at) then
+            return entry
+        end
+    end
+    return nil
+end
+
+-- Snapshot of everything the update run is about to apply, taken at launch:
+-- the run itself is non-interactive, so its target set is exactly the
+-- pending list. Flatpak entries are kept for display but can't be rolled
+-- back through the pacman cache.
+local function collectPendingPackages()
+    local packages = {}
+    for _, source in ipairs({ { key = "pacman", entry = sources.pacman }, { key = "aur", entry = sources.aur }, { key = "flatpak", entry = sources.flatpak } }) do
+        for _, item in ipairs(source.entry.items or {}) do
+            if #packages < MAX_RUN_PACKAGES then
+                table.insert(packages, { name = item.name, from = item.from, to = item.to, source = source.key })
+            end
+        end
+    end
+    return packages
+end
+
+-- ── Activity history (the upstream graph, opt-in) ───────────────────────────
+
+-- One { n, at, afterUpdate } entry per finished check: how many updates were
+-- pending at that moment. The panel draws these as a small trend graph.
+-- Distinct from the run history above: this tracks *checks* (including the
+-- stretches when nothing was updated), not applied runs.
+local function activityStatePath()
+    local dir = noctalia.pluginDataDir()
+    return dir ~= nil and (dir .. "/" .. ACTIVITY_FILE) or nil
+end
+
+local function loadActivityState()
+    if activityLoaded then
+        return
+    end
+    activityLoaded = true
+    local path = activityStatePath()
+    local encoded = path ~= nil and noctalia.readFile(path) or nil
+    local ok, decoded = pcall(function()
+        return encoded ~= nil and noctalia.json.decode(encoded) or nil
+    end)
+    if ok and type(decoded) == "table" then
+        if type(decoded.history) == "table" then
+            -- Migrates upstream's old format (a plain array of counts) to
+            -- entries with a timestamp and an afterUpdate flag.
+            local migrated = {}
+            for _, entry in ipairs(decoded.history) do
+                if type(entry) == "table" then
+                    table.insert(migrated, {
+                        n = tonumber(entry.n) or 0,
+                        at = tonumber(entry.at),
+                        afterUpdate = entry.afterUpdate == true,
+                    })
+                elseif type(entry) == "number" then
+                    table.insert(migrated, { n = entry, at = nil, afterUpdate = false })
+                end
+            end
+            activityHistory = migrated
+        end
+        if type(decoded.lastUpdateAt) == "number" then
+            activityLastUpdateAt = decoded.lastUpdateAt
+        end
+    end
+end
+
+local function saveActivityState()
+    local path = activityStatePath()
+    if path == nil then
+        return
+    end
+    local encoded = noctalia.json.encode({ history = activityHistory, lastUpdateAt = activityLastUpdateAt })
+    if encoded ~= nil then
+        noctalia.writeFile(path, encoded)
+    end
+end
+
+-- Appends the current total to the activity history, trimmed to the
+-- configured length. A no-op when the graph is turned off, so disabling it
+-- also stops collecting data, not just hides it.
+local function recordCheck()
+    local wasPostUpdate = checkIsPostUpdate
+    checkIsPostUpdate = false
+    if cfg("show_activity_graph") ~= true then
+        return
+    end
+    loadActivityState()
+    table.insert(activityHistory, { n = total, at = os.time(), afterUpdate = wasPostUpdate })
+    local maxLen = math.max(3, math.min(30, tonumber(cfg("activity_history_length")) or 10))
+    while #activityHistory > maxLen do
+        table.remove(activityHistory, 1)
+    end
+    saveActivityState()
+end
+
+-- Marks the check that follows as the one that verifies an update run, so its
+-- history entry can say "Updated" instead of just a pending count.
+local function recordUpdateRun()
+    checkIsPostUpdate = true
+    if cfg("show_activity_graph") ~= true then
+        return
+    end
+    loadActivityState()
+    activityLastUpdateAt = os.time()
+    saveActivityState()
+end
+
 -- ── Parsing ──────────────────────────────────────────────────────────────────
 
 -- One "name oldver -> newver" line per package: checkupdates' format, which
@@ -292,6 +516,9 @@ end
 -- ── Publishing ───────────────────────────────────────────────────────────────
 
 local function publish()
+    if cfg("show_activity_graph") == true then
+        loadActivityState() -- no-op after the first call; keeps the graph populated right after a reload
+    end
     stateNonce += 1
     noctalia.state.set(STATE_KEY, {
         nonce = stateNonce,
@@ -312,6 +539,12 @@ local function publish()
         ignoredDynamic = dynamicIgnore or {},
         ignoredConfig = configIgnoreList(),
         polkitRule = polkitRuleInstalled,
+        history = historyForState(),
+        activity = activityHistory,
+        lastUpdateAt = activityLastUpdateAt,
+        runKind = runKind,
+        runMode = runMode,
+        probe = probeResult,
         flatpakEnabled = cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak"),
         logTail = logTail,
         logPath = logPath(),
@@ -541,6 +774,7 @@ finishCheck = function()
     phase = total > 0 and "ready" or "clean"
     checkedAt = noctalia.formatTime("%H:%M")
     sinceCheck = 0
+    recordCheck()
     publish()
     if total > 0 and cfg("notify_on_updates") == true then
         noctalia.notify(tr("title"), noctalia.trp("notify_updates", total, { count = total }))
@@ -766,6 +1000,22 @@ end
 
 -- ── Updating (background) ────────────────────────────────────────────────────
 
+-- Shared by both modes. With an ignore list, filters ignored refs out of the
+-- pending Flatpak list before updating, so an app hidden from the panel's
+-- count can't still slip in through a bare `flatpak update`. `flags` carries
+-- the mode's own switches (non-interactive for the background run).
+local function flatpakUpdateCommand(flags)
+    local ignored = ignoreList()
+    if #ignored == 0 then
+        return "flatpak update" .. flags
+    end
+    local skipList = shellQuote(table.concat(ignored, "\n"))
+    return "{ flatpak_refs=$(flatpak remote-ls --updates --columns=application 2>/dev/null | awk -v ignore="
+        .. skipList
+        .. [=[ 'BEGIN { n = split(ignore, arr, "\n"); for (i = 1; i <= n; i++) skip[arr[i]] = 1 } !($0 in skip)'); ]=]
+        .. [[if [ -n "$flatpak_refs" ]; then flatpak update]] .. flags .. [[ $flatpak_refs; fi; }]]
+end
+
 -- The core upgrade command, fully non-interactive. pkexec raises the polkit
 -- password dialog; --noconfirm answers every remaining question with its
 -- default. AUR helpers run as the user and escalate through pkexec themselves
@@ -791,27 +1041,14 @@ local function buildBackgroundCommand()
     end
 
     if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
-        if #ignored > 0 then
-            -- Same ignore list as pacman/AUR: filter ignored refs out of the
-            -- pending Flatpak list before updating, so an app hidden from the
-            -- panel's count can't still slip in through a bare `flatpak update`.
-            local skipList = shellQuote(table.concat(ignored, "\n"))
-            table.insert(
-                parts,
-                "{ flatpak_refs=$(flatpak remote-ls --updates --columns=application 2>/dev/null | awk -v ignore="
-                    .. skipList
-                    .. [=[ 'BEGIN { n = split(ignore, arr, "\n"); for (i = 1; i <= n; i++) skip[arr[i]] = 1 } !($0 in skip)'); ]=]
-                    .. [[if [ -n "$flatpak_refs" ]; then flatpak update -y --noninteractive $flatpak_refs; fi; }]]
-            )
-        else
-            table.insert(parts, "flatpak update -y --noninteractive")
-        end
+        table.insert(parts, flatpakUpdateCommand(" -y --noninteractive"))
     end
 
     return table.concat(parts, " && ")
 end
 
--- Interactive variant for the terminal fallback: no --noconfirm, prompts and
+-- Interactive variant, used when update_mode is "terminal" (the default) and
+-- as the retry after a failed background run: no --noconfirm, prompts and
 -- the PKGBUILD review work as usual. Output is tee'd into the same log so the
 -- engine still sees the "::EXIT" marker and re-checks when the run ends.
 local function buildTerminalCommand()
@@ -826,7 +1063,7 @@ local function buildTerminalCommand()
         table.insert(parts, "sudo pacman -Syu" .. ignoreFlag)
     end
     if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
-        table.insert(parts, "flatpak update")
+        table.insert(parts, flatpakUpdateCommand(""))
     end
     return table.concat(parts, " && ")
 end
@@ -844,13 +1081,69 @@ local function launchTerminal(cmd)
     return noctalia.runAsync(term .. " " .. separator .. " sh -lc " .. shellQuote(cmd))
 end
 
-local function beginRun()
+-- "Open full log": xdg-open is unreliable for plain text (text/plain often
+-- maps to a terminal editor like vim, which cannot start without a tty and
+-- dies silently), so the log opens in a terminal pager instead.
+local function openLog()
+    local path = logPath()
+    if path == nil then
+        return
+    end
+    if not launchTerminal("less +G -- " .. shellQuote(path)) then
+        noctalia.notifyError(tr("title"), tr("err_no_terminal"))
+    end
+end
+
+-- The current run's kind, package list and expected total live in memory,
+-- which a hot reload or shell restart wipes; persisting them next to the
+-- log lets a resumed engine keep the progress percent and still record the
+-- run in the history when it finishes.
+local function runMetaPath()
+    local dir = noctalia.pluginDataDir()
+    return dir ~= nil and (dir .. "/" .. RUN_META_FILE) or nil
+end
+
+local function saveRunMeta()
+    local path = runMetaPath()
+    if path == nil then
+        return
+    end
+    local encoded = noctalia.json.encode({ kind = runKind, mode = runMode, total = runTotal, packages = runPackages })
+    if encoded ~= nil then
+        noctalia.writeFile(path, encoded)
+    end
+end
+
+local function loadRunMeta()
+    local path = runMetaPath()
+    local encoded = path ~= nil and noctalia.readFile(path) or nil
+    local ok, decoded = pcall(function()
+        return encoded ~= nil and noctalia.json.decode(encoded) or nil
+    end)
+    if ok and type(decoded) == "table" then
+        runKind = decoded.kind == "rollback" and "rollback" or "update"
+        runMode = decoded.mode == "terminal" and "terminal" or "background"
+        runTotal = tonumber(decoded.total) or 0
+        runPackages = type(decoded.packages) == "table" and decoded.packages or nil
+    end
+end
+
+local function clearRunMeta()
+    local path = runMetaPath()
+    if path ~= nil then
+        noctalia.runAsync("rm -f -- " .. shellQuote(path))
+    end
+end
+
+local function beginRun(kind, expectTotal, mode)
     phase = "running"
     errMsg = nil
     step = ""
+    runKind = kind or "update"
+    runMode = mode or "background"
     runExit = nil
     runDone = 0
-    runTotal = total
+    runTotal = expectTotal or total
     runStaleS = 0
     runPollTicks = 0
     logTail = {}
@@ -896,7 +1189,9 @@ local function runUpdate()
         publish()
         return
     end
-    beginRun()
+    runPackages = collectPendingPackages()
+    beginRun("update")
+    saveRunMeta()
 end
 
 local function runUpdateTerminal()
@@ -918,18 +1213,90 @@ local function runUpdateTerminal()
         noctalia.notifyError(tr("title"), tr("err_no_terminal"))
         return
     end
-    beginRun()
+    runPackages = collectPendingPackages()
+    beginRun("update", nil, "terminal")
+    saveRunMeta()
+end
+
+-- The history entry trusts the pending-list snapshot taken at launch, but an
+-- interactive terminal run lets the user decline packages along the way.
+-- Before recording, `pacman -Q` weeds out entries whose installed version
+-- never left `from`: they were not actually updated, so a rollback segment
+-- offering to "undo" them would lie. Flatpak entries are kept as-is (display
+-- only, not rollbackable). Any failure to verify records the full snapshot,
+-- like before.
+local function verifyAndRecordRun(kind, packages)
+    if type(packages) ~= "table" or #packages == 0 then
+        return
+    end
+    local names = {}
+    for _, item in ipairs(packages) do
+        if item.source ~= "flatpak" and validName(tostring(item.name or "")) then
+            table.insert(names, shellQuote(item.name))
+        end
+    end
+    if #names == 0 then
+        recordRun(kind, packages)
+        publish()
+        return
+    end
+    local cmd = "LC_ALL=C pacman -Q " .. table.concat(names, " ") .. " 2>/dev/null"
+    local started = noctalia.runAsync(cmd, function(result)
+        if result.timedOut then
+            recordRun(kind, packages)
+            publish()
+            return
+        end
+        local installed = {}
+        for line in (result.stdout or ""):gmatch("[^\n]+") do
+            local name, version = line:match("^(%S+)%s+(%S+)$")
+            if name ~= nil then
+                installed[name] = version
+            end
+        end
+        local applied = {}
+        for _, item in ipairs(packages) do
+            if item.source == "flatpak" then
+                table.insert(applied, item)
+            elseif installed[item.name] ~= nil and installed[item.name] ~= item.from then
+                table.insert(applied, item)
+            end
+        end
+        recordRun(kind, applied)
+        publish()
+    end, SIZE_TIMEOUT_MS)
+    if not started then
+        recordRun(kind, packages)
+        publish()
+    end
 end
 
 finishRun = function(code)
     runExit = code
     runStaleS = 0
     if code == 0 then
-        noctalia.notify(tr("title"), tr("notify_run_ok"))
+        if runKind == "rollback" then
+            -- One atomic pacman -U transaction: exit 0 means it all applied.
+            recordRun(runKind, runPackages)
+            noctalia.notify(tr("title"), tr("notify_rollback_ok"))
+            if cfg("rollback_auto_ignore") == true and type(runPackages) == "table" then
+                for _, item in ipairs(runPackages) do
+                    addIgnoreName(item.name)
+                end
+            end
+        else
+            verifyAndRecordRun(runKind, runPackages)
+            noctalia.notify(tr("title"), tr("notify_run_ok"))
+            recordUpdateRun() -- rollbacks don't count as "updated"
+        end
+        runPackages = nil
+        clearRunMeta()
         phase = "clean"
         publish()
         startCheck() -- verify: phase becomes checking, then clean/ready
     else
+        runPackages = nil
+        clearRunMeta()
         phase = "error"
         errMsg = tr("err_run_failed", { code = tostring(code) })
         publish()
@@ -941,16 +1308,11 @@ local function stripAnsi(line)
     return (line:gsub("\27%[[%d;]*[A-Za-z]", ""):gsub("\r", ""))
 end
 
-local function isProgressLine(line)
-    return line:match("^upgrading ") ~= nil
-        or line:match("^installing ") ~= nil
-        or line:match("^reinstalling ") ~= nil
-        or line:match("^downgrading ") ~= nil
-end
-
 -- One `tail` per poll: the last screenful for display plus a full-file
 -- progress count, so the bar doesn't reset when early lines scroll out of
--- the tail window.
+-- the tail window. The count matches pacman/AUR package lines and Flatpak's
+-- per-ref "Updating app/..." lines, so a run with pending Flatpak updates
+-- can still reach 100%.
 local function pollRunLog()
     local path = logPath()
     if path == nil then
@@ -959,16 +1321,22 @@ local function pollRunLog()
     local keep = math.max(6, math.min(30, tonumber(cfg("log_lines")) or 14))
     local quoted = shellQuote(path)
     local cmd = "tail -n " .. tostring(keep + 8) .. " " .. quoted .. " 2>/dev/null"
-        .. "; printf '::COUNT %s\\n' \"$(grep -cE '^(upgrading|installing|reinstalling|downgrading) ' " .. quoted .. " 2>/dev/null)\""
+        .. "; printf '::COUNT %s\\n' \"$(grep -cE '^(upgrading|installing|reinstalling|downgrading) |^(Updating|Installing) (app|runtime)/' " .. quoted .. " 2>/dev/null)\""
     local started = noctalia.runAsync(cmd, function(result)
         if phase ~= "running" then
             return
         end
         local text = result.stdout or ""
         if text == lastTailText then
-            runStaleS += RUN_POLL_SECONDS
-            if runStaleS >= RUN_STALE_LIMIT_S then
-                finishRun(-1)
+            -- Staleness only means "stuck" for non-interactive runs. In a
+            -- terminal the user may sit on a PKGBUILD diff or a prompt for
+            -- any amount of time; killing the tracking there would also
+            -- offer a retry that clobbers the log under the live process.
+            if runMode ~= "terminal" then
+                runStaleS += RUN_POLL_SECONDS
+                if runStaleS >= RUN_STALE_LIMIT_S then
+                    finishRun(-1)
+                end
             end
             return
         end
@@ -1014,11 +1382,13 @@ end
 local function resumeRunIfActive()
     local path = logPath()
     if path == nil then
+        resumeProbed = true
         return
     end
     local quoted = shellQuote(path)
     local cmd = "head -n 1 " .. quoted .. " 2>/dev/null; tail -n 3 " .. quoted .. " 2>/dev/null"
     local started = noctalia.runAsync(cmd, function(result)
+        resumeProbed = true
         if phase ~= "idle" then
             return
         end
@@ -1033,11 +1403,213 @@ local function resumeRunIfActive()
         if os.time() - startedAt > RUN_RESUME_MAX_AGE_S then
             return
         end
-        beginRun()
+        loadRunMeta()
+        beginRun(runKind, runTotal > 0 and runTotal or nil, runMode)
     end, FAST_TIMEOUT_MS)
     if not started then
+        resumeProbed = true
         noctalia.log("arch-updater: could not inspect the update log")
     end
+end
+
+-- ── Rollback ─────────────────────────────────────────────────────────────────
+
+-- Rollback = `pkexec pacman -U` on the old package files still present in
+-- the pacman cache (or the AUR helper's build cache). pacman installs the
+-- chosen version directly, no need to step through intermediate upgrades.
+-- --nodeps is never passed: a downgrade that would break another package's
+-- versioned dependency (sonames included) makes pacman refuse the whole
+-- transaction before anything changes.
+
+local function versionOk(version)
+    return version:match("^[%w:._+~-]+$") ~= nil
+end
+
+-- sh helper: prints the cached package file for "name version", trying the
+-- pacman cache first, then paru's and yay's build caches.
+local FIND_PKG_SH = [[find_pkg() {
+for f in /var/cache/pacman/pkg/"$1"-"$2"-*.pkg.tar.zst /var/cache/pacman/pkg/"$1"-"$2"-*.pkg.tar.xz \
+    "$HOME"/.cache/paru/clone/*/"$1"-"$2"-*.pkg.tar.zst "$HOME"/.cache/paru/clone/*/"$1"-"$2"-*.pkg.tar.xz \
+    "$HOME"/.cache/yay/*/"$1"-"$2"-*.pkg.tar.zst "$HOME"/.cache/yay/*/"$1"-"$2"-*.pkg.tar.xz; do
+    if [ -f "$f" ]; then printf '%s\n' "$f"; return 0; fi
+done
+return 1
+}]]
+
+local function specArgs(specs)
+    local args = {}
+    for _, spec in ipairs(specs) do
+        table.insert(args, shellQuote(spec.name) .. " " .. shellQuote(spec.version))
+    end
+    return table.concat(args, " ")
+end
+
+local function runRollback(specs, items)
+    if phase == "running" or phase == "checking" or #specs == 0 then
+        return
+    end
+    if not noctalia.commandExists("pkexec") then
+        phase = "error"
+        errMsg = tr("err_no_pkexec")
+        publish()
+        noctalia.notifyError(tr("title"), tr("err_no_pkexec"))
+        return
+    end
+    local path = logPath()
+    if path == nil then
+        return
+    end
+    local body = "set -- " .. specArgs(specs) .. "\n" .. FIND_PKG_SH .. [[
+
+files=""
+missing=""
+while [ "$#" -ge 2 ]; do
+    if f=$(find_pkg "$1" "$2"); then files="$files $f"; else missing="$missing $1"; fi
+    shift 2
+done
+if [ -n "$missing" ]; then echo "missing in cache:$missing"; exit 3; fi
+pkexec pacman -U --noconfirm --noprogressbar --color never $files]]
+    local quoted = shellQuote(path)
+    local script = "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+        .. "; { " .. body .. "\n} >> " .. quoted .. " 2>&1"
+        .. "; printf '::EXIT %s\\n' \"$?\" >> " .. quoted
+    if not noctalia.runAsync(script) then
+        phase = "error"
+        errMsg = tr("err_spawn")
+        publish()
+        return
+    end
+    runPackages = items
+    beginRun("rollback", #specs)
+    saveRunMeta()
+end
+
+-- Reverses one run entry: rolling back a package means going from its
+-- current `to` version back to `from`.
+local function reversedItem(item)
+    return { name = item.name, from = item.to, to = item.from, source = item.source }
+end
+
+-- Per-package rollback. The package's dependencies that were updated in the
+-- same run ride along in the same transaction (pactree intersected with the
+-- run's package list), so a program and its libraries move back together.
+local function startRollback(payload)
+    if type(payload) ~= "table" then
+        return
+    end
+    local run = findRun(payload.at)
+    if run == nil then
+        return
+    end
+    local name = trim(tostring(payload.pkg or ""))
+    local target = nil
+    for _, item in ipairs(run.packages) do
+        if item.name == name and item.source ~= "flatpak" then
+            target = item
+            break
+        end
+    end
+    if target == nil or not validName(name) or not versionOk(tostring(target.from or "")) then
+        return
+    end
+    local runMates = {}
+    for _, item in ipairs(run.packages) do
+        if item.source ~= "flatpak" and item.name ~= name and validName(item.name) and versionOk(tostring(item.from or "")) then
+            runMates[item.name] = item
+        end
+    end
+    local finish = function(depNames)
+        local specs = { { name = name, version = target.from } }
+        local items = { reversedItem(target) }
+        for _, dep in ipairs(depNames) do
+            local mate = runMates[dep]
+            if mate ~= nil then
+                table.insert(specs, { name = mate.name, version = mate.from })
+                table.insert(items, reversedItem(mate))
+                runMates[dep] = nil
+            end
+        end
+        runRollback(specs, items)
+    end
+    local started = noctalia.runAsync("pactree -l " .. shellQuote(name) .. " 2>/dev/null", function(result)
+        local deps = {}
+        if not result.timedOut and result.exitCode == 0 then
+            for line in (result.stdout or ""):gmatch("[^\n]+") do
+                -- pactree -l prints raw depend strings: version pins
+                -- ("libelf=0.196", "linux-api-headers>=4.10") and soname
+                -- provides included. Strip the constraint so the name can
+                -- match the run's package list.
+                local dep = trim(line):match("^([^<>=]+)")
+                if dep ~= nil and dep ~= "" then
+                    table.insert(deps, dep)
+                end
+            end
+        end
+        finish(deps)
+    end, SIZE_TIMEOUT_MS)
+    if not started then
+        finish({})
+    end
+end
+
+local function startRollbackRun(payload)
+    local run = findRun(type(payload) == "table" and payload.at or payload)
+    if run == nil then
+        return
+    end
+    local specs = {}
+    local items = {}
+    for _, item in ipairs(run.packages) do
+        if item.source ~= "flatpak" and validName(item.name) and versionOk(tostring(item.from or "")) then
+            table.insert(specs, { name = item.name, version = item.from })
+            table.insert(items, reversedItem(item))
+        end
+    end
+    runRollback(specs, items)
+end
+
+-- Cache availability and reverse-dependency counts for one run, fetched
+-- when the panel opens that run's package list: greys out packages whose
+-- old file is gone and shows how many installed packages require each one.
+local function probeRun(payload)
+    local run = findRun(type(payload) == "table" and payload.at or payload)
+    if run == nil then
+        return
+    end
+    local specs = {}
+    for _, item in ipairs(run.packages) do
+        if item.source ~= "flatpak" and validName(item.name) and versionOk(tostring(item.from or "")) then
+            table.insert(specs, { name = item.name, version = item.from })
+        end
+    end
+    if #specs == 0 then
+        probeResult = { at = run.at, pkgs = {} }
+        publish()
+        return
+    end
+    local cmd = "set -- " .. specArgs(specs) .. "\n" .. FIND_PKG_SH .. [[
+
+while [ "$#" -ge 2 ]; do
+    if find_pkg "$1" "$2" >/dev/null; then c=ok; else c=miss; fi
+    n=$(pactree -rd1 "$1" 2>/dev/null | wc -l)
+    [ "$n" -gt 0 ] && n=$((n - 1))
+    printf '%s|%s|%s\n' "$1" "$c" "$n"
+    shift 2
+done]]
+    noctalia.runAsync(cmd, function(result)
+        if result.timedOut then
+            return
+        end
+        local pkgs = {}
+        for line in (result.stdout or ""):gmatch("[^\n]+") do
+            local pkgName, cache, req = line:match("^(.-)|(%a+)|(%d+)$")
+            if pkgName ~= nil then
+                pkgs[pkgName] = { cache = cache == "ok", req = tonumber(req) or 0 }
+            end
+        end
+        probeResult = { at = run.at, pkgs = pkgs }
+        publish()
+    end, SIZE_TIMEOUT_MS)
 end
 
 -- ── Requests, lifecycle ──────────────────────────────────────────────────────
@@ -1045,19 +1617,16 @@ end
 -- Persists in IGNORE_FILE and takes effect immediately by moving the
 -- package out of the current snapshot; n is only decremented when the
 -- package was actually listed (entries beyond MAX_LISTED have no name).
-local function addIgnore(pkg)
-    local name = trim(tostring(pkg or ""))
+local function payloadPkg(payload)
+    return trim(tostring((type(payload) == "table" and payload.pkg or payload) or ""))
+end
+
+local function addIgnore(payload)
+    local name = payloadPkg(payload)
     if not validName(name) then
         return
     end
-    loadDynamicIgnore()
-    for _, existing in ipairs(ignoreList()) do
-        if existing == name then
-            return
-        end
-    end
-    table.insert(dynamicIgnore, name)
-    saveDynamicIgnore()
+    addIgnoreName(name)
     for _, entry in ipairs({ sources.pacman, sources.aur, sources.flatpak }) do
         for index, item in ipairs(entry.items or {}) do
             if item.name == name then
@@ -1077,8 +1646,8 @@ end
 
 -- Only the panel-managed list is editable here; settings entries and
 -- pacman.conf's IgnorePkg are managed where they live.
-local function removeIgnore(pkg)
-    local name = trim(tostring(pkg or ""))
+local function removeIgnore(payload)
+    local name = payloadPkg(payload)
     if name == "" then
         return
     end
@@ -1103,17 +1672,33 @@ local function removeIgnore(pkg)
     end
 end
 
-local function handle(action, pkg)
+local function handle(action, payload)
     if action == "check" then
         startCheck()
     elseif action == "update" then
+        -- Follows the update_mode setting; terminal is the default, like
+        -- the original plugin.
+        if cfg("update_mode") == "background" then
+            runUpdate()
+        else
+            runUpdateTerminal()
+        end
+    elseif action == "update_background" then
         runUpdate()
     elseif action == "update_terminal" then
         runUpdateTerminal()
     elseif action == "ignore" then
-        addIgnore(pkg)
+        addIgnore(payload)
     elseif action == "unignore" then
-        removeIgnore(pkg)
+        removeIgnore(payload)
+    elseif action == "rollback" then
+        startRollback(payload)
+    elseif action == "rollback_run" then
+        startRollbackRun(payload)
+    elseif action == "probe_run" then
+        probeRun(payload)
+    elseif action == "open_log" then
+        openLog()
     elseif action == "polkit_install" then
         installPolkitRule()
     elseif action == "dismiss" then
@@ -1140,12 +1725,13 @@ noctalia.state.watch(REQUEST_KEY, function(value)
         return
     end
     lastRequestNonce = nonce
-    handle(value.action, value.pkg)
+    handle(value.action, value)
 end)
 
 -- Scriptable control:
 --   noctalia msg plugin yuuto/arch-updater:service all check
 --   noctalia msg plugin yuuto/arch-updater:service all update
+--   noctalia msg plugin yuuto/arch-updater:service all update_background
 --   noctalia msg plugin yuuto/arch-updater:service all update_terminal
 --   noctalia msg plugin yuuto/arch-updater:service all dismiss
 --   noctalia msg plugin yuuto/arch-updater:service all ignore:NAME
@@ -1170,7 +1756,13 @@ function update()
         local hours = tonumber(cfg("auto_check_hours")) or 0
         if hours > 0 then
             if phase == "idle" then
-                startupTicks += 1
+                -- The startup auto-check waits for resumeRunIfActive's log
+                -- probe: if a detached run is still going, starting a check
+                -- first would flip phase to "checking" and the probe's
+                -- callback would decline to re-attach.
+                if resumeProbed then
+                    startupTicks += 1
+                end
                 if startupTicks >= AUTO_CHECK_DELAY then
                     startCheck()
                 end

--- a/arch-updater/translations/en.json
+++ b/arch-updater/translations/en.json
@@ -1,6 +1,34 @@
 {
   "action_check": "Check Updates",
+  "activity": {
+    "days_ago": {
+      "one": "1 day ago",
+      "other": "{count} days ago"
+    },
+    "hours_ago": {
+      "one": "1 hour ago",
+      "other": "{count} hours ago"
+    },
+    "just_now": "just now",
+    "minutes_ago": {
+      "one": "1 minute ago",
+      "other": "{count} minutes ago"
+    },
+    "never_updated": "Never updated",
+    "pending_at": {
+      "one": "1 pending update",
+      "other": "{count} pending updates"
+    },
+    "title": "Activity",
+    "updated": "Updated",
+    "updated_days_ago": {
+      "one": "Updated 1 day ago",
+      "other": "Updated {count} days ago"
+    },
+    "updated_today": "Updated today"
+  },
   "action_dismiss": "Dismiss",
+  "action_back": "Back",
   "action_open_log": "Open full log",
   "action_polkit_install": "Ask once",
   "action_open_news": "Open news",
@@ -22,6 +50,8 @@
   "err_polkit_install": "Could not install the polkit rule, see the system log for details",
   "err_run_failed": "Update failed (exit {code}), check the log or retry in a terminal",
   "err_spawn": "Could not run checkupdates",
+  "history_rollback_tag": "rollback",
+  "history_title": "Update history",
   "hover_hint": "Hover a package for its full versions",
   "ignored_tag_settings": "settings",
   "ignored_tag_system": "pacman.conf",
@@ -31,7 +61,7 @@
   "launcher": {
     "check_subtitle": "Check pacman, AUR and Flatpak for updates",
     "news_subtitle": "Open the Arch Linux news page",
-    "update_subtitle": "Update in the background (polkit password prompt)"
+    "update_subtitle": "Install the pending updates (terminal or background, per the update mode setting)"
   },
   "log_title": "Update log",
   "log_waiting": "Waiting for the polkit password prompt and the first output…",
@@ -41,8 +71,19 @@
     "other": "{count} unread Arch news posts, latest: \"{title}\""
   },
   "notify_polkit_ok": "Polkit rule installed: one password per update run from now on",
+  "notify_rollback_ok": "Rollback finished successfully",
   "notify_run_ok": "Update finished successfully",
   "polkit_hint": "Polkit asks for a password several times per update",
+  "rollback_confirm": "Sure?",
+  "rollback_missing": "The old version is no longer in the pacman/AUR cache",
+  "rollback_required_by": {
+    "one": "Careful: 1 installed package requires it",
+    "other": "Careful: {count} installed packages require it"
+  },
+  "run_packages": {
+    "one": "1 package",
+    "other": "{count} packages"
+  },
   "notify_updates": {
     "one": "1 package to upgrade",
     "other": "{count} packages to upgrade"
@@ -52,6 +93,14 @@
     "press_key": "Press any key to close"
   },
   "settings": {
+    "activity_history_length": {
+      "description": "How many of the most recent checks to keep for the activity graph.",
+      "label": "Activity history length"
+    },
+    "show_activity_graph": {
+      "description": "Track pending-update counts across recent checks and when you last updated, shown as a small graph above the update history strip. Off (default) also stops recording the history.",
+      "label": "Show activity graph"
+    },
     "aur_check_cmd": {
       "description": "Only used when the AUR helper above is 'Custom command'. Must print one 'name oldver -> newver' line per package, like 'yay -Qua' does.",
       "label": "Custom AUR check command"
@@ -107,6 +156,10 @@
       "description": "Send a desktop notification when a check finds packages to upgrade.",
       "label": "Notify when updates are found"
     },
+    "rollback_auto_ignore": {
+      "description": "After a successful rollback, add the rolled-back packages to the plugin's ignore list so the next check does not immediately offer them again.",
+      "label": "Ignore packages after a rollback"
+    },
     "show_count": {
       "description": "Show the number of pending updates next to the bar glyph.",
       "label": "Show the update count"
@@ -116,8 +169,16 @@
       "label": "Show download size"
     },
     "terminal": {
-      "description": "Terminal command used only for the 'Retry in terminal' fallback, e.g. kitty or ghostty. Empty (default) uses Noctalia's terminal detection ($TERMINAL, then the common emulators).",
-      "label": "Terminal (fallback)"
+      "description": "Terminal command for terminal-mode updates and the 'Retry in terminal' fallback, e.g. kitty or ghostty. Empty (default) uses Noctalia's terminal detection ($TERMINAL, then the common emulators).",
+      "label": "Terminal"
+    },
+    "update_mode": {
+      "description": "How the Update button runs the upgrade. 'In a terminal window' (default) behaves like the original plugin: prompts and the PKGBUILD review work as usual. 'In the background' is fully non-interactive (--noconfirm, review skipped) with a live log in the panel.",
+      "label": "Update mode",
+      "options": {
+        "background": "In the background (non-interactive)",
+        "terminal": "In a terminal window"
+      }
     },
     "update_cmd": {
       "description": "Full override for the background update command. Empty (default) builds it from the AUR helper, ignore list and Flatpak settings above, running pacman through pkexec.",
@@ -142,16 +203,22 @@
     "one": "1 package to upgrade",
     "other": "{count} packages to upgrade"
   },
+  "status_rolling_back": "Rolling back in the background…",
   "status_running": "Updating in the background…",
+  "status_running_terminal": "Updating in a terminal window…",
   "tip_check": "Check for updates now",
   "tip_close": "Close",
   "tip_copy": "Copy name and versions",
   "tip_ignore": "Ignore this package: hide it from the count and skip it on update",
   "tip_unignore": "Stop ignoring this package",
   "tip_open_page": "Open package page",
-  "tip_polkit_install": "Install a polkit rule (asks for your password once): afterwards one password covers a whole update run, kept for ~5 minutes like sudo",
+  "tip_history_segment": "Click to see this run's packages",
+  "tip_polkit_install": "Install a polkit rule (asks for your password once): afterwards one password covers a whole update run, kept for ~5 minutes like sudo. Note: the rule applies to any pkexec-launched pacman from your active local session (wheel group), not only this plugin.",
+  "tip_rollback": "Roll back to {version}, together with its dependencies from this run. pacman refuses the whole transaction if it would break other packages.",
+  "tip_rollback_run": "Downgrade every package of this run in one transaction",
   "tip_run_terminal": "Open a terminal window where prompts work normally",
   "tip_update": "Update in the background: polkit asks for your password, everything else is automatic",
+  "tip_update_terminal": "Update in a terminal window: prompts and the PKGBUILD review work as usual",
   "title": "Arch Updater",
   "tooltip_checked": "Checked",
   "tooltip_hints": "click: panel · right: check now",

--- a/arch-updater/translations/en.json
+++ b/arch-updater/translations/en.json
@@ -1,35 +1,11 @@
 {
   "action_check": "Check Updates",
   "action_dismiss": "Dismiss",
+  "action_open_log": "Open full log",
+  "action_polkit_install": "Ask once",
   "action_open_news": "Open news",
+  "action_run_terminal": "Retry in terminal",
   "action_update": "Update",
-  "activity": {
-    "days_ago": {
-      "one": "1 day ago",
-      "other": "{count} days ago"
-    },
-    "hours_ago": {
-      "one": "1 hour ago",
-      "other": "{count} hours ago"
-    },
-    "just_now": "just now",
-    "minutes_ago": {
-      "one": "1 minute ago",
-      "other": "{count} minutes ago"
-    },
-    "never_updated": "Never updated",
-    "pending_at": {
-      "one": "1 pending update",
-      "other": "{count} pending updates"
-    },
-    "title": "Activity",
-    "updated": "Updated",
-    "updated_days_ago": {
-      "one": "Updated 1 day ago",
-      "other": "Updated {count} days ago"
-    },
-    "updated_today": "Updated today"
-  },
   "caption_checked": "checked {time}",
   "caption_ignored": {
     "one": "1 package ignored",
@@ -40,20 +16,33 @@
   "err_check_timeout": "Timed out while checking for updates",
   "err_flatpak_failed": "Flatpak check failed, see the system log for details",
   "err_no_checkupdates": "checkupdates not found, install pacman-contrib and check your PATH",
+  "err_no_pkexec": "pkexec not found, install polkit to update in the background",
   "err_no_terminal": "No terminal emulator found, set one in the plugin settings",
   "err_no_xdg_open": "xdg-open not found, cannot open the package page",
+  "err_polkit_install": "Could not install the polkit rule, see the system log for details",
+  "err_run_failed": "Update failed (exit {code}), check the log or retry in a terminal",
   "err_spawn": "Could not run checkupdates",
   "hover_hint": "Hover a package for its full versions",
+  "ignored_tag_settings": "settings",
+  "ignored_tag_system": "pacman.conf",
+  "ignored_tip_settings": "Ignored via the plugin settings, remove it there. Click to open them.",
+  "ignored_tip_system": "Ignored by IgnorePkg in /etc/pacman.conf, edit that file (as root) to lift it",
+  "ignored_title": "Ignored",
   "launcher": {
     "check_subtitle": "Check pacman, AUR and Flatpak for updates",
     "news_subtitle": "Open the Arch Linux news page",
-    "update_subtitle": "Open a terminal and run the update"
+    "update_subtitle": "Update in the background (polkit password prompt)"
   },
+  "log_title": "Update log",
+  "log_waiting": "Waiting for the polkit password prompt and the first output…",
   "more_packages": "+{count} more",
   "news_unread": {
     "one": "1 unread Arch news post: \"{title}\"",
     "other": "{count} unread Arch news posts, latest: \"{title}\""
   },
+  "notify_polkit_ok": "Polkit rule installed: one password per update run from now on",
+  "notify_run_ok": "Update finished successfully",
+  "polkit_hint": "Polkit asks for a password several times per update",
   "notify_updates": {
     "one": "1 package to upgrade",
     "other": "{count} packages to upgrade"
@@ -63,14 +52,6 @@
     "press_key": "Press any key to close"
   },
   "settings": {
-    "activity_history_length": {
-      "description": "How many of the most recent checks to keep for the activity graph.",
-      "label": "Activity history length"
-    },
-    "assume_yes": {
-      "description": "Pass --noconfirm / -y so package managers do not ask for confirmation. Off means you confirm each one in the terminal window.",
-      "label": "Answer yes automatically"
-    },
     "aur_check_cmd": {
       "description": "Only used when the AUR helper above is 'Custom command'. Must print one 'name oldver -> newver' line per package, like 'yay -Qua' does.",
       "label": "Custom AUR check command"
@@ -106,6 +87,10 @@
       "description": "The glyph shown for the widget on the bar.",
       "label": "Bar glyph"
     },
+    "hide_polkit_hint": {
+      "description": "Hide the panel line offering to install the polkit keep-authorization rule (one password per update run).",
+      "label": "Hide the polkit rule suggestion"
+    },
     "hide_on_empty": {
       "description": "Hide the widget entirely when there are no pending updates and no reboot recommendation. Off (default) always shows the glyph.",
       "label": "Hide when there is nothing to show"
@@ -114,13 +99,13 @@
       "description": "Package names to leave out of the count and pass as --ignore to the update itself, in addition to pacman.conf's own IgnorePkg.",
       "label": "Ignore packages"
     },
+    "log_lines": {
+      "description": "How many of the latest update-log lines the panel shows while an update is running.",
+      "label": "Log lines in the panel"
+    },
     "notify_on_updates": {
       "description": "Send a desktop notification when a check finds packages to upgrade.",
       "label": "Notify when updates are found"
-    },
-    "show_activity_graph": {
-      "description": "Track pending-update counts across recent checks and when you last updated, shown as a small graph in the panel. Turning this off also stops recording the history.",
-      "label": "Show activity graph"
     },
     "show_count": {
       "description": "Show the number of pending updates next to the bar glyph.",
@@ -131,11 +116,11 @@
       "label": "Show download size"
     },
     "terminal": {
-      "description": "Terminal command used for the update run, e.g. kitty or ghostty. Empty (default) uses Noctalia's terminal detection ($TERMINAL, then the common emulators).",
-      "label": "Terminal"
+      "description": "Terminal command used only for the 'Retry in terminal' fallback, e.g. kitty or ghostty. Empty (default) uses Noctalia's terminal detection ($TERMINAL, then the common emulators).",
+      "label": "Terminal (fallback)"
     },
     "update_cmd": {
-      "description": "Full override for the command run in the terminal on Update. Empty (default) builds it from the AUR helper, ignore list, Flatpak and 'Answer yes' settings above.",
+      "description": "Full override for the background update command. Empty (default) builds it from the AUR helper, ignore list and Flatpak settings above, running pacman through pkexec.",
       "label": "Custom update command"
     }
   },
@@ -157,12 +142,16 @@
     "one": "1 package to upgrade",
     "other": "{count} packages to upgrade"
   },
-  "status_running": "Update running in a terminal…",
+  "status_running": "Updating in the background…",
   "tip_check": "Check for updates now",
   "tip_close": "Close",
   "tip_copy": "Copy name and versions",
+  "tip_ignore": "Ignore this package: hide it from the count and skip it on update",
+  "tip_unignore": "Stop ignoring this package",
   "tip_open_page": "Open package page",
-  "tip_update": "Run the update in a terminal window",
+  "tip_polkit_install": "Install a polkit rule (asks for your password once): afterwards one password covers a whole update run, kept for ~5 minutes like sudo",
+  "tip_run_terminal": "Open a terminal window where prompts work normally",
+  "tip_update": "Update in the background: polkit asks for your password, everything else is automatic",
   "title": "Arch Updater",
   "tooltip_checked": "Checked",
   "tooltip_hints": "click: panel · right: check now",

--- a/arch-updater/widget.luau
+++ b/arch-updater/widget.luau
@@ -99,7 +99,13 @@ local function render()
         barWidget.setGlyphColor("on_surface")
     end
 
-    if pending() and noctalia.getConfig("show_count") == true then
+    if phase == "running" and snapshot ~= nil and type(snapshot.progress) == "table"
+        and (tonumber(snapshot.progress.total) or 0) > 0 then
+        -- Live progress replaces the count while the background run is going.
+        local done = tonumber(snapshot.progress.done) or 0
+        local expect = tonumber(snapshot.progress.total) or 1
+        barWidget.setText(tostring(math.min(math.floor(done / expect * 100), 100)) .. "%")
+    elseif pending() and noctalia.getConfig("show_count") == true then
         barWidget.setText(tostring(snapshot.total))
     else
         barWidget.setText("")


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `yuuto/arch-updater`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Three commits. The first is a standalone bugfix and can be cherry-picked on its own if the rest is not wanted; the second and third change the plugin's update flow, so they need @yuuto's sign-off per the repo rules. The third commit addresses @Reiling-Jeff's review of the first revision.

**Commit 1 — fix the news timer (fixes #382), version 1.1.1.**
The startup branch of the Arch news check (`sinceNewsCheck == AUTO_CHECK_DELAY`) resets the counter to `0`, so it re-fires every 10 seconds forever. Each firing is an HTTP fetch plus RSS parsing in the service callback; the repeated work exceeds the 25 ms CPU budget and Noctalia's health watchdog auto-disables the whole plugin ~50 seconds after the shell starts whenever `check_arch_news` is on (the default). The fix resets the counter back to `AUTO_CHECK_DELAY`, so news is checked once at startup and then every 6 hours, as intended.

**Commit 2 — background updates, ignore management, one polkit password, version 2.0.0.**

*Background update run.* The run is spawned fully detached (double-fork + setsid): `pkexec pacman -Syu` for repo packages, the AUR helper with `--sudo pkexec` plus non-interactive flags (`--noconfirm --noprogressbar --color never`, paru: `--skipreview`, yay: `--answerdiff/--answerclean/--answeredit None`), then optionally `flatpak update -y --noninteractive`. All output goes to `<data>/update.log` between `::START <epoch>` / `::EXIT <code>` markers. The engine tails the log every 2 s: the panel swaps the package list for a live log tail (configurable `log_lines`) with a progress bar, and the bar widget shows a percentage. Because the runner is detached it survives a shell restart — a fresh engine re-attaches to an unfinished log (younger than 6 h). On success: notification + automatic re-check; a failed run keeps its log on screen and offers **Retry in terminal**, `tee`'d into the same log.

*Ignore management.* Packages held back by `pacman.conf`'s `IgnorePkg` come out of `checkupdates`/`-Qua` with an `[ignored]` suffix; previously they were counted and listed as pending even though the run skips them. They are now excluded from the count and shown in a new expandable **Ignored** section, together with the plugin-side ignore list. Each package row gets an ignore button; those entries persist in `<data>/ignore.json` (the panel cannot write plugin settings) and have a restore button. Entries from the `ignore_packages` setting and from `pacman.conf` are tagged with where they are managed (the settings tag opens the plugin settings; `pacman.conf` is never edited by the plugin). New `ignore:NAME` / `unignore:NAME` IPC events.

*One polkit password per run.* `pkexec` authenticates each pacman transaction separately, so a db sync plus a couple of AUR install batches meant three password dialogs. The panel shows a hint with an **Ask once** button until a keep-authorization rule is installed: one user-confirmed `pkexec install` call places `polkit/49-arch-updater-pacman.rules` (shipped in the plugin directory, also embedded in `service.luau` because Lua cannot see the plugin dir) into `/etc/polkit-1/rules.d/`. `rules.d` is `750 root:polkitd` on Arch — not probeable by a regular user — so a marker file in the data dir remembers a successful install; the hint can also be hidden with the `hide_polkit_hint` setting.

**Commit 3 — review follow-up + update history with rollback, version 2.4.0.**

*The terminal is a first-class update path again (review point 2).* A new `update_mode` setting: **"terminal"** (the default — the same interactive flow the plugin always had: prompts, conflicts and the PKGBUILD review work exactly as on the command line) or **"background"** (the opt-in non-interactive run from commit 2). **Update** follows the setting; `update_background` / `update_terminal` IPC events force one mode. Terminal runs `tee` into the same log, so the live tail, progress bar, bar-widget percentage and the history all work in both modes. Net effect vs. upstream 1.1.0: the default behavior is unchanged, the background run is something you turn on.

*The activity graph is restored (review point 1).* `show_activity_graph` and `activity_history_length` are back, along with the `history_state.json` read/write path (old-format data migrates) and the panel section — gated on the setting, opt-in default as suggested. One deviation from a 1:1 restore, submitted for the reviewer's consideration: the hover hit-zones under the graph used to be invisible ghost buttons; their geometry and behavior are unchanged, but they are now drawn as a row of small axis dots (the hovered dot is highlighted in the accent color). The invisible zones were difficult to discover, and the ghost buttons' hover flash was more prominent than the graph itself. This detail will be reverted on request.

*Stale-run guard fixed (review point 3).* The 30-minute no-log-growth timeout now applies only to background runs. The run's mode is tracked and persisted in `run_meta.json`, so the exemption survives a shell restart mid-run. A user reading a PKGBUILD diff for an hour no longer gets their run declared failed (and can no longer be offered a retry that would truncate the log under the live process).

*Missing dependency (review point 4).* `install` is declared, and while at it every other shelled-out helper too: `date`, `grep`, `head`, `less`, `rm`, `tee`, `wc`.

*Flatpak progress (review point 5).* The progress count now also matches Flatpak's per-ref `Updating app/...` lines, so a run with pending Flatpak updates can reach 100%.

*Startup race (review point 6).* The startup auto-check now waits until `resumeRunIfActive`'s log probe has answered, so it can no longer steal the phase from a still-running detached update.

*Polkit scope disclosure (review point 7).* The install button's tooltip and the README now state plainly that the rule covers any `pkexec`-launched `/usr/bin/pacman` call from an active local `wheel` session for ~5 minutes after an authentication — not only this plugin's calls — and how to remove it.

*New: update history with rollback.* A strip at the bottom of the panel shows one segment per recorded run (last 15, stored in `<data>/runs.json`; rollbacks get their own segments). Click a segment to open the run's package list (`name from → to` per row): each row has a rollback button (second click confirms), the header rolls back the whole run in one transaction. Rollback installs the old package files straight from the caches (`/var/cache/pacman/pkg`, paru's/yay's build dirs) with `pkexec pacman -U`; dependencies updated in the same run ride along in the same transaction (resolved with `pactree` against the run's package list, version constraints stripped). `--nodeps` is never used, so a downgrade that would break other packages makes pacman refuse the whole transaction before anything changes. Opening a run probes the caches and reverse dependencies: packages whose old file is gone are greyed out, and the tooltip warns how many installed packages require the one being rolled back. Flatpak entries are listed but not rollbackable. Before a run is recorded, `pacman -Q` verifies which packages actually changed, so anything declined during an interactive terminal run is not offered for rollback; failed runs are not recorded. An optional `rollback_auto_ignore` setting (off by default) adds rolled-back packages to the plugin ignore list.

*Also new:* `run_meta.json` persists the current run's kind and package list, so a run resumed after a shell restart keeps its progress percentage and still lands in the history; **Open full log** opens the log in a terminal pager (`less +G`) instead of `xdg-open`, which dies silently when `text/plain` maps to a terminal editor; the polkit hint only shows in background mode (terminal runs go through `sudo` and never hit the multi-prompt problem); the retry-in-terminal button is not offered after a failed *rollback* (retrying the update command is not a retry of the rollback).

## External dependencies

All declared in `dependencies` in `plugin.toml`: `pacman-contrib` (checkupdates, pactree), `pacman`, `pkexec` (polkit escalation for the background run and rollback), `sh`, `awk`, `sed`, `grep`, `tail`, `head`, `tee`, `wc`, `date`, `rm`, `install`, `less`, `test`, `uname`, plus optional `paru`/`yay`, `flatpak`, `xdg-open`, and `sudo` (terminal mode and fallback).

Full accounting: network access is the same set of mirror/AUR/Flatpak contacts a manual upgrade makes, plus the Arch news feed fetch (startup + every 6 h). Files written are confined to the plugin data directory (`update.log`, `run_meta.json`, `runs.json`, `history_state.json`, `ignore.json`, `news_state.json`, a staged copy of the polkit rule, an install marker) — with one exception, `/etc/polkit-1/rules.d/49-arch-updater-pacman.rules`, written only by `pkexec install` after the user explicitly clicks **Ask once** and authenticates. Processes spawned are listed in the README's Notes section.

## Testing

Exercised on a real Arch system over several sessions: checks across pacman/AUR (paru)/Flatpak; full background runs (paru building and installing AUR packages, log tail + progress in the panel, `::EXIT 0`, notification, auto re-check) with the polkit rule asking exactly one password; the `[ignored]` filtering against a real `IgnorePkg` entry; ignore/unignore via panel buttons and IPC (persistence verified); the polkit rule install and removal via the panel flow (rule active, marker recorded, hint gone; hint returns after removal); live per-package rollback of real system packages with a same-run dependency riding along (`fzf` + `linux-api-headers` via glibc's `pactree` closure — including the version-constraint parsing fix this exposed), a whole-run rollback, and a roll-forward through the rollback's own history segment; history verification against `pacman -Q` after a run; the activity graph recording checks, surviving reloads and drawing the post-update drop; hot-reload and full plugin reload with no `[ERR]` lines; the news fix running for days with `check_arch_news` on and no watchdog trips.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** noctalia-git 5.0.0.r5277.gced2221ee-1
- **Plugin API level:** 9

## Screenshots / Videos

Attached in a comment below: idle panel with the Ignored section, the polkit hint, the activity graph and the history strip; a background run in progress with the live log; the panel after an update (graph showing the drop, history grown).

---

A note on language: I do not speak English; this text and the review conversation are translated with AI assistance. The changes themselves are tested on a real system as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

Note on the thumbnail item: `thumbnail.webp` is the plugin's existing generator-made thumbnail, shipped unchanged by this PR (the box is checked because the repository's template check requires every item checked on a non-draft PR). This PR adds no non-English translations; the existing `de`/`fr`/`tr` files are untouched (their new keys fall back to English until the translation service catches up).

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
