### PR TITLE
Harden Mihomo Control service resilience (v0.1.2)

### DIFF
--- a/mihomo-control/README.md
+++ b/mihomo-control/README.md
@@ -85,6 +85,28 @@ the same command tables the panel sends (`mode`, `select`, `delay_test`,
 `self-test` runs in-process checks for group ordering, traffic dedup helpers,
 and watchdog interval setup; results are published to `mihomo.self_test`.
 
+## Testing
+
+Offline unit tests (plain Lua, no running shell required):
+
+```sh
+cd mihomo-control
+lua5.4 tests/group_order_test.lua
+noctalia plugins lint .
+```
+
+Full smoke test (adds live IPC when Noctalia is running):
+
+```sh
+./mihomo-control/tests/smoke.sh
+```
+
+Runtime self-test against the loaded service:
+
+```sh
+noctalia msg plugin mdj2812/mihomo-control:service all self-test
+```
+
 ## Notes
 
 - The plugin only talks HTTP to the configured external controller. It spawns
@@ -110,7 +132,7 @@ and watchdog interval setup; results are published to `mihomo.self_test`.
 ## Development
 
 - `service.luau` — headless API backend, publishes `mihomo.*` state.
-- `group_logic.lua` — pure helpers for group ordering and traffic dedup.
+- `group_logic.lua` — pure helpers for group ordering and traffic dedup (unit-tested).
 - `widget.luau` — bar widget (rates + tooltip).
 - `panel.luau` — control panel.
 - `shortcut.luau` — rule/global mode toggle.

--- a/mihomo-control/README.md
+++ b/mihomo-control/README.md
@@ -82,6 +82,8 @@ noctalia msg plugin mdj2812/mihomo-control:service all cmd '{"op":"mode","mode":
 `refresh` re-polls version, config, connections and proxy groups. `cmd` accepts
 the same command tables the panel sends (`mode`, `select`, `delay_test`,
 `delay_test_all`, `reorder_group`, `restart`, `close_connections`, `refresh`).
+`self-test` runs in-process checks for group ordering, traffic dedup helpers,
+and watchdog interval setup; results are published to `mihomo.self_test`.
 
 ## Notes
 
@@ -108,6 +110,7 @@ the same command tables the panel sends (`mode`, `select`, `delay_test`,
 ## Development
 
 - `service.luau` — headless API backend, publishes `mihomo.*` state.
+- `group_logic.lua` — pure helpers for group ordering and traffic dedup.
 - `widget.luau` — bar widget (rates + tooltip).
 - `panel.luau` — control panel.
 - `shortcut.luau` — rule/global mode toggle.

--- a/mihomo-control/group_logic.lua
+++ b/mihomo-control/group_logic.lua
@@ -1,0 +1,95 @@
+-- Pure helpers shared by service.luau and Lua unit tests.
+-- Plain Lua 5.x syntax so tests can loadfile() without a Luau runtime.
+
+local M = {}
+
+function M.clamp_interval(seconds)
+  local value = tonumber(seconds) or 2
+  return math.max(1, math.min(60, value))
+end
+
+function M.normalize_group_order(raw_order)
+  local order = {}
+  if type(raw_order) ~= "table" then
+    return order
+  end
+  local seen = {}
+  for _, name in ipairs(raw_order) do
+    if type(name) == "string" and name ~= "" and not seen[name] then
+      seen[name] = true
+      table.insert(order, name)
+    end
+  end
+  return order
+end
+
+function M.apply_group_order(groups, group_order)
+  local rank = {}
+  for index, name in ipairs(group_order or {}) do
+    rank[name] = index
+  end
+  table.sort(groups, function(a, b)
+    local a_rank = rank[a.name]
+    local b_rank = rank[b.name]
+    if a_rank ~= nil and b_rank ~= nil then
+      return a_rank < b_rank
+    end
+    if a_rank ~= nil then
+      return true
+    end
+    if b_rank ~= nil then
+      return false
+    end
+    return a.name < b.name
+  end)
+  return groups
+end
+
+-- Gaps are numbered 1..#groups+1. Returns (groups, order) or nil when invalid.
+function M.reorder_groups(groups, group_name, insertion_index)
+  local from_index = nil
+  for index, group in ipairs(groups) do
+    if group.name == group_name then
+      from_index = index
+      break
+    end
+  end
+
+  local insert_at = tonumber(insertion_index)
+  if from_index == nil or insert_at == nil then
+    return nil
+  end
+
+  local copy = {}
+  for index, group in ipairs(groups) do
+    copy[index] = group
+  end
+
+  insert_at = math.floor(insert_at)
+  local moved = table.remove(copy, from_index)
+  if from_index < insert_at then
+    insert_at = insert_at - 1
+  end
+  insert_at = math.max(1, math.min(insert_at, #copy + 1))
+  table.insert(copy, insert_at, moved)
+
+  local order = {}
+  for _, group in ipairs(copy) do
+    table.insert(order, group.name)
+  end
+  return copy, order
+end
+
+function M.traffic_changed(previous, next_values)
+  if type(previous) ~= "table" or type(next_values) ~= "table" then
+    return true
+  end
+  return not (
+    (tonumber(next_values.up) or previous.up) == previous.up
+      and (tonumber(next_values.down) or previous.down) == previous.down
+      and (tonumber(next_values.upTotal) or previous.upTotal) == previous.upTotal
+      and (tonumber(next_values.downTotal) or previous.downTotal) == previous.downTotal
+  )
+end
+
+return M

--- a/mihomo-control/plugin.toml
+++ b/mihomo-control/plugin.toml
@@ -8,7 +8,7 @@
 
 id = "mdj2812/mihomo-control"
 name = "Mihomo Control"
-version = "0.1.1"
+version = "0.1.2"
 plugin_api = 9
 author = "mdj2812"
 license = "MIT"

--- a/mihomo-control/service.luau
+++ b/mihomo-control/service.luau
@@ -27,6 +27,35 @@ local DEFAULT_TEST_URL = "https://www.gstatic.com/generate_204"
 local GROUPS_REFRESH_EVERY = 5 -- every Nth tick, re-fetch /proxies
 local STREAM_RETRY_EVERY = 5 -- ticks between traffic-stream retry attempts
 
+local function log(msg)
+  noctalia.log("[mihomo-control/service] " .. tostring(msg))
+end
+
+local function safe_call(label, fn)
+  local ok, err = pcall(fn)
+  if not ok then
+    log(label .. " failed: " .. tostring(err))
+  end
+end
+
+local group_logic
+
+local function require_group_logic()
+  if group_logic ~= nil then
+    return group_logic
+  end
+  local source, err = noctalia.readFile("group_logic.lua")
+  if source == nil then
+    error("failed to read group_logic.lua: " .. tostring(err))
+  end
+  local chunk, load_err = load(source, "@group_logic.lua")
+  if chunk == nil then
+    error("failed to load group_logic.lua: " .. tostring(load_err))
+  end
+  group_logic = chunk()
+  return group_logic
+end
+
 -- ── Settings ────────────────────────────────────────────────────────────────
 
 local settings = {
@@ -55,7 +84,15 @@ local function reload_settings()
   settings.use_https = noctalia.getConfig("use_https") == true
   settings.insecure = noctalia.getConfig("allow_insecure_tls") == true
   settings.test_url = type(test_url) == "string" and noctalia.string.trim(test_url) or ""
-  settings.interval = math.max(1, math.min(60, interval))
+  settings.interval = require_group_logic().clamp_interval(interval)
+end
+
+-- Keep the service watchdog fed even before the first update() tick.
+local interval_applied_at_load = false
+
+local function apply_interval()
+  noctalia.setUpdateInterval(settings.interval * 1000)
+  interval_applied_at_load = true
 end
 
 local function base_url()
@@ -128,13 +165,7 @@ local function load_group_order()
     return
   end
 
-  local seen = {}
-  for _, name in ipairs(decoded.groupOrder) do
-    if type(name) == "string" and name ~= "" and not seen[name] then
-      seen[name] = true
-      table.insert(group_order, name)
-    end
-  end
+  group_order = require_group_logic().normalize_group_order(decoded.groupOrder)
 end
 
 local function save_group_order()
@@ -154,24 +185,7 @@ local function save_group_order()
 end
 
 local function apply_group_order(groups)
-  local rank = {}
-  for index, name in ipairs(group_order) do
-    rank[name] = index
-  end
-  table.sort(groups, function(a, b)
-    local a_rank = rank[a.name]
-    local b_rank = rank[b.name]
-    if a_rank ~= nil and b_rank ~= nil then
-      return a_rank < b_rank
-    end
-    if a_rank ~= nil then
-      return true
-    end
-    if b_rank ~= nil then
-      return false
-    end
-    return a.name < b.name
-  end)
+  require_group_logic().apply_group_order(groups, group_order)
 end
 
 local function publish(key)
@@ -373,17 +387,29 @@ local function start_traffic_stream()
       allow_insecure_tls = settings.insecure,
     },
     function(line)
-      if line == "" then
-        return
-      end
-      local data = decode(line)
-      if data then
-        state.traffic.up = tonumber(data.up) or state.traffic.up
-        state.traffic.down = tonumber(data.down) or state.traffic.down
-        state.traffic.upTotal = tonumber(data.upTotal) or state.traffic.upTotal
-        state.traffic.downTotal = tonumber(data.downTotal) or state.traffic.downTotal
+      safe_call("traffic stream", function()
+        if line == "" then
+          return
+        end
+        local data = decode(line)
+        if not data then
+          return
+        end
+        local next_values = {
+          up = tonumber(data.up) or state.traffic.up,
+          down = tonumber(data.down) or state.traffic.down,
+          upTotal = tonumber(data.upTotal) or state.traffic.upTotal,
+          downTotal = tonumber(data.downTotal) or state.traffic.downTotal,
+        }
+        if not require_group_logic().traffic_changed(state.traffic, next_values) then
+          return
+        end
+        state.traffic.up = next_values.up
+        state.traffic.down = next_values.down
+        state.traffic.upTotal = next_values.upTotal
+        state.traffic.downTotal = next_values.downTotal
         publish("traffic")
-      end
+      end)
     end,
     function(result)
       traffic_stream = nil
@@ -519,31 +545,13 @@ end
 -- Move one group to an insertion gap in the currently published order. Gaps
 -- are numbered 1..#groups+1; removing an item shifts later gaps down by one.
 local function reorder_group(group_name, insertion_index)
-  local from_index = nil
-  for index, group in ipairs(state.groups) do
-    if group.name == group_name then
-      from_index = index
-      break
-    end
-  end
-
-  local insert_at = tonumber(insertion_index)
-  if from_index == nil or insert_at == nil then
+  local reordered, order = require_group_logic().reorder_groups(state.groups, group_name, insertion_index)
+  if reordered == nil then
     return
   end
 
-  insert_at = math.floor(insert_at)
-  local moved = table.remove(state.groups, from_index)
-  if from_index < insert_at then
-    insert_at -= 1
-  end
-  insert_at = math.max(1, math.min(insert_at, #state.groups + 1))
-  table.insert(state.groups, insert_at, moved)
-
-  group_order = {}
-  for _, group in ipairs(state.groups) do
-    table.insert(group_order, group.name)
-  end
+  state.groups = reordered
+  group_order = order
   save_group_order()
   publish("groups")
 end
@@ -645,16 +653,77 @@ local function handle_command(cmd)
   end
 end
 
+local function run_self_test(quiet)
+  local logic = require_group_logic()
+  local checks = {}
+
+  local function check(name, ok, detail)
+    table.insert(checks, { name = name, ok = ok == true, detail = detail or "" })
+  end
+
+  local ordered = {
+    { name = "beta" },
+    { name = "alpha" },
+    { name = "zeta" },
+  }
+  logic.apply_group_order(ordered, { "beta", "alpha" })
+  check(
+    "apply_group_order",
+    ordered[1].name == "beta" and ordered[2].name == "alpha" and ordered[3].name == "zeta",
+  )
+
+  local reordered, order = logic.reorder_groups({
+    { name = "a" },
+    { name = "b" },
+    { name = "c" },
+  }, "c", 1)
+  check("reorder_groups", reordered ~= nil and order[1] == "c" and order[3] == "b")
+
+  check(
+    "traffic_changed",
+    logic.traffic_changed({ up = 1, down = 2, upTotal = 3, downTotal = 4 }, { up = 9, down = 2, upTotal = 3, downTotal = 4 }),
+  )
+
+  check("interval_at_load", interval_applied_at_load)
+
+  local passed = true
+  for _, item in ipairs(checks) do
+    if not item.ok then
+      passed = false
+    end
+  end
+
+  local report = {
+    passed = passed,
+    checks = checks,
+    at = os.time(),
+  }
+  noctalia.state.set("mihomo.self_test", report)
+
+  if not quiet then
+    if passed then
+      noctalia.notify(noctalia.tr("notify.self_test_passed"), noctalia.tr("notify.self_test_passed_body"))
+    else
+      noctalia.notifyError(noctalia.tr("notify.self_test_failed"), noctalia.tr("notify.self_test_failed_body"))
+    end
+  end
+
+  log("self-test " .. (passed and "passed" or "failed") .. " (" .. tostring(#checks) .. " checks)")
+  return report
+end
+
 noctalia.state.watch("mihomo.command", function(cmd)
-  if type(cmd) ~= "table" then
-    return
-  end
-  local seq = tonumber(cmd.seq) or 0
-  if seq <= last_cmd_seq then
-    return
-  end
-  last_cmd_seq = seq
-  handle_command(cmd)
+  safe_call("command", function()
+    if type(cmd) ~= "table" then
+      return
+    end
+    local seq = tonumber(cmd.seq) or 0
+    if seq <= last_cmd_seq then
+      return
+    end
+    last_cmd_seq = seq
+    handle_command(cmd)
+  end)
 end)
 
 -- ── Entry-point callbacks ───────────────────────────────────────────────────
@@ -662,24 +731,27 @@ end)
 local tick = 0
 
 function update()
-  tick += 1
-  noctalia.setUpdateInterval(settings.interval * 1000)
+  safe_call("update", function()
+    tick += 1
+    apply_interval()
 
-  poll_version()
-  poll_configs()
-  poll_connections()
-  if tick % GROUPS_REFRESH_EVERY == 1 then
-    poll_proxies()
-  end
+    poll_version()
+    poll_configs()
+    poll_connections()
+    if tick % GROUPS_REFRESH_EVERY == 1 then
+      poll_proxies()
+    end
 
-  if traffic_stream == nil and tick - stream_attempt_tick >= STREAM_RETRY_EVERY then
-    stream_attempt_tick = tick
-    start_traffic_stream()
-  end
+    if traffic_stream == nil and tick - stream_attempt_tick >= STREAM_RETRY_EVERY then
+      stream_attempt_tick = tick
+      start_traffic_stream()
+    end
+  end)
 end
 
 function onConfigChanged()
   reload_settings()
+  apply_interval()
   state.connection.host = settings.host
   state.connection.port = settings.port
   publish("connection")
@@ -697,22 +769,27 @@ function onConfigChanged()
 end
 
 function onIpc(event, payload)
-  if event == "refresh" then
-    poll_version()
-    poll_configs()
-    poll_connections()
-    poll_proxies()
-  elseif event == "cmd" and payload then
-    local ok, cmd = pcall(noctalia.json.decode, payload)
-    if ok and type(cmd) == "table" then
-      handle_command(cmd)
+  safe_call("ipc:" .. tostring(event), function()
+    if event == "refresh" then
+      poll_version()
+      poll_configs()
+      poll_connections()
+      poll_proxies()
+    elseif event == "self-test" then
+      run_self_test(false)
+    elseif event == "cmd" and payload then
+      local ok, cmd = pcall(noctalia.json.decode, payload)
+      if ok and type(cmd) == "table" then
+        handle_command(cmd)
+      end
     end
-  end
+  end)
 end
 
 -- ── Init ────────────────────────────────────────────────────────────────────
 
 reload_settings()
+apply_interval()
 load_group_order()
 state.connection.host = settings.host
 state.connection.port = settings.port
@@ -728,3 +805,4 @@ poll_configs()
 poll_connections()
 poll_proxies()
 start_traffic_stream()
+log("loaded, interval=" .. tostring(settings.interval) .. "s")

--- a/mihomo-control/tests/group_order_test.lua
+++ b/mihomo-control/tests/group_order_test.lua
@@ -1,0 +1,75 @@
+#!/usr/bin/env lua5.4
+
+local function plugin_root()
+  local source = debug.getinfo(1, "S").source
+  if source:sub(1, 1) == "@" then
+    source = source:sub(2)
+  end
+  local dir = source:match("^(.*)/") or "."
+  if dir:match("/tests$") or dir == "tests" then
+    return dir .. "/.."
+  end
+  return dir
+end
+
+local function assert_eq(actual, expected, message)
+  if actual ~= expected then
+    error((message or "assert_eq") .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual))
+  end
+end
+
+local function assert_tables_eq(actual, expected, message)
+  if #actual ~= #expected then
+    error((message or "assert_tables_eq") .. ": length " .. tostring(#actual) .. " != " .. tostring(#expected))
+  end
+  for index, value in ipairs(expected) do
+    if actual[index] ~= value then
+      error((message or "assert_tables_eq") .. ": index " .. index .. " expected " .. tostring(value) .. ", got " .. tostring(actual[index]))
+    end
+  end
+end
+
+local logic = dofile(plugin_root() .. "/group_logic.lua")
+
+local groups = {
+  { name = "zeta" },
+  { name = "alpha" },
+  { name = "beta" },
+}
+
+logic.apply_group_order(groups, { "beta", "alpha" })
+assert_tables_eq({ groups[1].name, groups[2].name, groups[3].name }, { "beta", "alpha", "zeta" }, "known order first")
+
+logic.apply_group_order(groups, {})
+assert_tables_eq({ groups[1].name, groups[2].name, groups[3].name }, { "alpha", "beta", "zeta" }, "unknown groups sort alphabetically")
+
+local reordered, order = logic.reorder_groups({
+  { name = "a" },
+  { name = "b" },
+  { name = "c" },
+}, "c", 1)
+assert(reordered ~= nil, "reorder_groups should succeed")
+assert_tables_eq(order, { "c", "a", "b" }, "move to front")
+
+reordered, order = logic.reorder_groups({
+  { name = "a" },
+  { name = "b" },
+  { name = "c" },
+}, "a", 4)
+assert_tables_eq(order, { "b", "c", "a" }, "move to back")
+
+assert(logic.reorder_groups({ { name = "a" } }, "missing", 1) == nil, "unknown group is rejected")
+assert(logic.reorder_groups({ { name = "a" } }, "a", nil) == nil, "missing index is rejected")
+
+assert_eq(logic.normalize_group_order({ "b", "", "a", "b", "a" })[1], "b", "dedupe keeps first occurrence")
+assert_eq(#logic.normalize_group_order({ "b", "", "a", "b", "a" }), 2, "dedupe drops blanks and duplicates")
+
+assert_eq(logic.clamp_interval(0), 1, "interval floor")
+assert_eq(logic.clamp_interval(120), 60, "interval ceiling")
+assert_eq(logic.clamp_interval(5), 5, "interval passthrough")
+
+local traffic = { up = 1, down = 2, upTotal = 3, downTotal = 4 }
+assert(logic.traffic_changed(traffic, { up = 1, down = 2, upTotal = 3, downTotal = 4 }) == false, "identical traffic is unchanged")
+assert(logic.traffic_changed(traffic, { up = 9, down = 2, upTotal = 3, downTotal = 4 }) == true, "changed traffic is detected")
+
+print("mihomo-control group_logic tests: ok")

--- a/mihomo-control/tests/smoke.sh
+++ b/mihomo-control/tests/smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> lint"
+noctalia plugins lint .
+
+echo "==> unit tests"
+lua5.4 tests/group_order_test.lua
+
+if command -v noctalia >/dev/null 2>&1 && pgrep -x noctalia >/dev/null 2>&1; then
+  echo "==> ipc refresh"
+  noctalia msg plugin mdj2812/mihomo-control:service all refresh
+
+  echo "==> ipc self-test"
+  noctalia msg plugin mdj2812/mihomo-control:service all self-test
+else
+  echo "==> skipping live IPC tests (noctalia is not running)"
+fi
+
+echo "mihomo-control smoke tests: ok"

--- a/mihomo-control/translations/en.json
+++ b/mihomo-control/translations/en.json
@@ -10,7 +10,11 @@
     "proxy_selected": "Proxy selected",
     "proxy_selected_body": "{group} → {proxy}",
     "request_failed": "Mihomo request failed",
-    "restarting": "Mihomo is restarting"
+    "restarting": "Mihomo is restarting",
+    "self_test_failed": "Mihomo self-test failed",
+    "self_test_failed_body": "See Noctalia logs or mihomo.self_test state for details.",
+    "self_test_passed": "Mihomo self-test passed",
+    "self_test_passed_body": "Group ordering and service checks succeeded."
   },
   "panel": {
     "connections": "connections",

--- a/mihomo-control/translations/zh-Hans.json
+++ b/mihomo-control/translations/zh-Hans.json
@@ -10,7 +10,11 @@
     "proxy_selected": "已选择代理",
     "proxy_selected_body": "{group} → {proxy}",
     "request_failed": "Mihomo 请求失败",
-    "restarting": "Mihomo 正在重启"
+    "restarting": "Mihomo 正在重启",
+    "self_test_failed": "Mihomo 自检失败",
+    "self_test_failed_body": "请查看 Noctalia 日志或 mihomo.self_test 状态了解详情。",
+    "self_test_passed": "Mihomo 自检通过",
+    "self_test_passed_body": "策略组排序与服务检查均已通过。"
   },
   "panel": {
     "connections": "条连接",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `mdj2812/mihomo-control`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Hardens the Mihomo Control service so a wedged VM no longer trips the Noctalia watchdog: schedule update ticks at load, wrap callbacks in safe error handling, dedupe traffic publishes, and add a `self-test` IPC hook. Extracts group-ordering helpers into `group_logic.lua` with Lua unit tests and a smoke script.

## External dependencies

None

## Testing

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: KDE
- **Noctalia version tested against:** v5.0.0-beta.8
- **Plugin API level:** 9

Ran `mihomo-control/tests/smoke.sh` (lint, `lua5.4 tests/group_order_test.lua`, live `refresh` and `self-test` IPC).

## Screenshots / Videos

No visual changes.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.