### PR TITLE
Update felipeartur/ai-usagebar

### DIFF
--- a/ai-usagebar/README.md
+++ b/ai-usagebar/README.md
@@ -145,3 +145,11 @@ noctalia msg plugin felipeartur/ai-usagebar:poller all select anthropic
 - A provider that fails still comes back as an entry with `status = "error"`, so
   one broken provider does not blank the others. A reading the CLI marks stale
   keeps showing, flagged in the capsule and in the panel header.
+- The file watcher follows the `.luau` entries only, so the files in
+  `translations/` are read once, when the plugin loads. Editing a string takes
+  a reload before the new text shows up:
+
+  ```sh
+  noctalia msg plugins disable felipeartur/ai-usagebar
+  noctalia msg plugins enable felipeartur/ai-usagebar
+  ```

--- a/ai-usagebar/README.md
+++ b/ai-usagebar/README.md
@@ -24,6 +24,10 @@ tarballs on the project's GitHub Releases page. Configure your providers once in
 `~/.config/ai-usagebar/config.toml`; the CLI owns the credentials and the
 endpoints, and this plugin never sees them.
 
+`xdg-open` is optional. It is spawned by one row in the panel, the link to the
+CLI's project page offered when `ai-usagebar` is not on `PATH`. Without
+xdg-utils that row does nothing and the rest of the plugin is unaffected.
+
 ## Usage
 
 Add `felipeartur/ai-usagebar:bar` to a bar in Settings, Bar. The capsule shows

--- a/ai-usagebar/bar.luau
+++ b/ai-usagebar/bar.luau
@@ -336,6 +336,10 @@ end
 
 local function render()
     local picked, hidden = shown()
+    -- A failure drops the reading here too, so the bar cannot be read as a
+    -- live percentage while the panel behind it says the CLI is unreachable.
+    -- Empty is already the shape that draws the alert glyph.
+    if failure.code ~= "" then picked, hidden = {}, 0 end
 
     local children = {}
     for _, entry in ipairs(picked) do

--- a/ai-usagebar/bar.luau
+++ b/ai-usagebar/bar.luau
@@ -12,8 +12,17 @@ local showName = noctalia.getConfig("show_name") == true
 local colorByUsage = noctalia.getConfig("color_by_usage") ~= false
 
 local report = nil
-local errorMsg = ""
 local polling = false
+
+-- The poller names the failure, so the capsule only has a code to translate.
+-- Anything else in that state slot reads as no failure at all.
+local NO_FAILURE = { code = "", detail = "" }
+
+local function asFailure(value)
+    return type(value) == "table" and value or NO_FAILURE
+end
+
+local failure = NO_FAILURE
 
 -- Tabler has no Anthropic mark, so providers without a brand glyph get a
 -- semantic one. Same approach the other CLI-backed meters in this repo take.
@@ -279,7 +288,14 @@ local function chip(entry)
 end
 
 local function tooltip(picked, hidden)
-    if errorMsg ~= "" then return { { key = noctalia.tr("ui.title"), value = errorMsg } } end
+    if failure.code ~= "" then
+        local key = "ui.error." .. failure.code
+        local rows = { { key = noctalia.tr(key), value = noctalia.tr(key .. "_hint") } }
+        if failure.detail ~= "" then
+            rows[2] = { key = noctalia.tr("ui.details"), value = failure.detail }
+        end
+        return rows
+    end
     if #picked == 0 then
         local waiting = vendor == "auto" and noctalia.tr("ui.waiting")
             or noctalia.tr("ui.not_configured", { vendor = vendor })
@@ -349,16 +365,14 @@ end
 noctalia.state.watch("report", function(value)
     if type(value) == "table" then
         report = value
-        errorMsg = ""
+        failure = NO_FAILURE
         render()
     end
 end)
 
 noctalia.state.watch("error", function(value)
-    if type(value) == "string" then
-        errorMsg = value
-        render()
-    end
+    failure = asFailure(value)
+    render()
 end)
 
 noctalia.state.watch("polling", function(value)
@@ -378,8 +392,7 @@ function onRightClick()
 end
 
 report = noctalia.state.get("report")
-local existingError = noctalia.state.get("error")
-if type(existingError) == "string" then errorMsg = existingError end
+failure = asFailure(noctalia.state.get("error"))
 
 -- Live countdowns without waking the CLI.
 noctalia.setUpdateInterval(30000)

--- a/ai-usagebar/panel.luau
+++ b/ai-usagebar/panel.luau
@@ -437,14 +437,19 @@ local function detailPane(entry)
     if entry ~= nil then
         local chips = {
             ui.label({ text = tostring(entry.id or ""), fontSize = 10, color = "on_surface_variant" }),
-            ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" }),
-            ui.label({
+        }
+        -- While a read is failing, `status` still describes the last good one,
+        -- so a `ready` chip would sit directly above an alert saying
+        -- otherwise. The stale chip stands in for it.
+        if failure.code == "" then
+            chips[#chips + 1] = ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" })
+            chips[#chips + 1] = ui.label({
                 text = tostring(entry.status or ""),
                 fontSize = 10,
                 color = entry.status == "ready" and "on_surface_variant" or "error",
-            }),
-        }
-        if entry.stale == true then
+            })
+        end
+        if entry.stale == true or failure.code ~= "" then
             chips[#chips + 1] = ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" })
             chips[#chips + 1] = ui.label({ text = noctalia.tr("ui.stale"), fontSize = 10, color = "tertiary" })
         end

--- a/ai-usagebar/panel.luau
+++ b/ai-usagebar/panel.luau
@@ -17,6 +17,10 @@ end
 
 local failure = NO_FAILURE
 
+-- Read once: a session either has xdg-utils or it does not, and the panel
+-- would otherwise stat PATH on every second tick it spends in a failure.
+local HAS_OPENER = noctalia.commandExists("xdg-open")
+
 -- Same parsing the capsule does. There is no require() below API 22, so the
 -- four helpers below are copied instead of shared.
 local function parseIso(value)
@@ -376,8 +380,9 @@ local function errorBlock()
     end)
 
     -- Retrying is pointless until the CLI exists, so that one failure gets the
-    -- install page as well. The URL is a literal, so there is nothing to quote.
-    if failure.code == "not_installed" then
+    -- install page as well. The URL is a literal, so there is nothing to quote,
+    -- and the row is only offered where something can open it.
+    if failure.code == "not_installed" and HAS_OPENER then
         children[#children + 1] = actionRow("external-link", "github.com/akitaonrails/ai-usagebar", function()
             noctalia.runAsync("xdg-open https://github.com/akitaonrails/ai-usagebar")
         end)

--- a/ai-usagebar/panel.luau
+++ b/ai-usagebar/panel.luau
@@ -394,12 +394,7 @@ local function listPane(entry)
       end
     end
     if #rows == 0 then
-        -- Headline only; the detail pane spells the failure out.
-        rows[1] = ui.label({
-            text = failure.code ~= "" and noctalia.tr("ui.error." .. failure.code)
-                or noctalia.tr("ui.loading"),
-            fontSize = 11, color = failure.code ~= "" and "error" or "on_surface_variant",
-        })
+        rows[1] = ui.label({ text = noctalia.tr("ui.loading"), fontSize = 11, color = "on_surface_variant" })
     end
 
     return ui.column({ gap = 10, padding = 14, width = 250 }, {
@@ -437,19 +432,14 @@ local function detailPane(entry)
     if entry ~= nil then
         local chips = {
             ui.label({ text = tostring(entry.id or ""), fontSize = 10, color = "on_surface_variant" }),
-        }
-        -- While a read is failing, `status` still describes the last good one,
-        -- so a `ready` chip would sit directly above an alert saying
-        -- otherwise. The stale chip stands in for it.
-        if failure.code == "" then
-            chips[#chips + 1] = ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" })
-            chips[#chips + 1] = ui.label({
+            ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" }),
+            ui.label({
                 text = tostring(entry.status or ""),
                 fontSize = 10,
                 color = entry.status == "ready" and "on_surface_variant" or "error",
-            })
-        end
-        if entry.stale == true or failure.code ~= "" then
+            }),
+        }
+        if entry.stale == true then
             chips[#chips + 1] = ui.label({ text = "·", fontSize = 10, color = "on_surface_variant" })
             chips[#chips + 1] = ui.label({ text = noctalia.tr("ui.stale"), fontSize = 10, color = "tertiary" })
         end
@@ -465,14 +455,10 @@ local function detailPane(entry)
         children[#children + 1] = ui.row({ gap = 4, align = "center" }, chips)
     end
 
-    if failure.code ~= "" then
-        children[#children + 1] = errorBlock()
-    else
-        local status = entry == nil and noctalia.tr("ui.loading")
-            or entry.status == "error" and tostring(entry.error or noctalia.tr("ui.unavailable"))
-        if status then
-            children[#children + 1] = ui.label({ text = status, fontSize = 11, color = "on_surface_variant" })
-        end
+    local status = entry == nil and noctalia.tr("ui.loading")
+        or entry.status == "error" and tostring(entry.error or noctalia.tr("ui.unavailable"))
+    if status then
+        children[#children + 1] = ui.label({ text = status, fontSize = 11, color = "on_surface_variant" })
     end
 
     local cards = {}
@@ -496,6 +482,23 @@ end
 
 function render()
     local entry = currentEntry()
+    -- A failure replaces the report rather than sitting above it. The numbers
+    -- are from a read that is no longer happening, and leaving them up puts a
+    -- provider list and a percentage next to an alert saying neither can be
+    -- trusted.
+    if failure.code ~= "" then
+        -- The panel keeps the fixed size the manifest gives it, so the block
+        -- is width-bounded rather than stretched across 720px of button.
+        panel.render(ui.column({ gap = 10, padding = 14, width = 320 }, {
+            ui.row({ gap = 8, align = "center" }, {
+                ui.glyph({ name = "brain", size = 18, color = "primary" }),
+                ui.label({ text = noctalia.tr("ui.title"), fontSize = 15, fontWeight = "bold", color = "primary" }),
+            }),
+            errorBlock(),
+        }))
+        return
+    end
+
     panel.render(ui.row({ gap = 0 }, {
         listPane(entry),
         -- ui.separator is horizontal only; a one-pixel column is the divider.

--- a/ai-usagebar/panel.luau
+++ b/ai-usagebar/panel.luau
@@ -375,6 +375,14 @@ local function errorBlock()
         noctalia.state.set("command", { action = "refresh", at = os.time() })
     end)
 
+    -- Retrying is pointless until the CLI exists, so that one failure gets the
+    -- install page as well. The URL is a literal, so there is nothing to quote.
+    if failure.code == "not_installed" then
+        children[#children + 1] = actionRow("external-link", "github.com/akitaonrails/ai-usagebar", function()
+            noctalia.runAsync("xdg-open https://github.com/akitaonrails/ai-usagebar")
+        end)
+    end
+
     return ui.column({ gap = 6 }, children)
 end
 

--- a/ai-usagebar/panel.luau
+++ b/ai-usagebar/panel.luau
@@ -5,8 +5,17 @@
 -- and free text that the shorter `metrics[]` view drops still show up.
 
 local report = nil
-local errorMsg = ""
 local polling = false
+
+-- The poller names the failure, so the panel only has a code to translate.
+-- Anything else in that state slot reads as no failure at all.
+local NO_FAILURE = { code = "", detail = "" }
+
+local function asFailure(value)
+    return type(value) == "table" and value or NO_FAILURE
+end
+
+local failure = NO_FAILURE
 
 -- Same parsing the capsule does. There is no require() below API 22, so the
 -- four helpers below are copied instead of shared.
@@ -334,6 +343,41 @@ end
 
 -- ── Render ────────────────────────────────────────────────────────────────────
 
+local function actionRow(glyph, text, onClick)
+    return ui.row({
+        gap = 5, align = "center", padding = 6, radius = 6,
+        fill = "surface_variant", onClick = onClick,
+    }, {
+        ui.glyph({ name = glyph, size = 12, color = "primary" }),
+        ui.label({ text = text, fontSize = 11, color = "primary" }),
+    })
+end
+
+-- The failure and the suggested fix read first; the CLI's own words come last
+-- and smallest, where a bug report can still quote them.
+local function errorBlock()
+    local key = "ui.error." .. failure.code
+    local children = {
+        ui.row({ gap = 6, align = "center" }, {
+            ui.glyph({ name = "alert-circle", size = 14, color = "error" }),
+            ui.label({ text = noctalia.tr(key), fontSize = 12, fontWeight = "bold", color = "error" }),
+        }),
+        ui.label({ text = noctalia.tr(key .. "_hint"), fontSize = 11, color = "on_surface_variant" }),
+    }
+
+    if failure.detail ~= "" then
+        children[#children + 1] = ui.label({
+            text = failure.detail, fontSize = 10, color = "on_surface_variant", maxLines = 3,
+        })
+    end
+
+    children[#children + 1] = actionRow("refresh", noctalia.tr("ui.retry"), function()
+        noctalia.state.set("command", { action = "refresh", at = os.time() })
+    end)
+
+    return ui.column({ gap = 6 }, children)
+end
+
 local function listPane(entry)
     local rows = {}
     for _, candidate in ipairs(entries()) do
@@ -342,9 +386,11 @@ local function listPane(entry)
       end
     end
     if #rows == 0 then
+        -- Headline only; the detail pane spells the failure out.
         rows[1] = ui.label({
-            text = errorMsg ~= "" and errorMsg or noctalia.tr("ui.loading"),
-            fontSize = 11, color = errorMsg ~= "" and "error" or "on_surface_variant",
+            text = failure.code ~= "" and noctalia.tr("ui.error." .. failure.code)
+                or noctalia.tr("ui.loading"),
+            fontSize = 11, color = failure.code ~= "" and "error" or "on_surface_variant",
         })
     end
 
@@ -406,19 +452,14 @@ local function detailPane(entry)
         children[#children + 1] = ui.row({ gap = 4, align = "center" }, chips)
     end
 
-    local status = ""
-    if errorMsg ~= "" then
-        status = errorMsg
-    elseif entry == nil then
-        status = noctalia.tr("ui.loading")
-    elseif entry.status == "error" then
-        status = tostring(entry.error or noctalia.tr("ui.unavailable"))
-    end
-    if status ~= "" then
-        children[#children + 1] = ui.label({
-            text = status, fontSize = 11,
-            color = errorMsg ~= "" and "error" or "on_surface_variant",
-        })
+    if failure.code ~= "" then
+        children[#children + 1] = errorBlock()
+    else
+        local status = entry == nil and noctalia.tr("ui.loading")
+            or entry.status == "error" and tostring(entry.error or noctalia.tr("ui.unavailable"))
+        if status then
+            children[#children + 1] = ui.label({ text = status, fontSize = 11, color = "on_surface_variant" })
+        end
     end
 
     local cards = {}
@@ -455,16 +496,14 @@ end
 noctalia.state.watch("report", function(value)
     if type(value) == "table" then
         report = value
-        errorMsg = ""
+        failure = NO_FAILURE
         render()
     end
 end)
 
 noctalia.state.watch("error", function(value)
-    if type(value) == "string" then
-        errorMsg = value
-        render()
-    end
+    failure = asFailure(value)
+    render()
 end)
 
 noctalia.state.watch("polling", function(value)
@@ -478,8 +517,7 @@ function onOpen(_context)
     -- together, so reopening the panel repeatedly is cheap.
     noctalia.state.set("command", { action = "refresh", at = os.time() })
     report = noctalia.state.get("report")
-    local existingError = noctalia.state.get("error")
-    errorMsg = type(existingError) == "string" and existingError or ""
+    failure = asFailure(noctalia.state.get("error"))
     polling = noctalia.state.get("polling") == true
     -- Countdowns tick locally; the CLI is only woken by the poller's interval.
     panel.setWantsSecondTicks(true)

--- a/ai-usagebar/plugin.toml
+++ b/ai-usagebar/plugin.toml
@@ -1,6 +1,6 @@
 id = "felipeartur/ai-usagebar"
 name = "AI Usage"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 9
 author = "felipeartur"
 license = "MIT"

--- a/ai-usagebar/plugin.toml
+++ b/ai-usagebar/plugin.toml
@@ -9,7 +9,7 @@ description = "AI plan usage in the bar, powered by the ai-usagebar CLI."
 tags = ["bar", "panel", "ai", "indicator", "utility"]
 # The CLI owns credentials, vendor endpoints and caching. This plugin only runs
 # `ai-usagebar usage --json` and draws the result.
-dependencies = ["ai-usagebar"]
+dependencies = ["ai-usagebar", "xdg-open"]
 
 # ── Plugin-level settings (shared by the poller, every capsule and the panel) ──
 

--- a/ai-usagebar/service.luau
+++ b/ai-usagebar/service.luau
@@ -20,10 +20,18 @@ end
 local function safeText(value)
     local text = noctalia.string.trim(tostring(value or ""))
     text = text:gsub("%s+", " ")
-    text = text:gsub("([%w_%-]*[Kk][Ee][Yy][%w_%-]*=)[^%s]+", "%1<redacted>")
-    text = text:gsub("([Tt][Oo][Kk][Ee][Nn][%w_%-]*=)[^%s]+", "%1<redacted>")
-    text = text:gsub("([Ss][Ee][Cc][Rr][Ee][Tt][%w_%-]*=)[^%s]+", "%1<redacted>")
-    text = text:gsub("([Bb]earer%s+)[^%s]+", "%1<redacted>")
+    -- `scrub` runs this over ~165 strings per two-vendor read, and four
+    -- backtracking patterns on each one exhaust the callback's CPU budget,
+    -- which costs the whole report. All four need a literal `=` or `earer` to
+    -- match, so a plan name or a percentage skips them.
+    if text:find("=", 1, true) then
+        text = text:gsub("([%w_%-]*[Kk][Ee][Yy][%w_%-]*=)[^%s]+", "%1<redacted>")
+        text = text:gsub("([Tt][Oo][Kk][Ee][Nn][%w_%-]*=)[^%s]+", "%1<redacted>")
+        text = text:gsub("([Ss][Ee][Cc][Rr][Ee][Tt][%w_%-]*=)[^%s]+", "%1<redacted>")
+    end
+    if text:find("earer", 1, true) then
+        text = text:gsub("([Bb]earer%s+)[^%s]+", "%1<redacted>")
+    end
     if #text > 200 then text = string.sub(text, 1, 200) .. "..." end
     return text
 end

--- a/ai-usagebar/service.luau
+++ b/ai-usagebar/service.luau
@@ -45,6 +45,33 @@ local function scrub(value)
     return value
 end
 
+-- The one place a failure is named. Subscribers translate the code, and the
+-- CLI's own text travels with it as `detail`, redacted like any other string
+-- that reaches the screen.
+local function failure(code, detail)
+    return { code = code, detail = safeText(detail) }
+end
+
+-- The run's outcome as one code. A missing binary is split out from the
+-- generic failure because it is the one a user can fix directly, and shells
+-- report it as one of two messages.
+local function classify(result)
+    if result == nil then return failure("spawn_failed") end
+    if result.timedOut then return failure("timed_out") end
+
+    local stderr = safeText(result.stderr)
+    local lower = stderr:lower()
+    if lower:find("command not found", 1, true)
+        or lower:find("no such file or directory", 1, true) then
+        return failure("not_installed", stderr)
+    end
+    if result.exitCode ~= 0 then
+        return failure("failed", stderr ~= "" and stderr
+            or ("ai-usagebar exited with code " .. tostring(result.exitCode)))
+    end
+    return failure("no_data", stderr)
+end
+
 local inFlight = false
 
 -- The CLI caches for a minute, so a manual refresh usually answers in about ten
@@ -90,27 +117,18 @@ local function refresh()
             -- A vendor that failed still comes back as an entry with `status =
             -- "error"`, so a non-zero exit is not a reason to drop the report.
             noctalia.state.set("report", scrub(decoded))
-            noctalia.state.set("error", "")
+            noctalia.state.set("error", failure(""))
             return
         end
 
-        local message = "ai-usagebar returned no usage data"
-        if result == nil then
-            message = "could not run ai-usagebar"
-        elseif result.timedOut then
-            message = "ai-usagebar timed out"
-        elseif result.exitCode ~= 0 then
-            local stderr = safeText(result.stderr)
-            message = stderr ~= "" and stderr or ("ai-usagebar exited with code " .. tostring(result.exitCode))
-        end
-        noctalia.state.set("error", message)
+        noctalia.state.set("error", classify(result))
     end, 30000)
 
     -- A refusal to spawn never calls back, and without this the poller would
     -- sit in flight forever and stop asking.
     if not started then
         inFlight = false
-        noctalia.state.set("error", "could not run ai-usagebar")
+        noctalia.state.set("error", failure("spawn_failed"))
         stopPolling()
     end
 end

--- a/ai-usagebar/service.luau
+++ b/ai-usagebar/service.luau
@@ -61,7 +61,10 @@ local function classify(result)
     if result == nil then return failure("spawn_failed") end
     if result.timedOut then return failure("timed_out") end
 
-    local stderr = safeText(result.stderr)
+    -- Matched raw. `failure` scrubs what it is given, and scrubbing first would
+    -- mean matching against text already capped at 200 characters, so a noisy
+    -- run could push the message that names the failure out of reach.
+    local stderr = tostring(result.stderr or "")
     local lower = stderr:lower()
     if result.exitCode == 127
         and (lower:find("command not found", 1, true)
@@ -69,7 +72,9 @@ local function classify(result)
         return failure("not_installed", stderr)
     end
     if result.exitCode ~= 0 then
-        return failure("failed", stderr ~= "" and stderr
+        -- Whitespace-only stderr scrubs down to nothing, so the exit code has
+        -- to answer for it rather than a detail that arrives on screen empty.
+        return failure("failed", stderr:find("%S") and stderr
             or ("ai-usagebar exited with code " .. tostring(result.exitCode)))
     end
     return failure("no_data", stderr)

--- a/ai-usagebar/service.luau
+++ b/ai-usagebar/service.luau
@@ -53,16 +53,19 @@ local function failure(code, detail)
 end
 
 -- The run's outcome as one code. A missing binary is split out from the
--- generic failure because it is the one a user can fix directly, and shells
--- report it as one of two messages.
+-- generic failure because the panel can offer an install link for that one,
+-- and shells report it as one of two messages. Both arrive with status 127,
+-- which a CLI that merely cannot open its own config file does not use, so the
+-- code has to agree with the message before the install link is offered.
 local function classify(result)
     if result == nil then return failure("spawn_failed") end
     if result.timedOut then return failure("timed_out") end
 
     local stderr = safeText(result.stderr)
     local lower = stderr:lower()
-    if lower:find("command not found", 1, true)
-        or lower:find("no such file or directory", 1, true) then
+    if result.exitCode == 127
+        and (lower:find("command not found", 1, true)
+            or lower:find("no such file or directory", 1, true)) then
         return failure("not_installed", stderr)
     end
     if result.exitCode ~= 0 then

--- a/ai-usagebar/translations/en.json
+++ b/ai-usagebar/translations/en.json
@@ -61,13 +61,27 @@
     }
   },
   "ui": {
+    "details": "Details",
     "elapsed": "{percent}% of the window elapsed",
+    "error": {
+      "failed": "Could not read usage",
+      "failed_hint": "ai-usagebar exited with an error.",
+      "no_data": "No usage reported",
+      "no_data_hint": "ai-usagebar ran but reported no usage. Check the providers in `~/.config/ai-usagebar/config.toml`.",
+      "not_installed": "ai-usagebar is not installed",
+      "not_installed_hint": "The CLI is not on PATH. Install it, then try again.",
+      "spawn_failed": "Could not start ai-usagebar",
+      "spawn_failed_hint": "The process never started. Try again in a moment.",
+      "timed_out": "ai-usagebar did not answer",
+      "timed_out_hint": "The read took too long. A provider may be answering slowly."
+    },
     "hidden_label": "Not shown",
     "hidden_value": "{count} more, click to open the panel",
     "loading": "Loading…",
     "no_usage": "No usage reported",
     "not_configured": "`{vendor}` is not configured in ai-usagebar",
     "now": "now",
+    "retry": "Try again",
     "stale": "stale",
     "stale_hint": "showing last known data",
     "title": "AI Usage",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `felipeartur/ai-usagebar`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

A failing read used to freeze the widget, and the message it left on screen
was the shell's rather than the plugin's. Each commit stands on its own.

The freeze came from the scrubber. Every string in the report goes through
`safeText`, which is around a hundred and sixty of them on a two-vendor read,
and each one paid for four patterns that backtrack. That exhausted the Luau
callback's CPU budget, and a callback that dies never reaches the line that
publishes the report, so the widget latched on whatever error was written last
and could not recover: the next read died in the same place before it could
clear it. All four patterns need a literal `=`, or `earer` for the Bearer
case, before they can match, so a plain `find` now decides whether they run at
all. The patterns themselves are untouched and the output is byte-identical.

The message it latched on was `/bin/sh: line 1: ai-usagebar: command not
found`, which is the plugin's own plumbing talking. The poller now names the
outcome instead: `not_installed`, `spawn_failed`, `timed_out`, `no_data` or
`failed`, carrying the CLI's text alongside as `detail`. The panel lays that
out in the order it is read: what broke, what to do about it, then the CLI's
own words last and smallest, with a retry row under them. The detail goes
through the same scrubber as every other string, so a credential quoted in
stderr is redacted before it is drawn. The provider list keeps the headline
only, since it is 250px of column and the raw text was clipping mid-word
there.

A missing binary is the one failure a user can fix on the spot, so that code
also gets a row opening the CLI's page, labelled with the destination. Only
that code gets it, because on a timeout the CLI is already installed.
Tightening what counts as missing came with it: matching the message alone
also caught the CLI failing to open its own config file, which says "no such
file or directory" too, and the panel would then send the user to reinstall
the one thing that was working. Both shell forms exit 127, so the status has
to agree with the message.

A failure now replaces the report rather than sitting above it. The panel used
to keep the last one on screen under the alert, which left a provider list and
a percentage in front of someone who had just been told the CLI could not be
reached, with nothing saying how old either was. The panel draws the error
block alone, and the capsule falls back to the alert glyph it already had for
an empty reading. The report stays in plugin state, so a read that lands puts
everything back without another spawn.

The readme gains a note that the file watcher follows the `.luau` entries
only, so strings in `translations/` are read once when the plugin loads.
Editing one looks like nothing happened until the plugin is cycled.

`translations/en.json` keeps the sorted layout this repo normalised it to, and
`catalog.toml` is untouched.

## External dependencies

`ai-usagebar`, as before: one `ai-usagebar usage --json` per interval, which
is the only source of anything the plugin draws.

`xdg-open` is new in this PR, added to `dependencies` in `plugin.toml`. It is
spawned by one row in the panel, the install link shown on a `not_installed`
failure, with a literal URL and nothing interpolated into the command. The row
is drawn only where `commandExists` finds an opener, so a session without
xdg-utils loses that link and nothing else.

No network calls and no filesystem writes.

## Testing

Exercised on a live bar with the real CLI against Claude and Codex.

The failure path was forced by pointing the poller at a binary that does not
exist, so every branch of the error UI was seen on screen rather than reasoned
about: the named title, the hint, the raw CLI line, the retry row and the
install link. The link was confirmed to open the project page. Recovery was
checked by restoring the command and watching the panel come back to live
numbers on its own.

The branch where no opener exists was exercised too, by pointing
`commandExists` at a name that is genuinely absent from PATH. The install row
disappears and the retry row stays, which is what the readme promises. That
was done in place of uninstalling xdg-utils, since qt6-base depends on it and
noctalia is the Qt application under test.

`noctalia msg plugin felipeartur/ai-usagebar:poller all refresh` and
`noctalia msg panel-open felipeartur/ai-usagebar:panel` both still behave.
Settings were toggled across `style`, `provider_limit` and `extras`.

Beyond the UI, each failure code was driven through the real `service.luau`
with a stubbed host, including a case proving a credential in stderr is
redacted before it reaches `detail`, and a case proving a good read clears the
failure rather than latching it. The redaction guards were checked against the
unguarded patterns over 400k generated strings, byte-identical on every one.
Matching the classifier against raw stderr was checked with 250 characters of
noise ahead of `command not found`: it came back `failed` before and
`not_installed` after.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0 (5.0.0_beta.8)
- **Plugin API level:** 9

## Screenshots / Videos

The panel with a failing read. The poller was pointed at a binary that does
not exist, which is why the CLI line names `ai-usagebar-TESTONLY`. No provider
list and no percentages: the reading is gone for as long as the failure lasts.

![Panel showing a failed read and nothing else: the title "ai-usagebar is not installed", the hint, the raw CLI line, a retry row and a link to the CLI's page](https://github.com/FelipeArtur/community-plugins/releases/download/pr-391-assets/shot-error.png)

The same panel once a read lands. The report comes back from plugin state
without another spawn.

![Panel with live usage: Claude at 72% of the session window and 32% of the weekly window](https://github.com/FelipeArtur/community-plugins/releases/download/pr-391-assets/shot-healthy.png)

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
