### PR TITLE
fix(keybind-cheatsheet): update to v0.2.3 and prevent short key pill elision

### DIFF
--- a/keybind-cheatsheet/panel.luau
+++ b/keybind-cheatsheet/panel.luau
@@ -293,13 +293,14 @@ end
 local function keyPill(text, bucketId, key)
   return ui.column({
     key = key,
+    minWidth = 20,
     fill = colorValue(bucketId, "background"),
     radius = 4,
     paddingH = 7,
     paddingV = 3,
     align = "center",
   }, {
-    ui.label({ text = text, color = colorValue(bucketId, "text"), fontSize = 12, fontWeight = "bold", maxLines = 1 }),
+    ui.label({ text = text, color = colorValue(bucketId, "text"), fontSize = 12, fontWeight = "bold" }),
   })
 end
 
@@ -883,6 +884,7 @@ return {
   restoreHiddenBindings = restoreHiddenBindings,
   categoryPriority = categoryPriority,
   friendlyAction = friendlyAction,
+  keyPill = keyPill,
   applySnapshot = applySnapshot,
   onOpen = onOpen,
   onClose = onClose,

--- a/keybind-cheatsheet/plugin.toml
+++ b/keybind-cheatsheet/plugin.toml
@@ -1,6 +1,6 @@
 id = "kenn/keybind-cheatsheet"
 name = "Keybind Cheatsheet"
-version = "0.2.2"
+version = "0.2.3"
 plugin_api = 9
 author = "kenn"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** kenn/keybind-cheatsheet
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes Issue #398 by adding `minWidth = 20` and removing `maxLines = 1` from key pill labels in `panel.luau`. This prevents QML text layout from truncating 1-character and 2-character key names (such as `D`, `up`, `1`) into ellipses (`...`) on tight badge containers.

## External dependencies

None

## Testing

- [x] Tested on Niri
- [x] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** 9

## Screenshots / Videos

No UI layout structure changes; prevents text truncation on short key pills.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.