### PR TITLE
feat(screen-toolkit): annotate focused window on Niri

### DIFF
--- a/screen-toolkit/README.md
+++ b/screen-toolkit/README.md
@@ -48,11 +48,12 @@ Optional:
 - **`swappy`** / **`satty`** — annotation editor (Markup tool)
 - **`gimp`** — fallback annotation editor when swappy/satty are missing
 - **`translate-shell`** (`trans`) — OCR translation
-- **hyprctl** — annotate the focused window (Hyprland only)
+- **hyprctl** — annotate the focused window (Hyprland)
+- **`niri`** — annotate the focused window (Niri)
 
 Compositor support: region tools, measure, annotate and recording work on any
 Wayland compositor with `wlroots` protocols. `Annotate Window` requires Hyprland
-(`hyprctl`).
+(`hyprctl`) or Niri (`niri msg`).
 
 ## Usage
 
@@ -129,7 +130,8 @@ not expose a portable cursor flag, so its behavior depends on the compositor.
 - **Markup** captures the region and opens it in `swappy` (or `satty`). Saving
   happens in that editor; satty saves to your screenshot path automatically.
   **Markup Window** shows a crosshair — click the window you want to annotate
-  and it captures that window (Hyprland only).
+  and it captures that window (Hyprland). On Niri it captures the focused
+  window directly.
 - **Measure** reports the region's pixel size and copies it to the clipboard.
 - **OCR** extracts text and copies it to the clipboard. The result includes the
   capture preview and an editable multiline text area, so you can correct, trim,
@@ -229,7 +231,7 @@ Summary of every service command:
 | `measure` | — | Report a region's pixel size |
 | `annotate` | — | Open a region in the annotation editor |
 | `annotateFullscreen` | — | Annotate the full screen |
-| `annotateWindow` | — | Annotate the focused window (Hyprland only) |
+| `annotateWindow` | — | Annotate the focused window (Hyprland / Niri) |
 | `record` | — | Record a region as GIF |
 | `recordMp4` | — | Record a region as MP4 |
 | `recordFullscreen` | — | Record the full screen as GIF |

--- a/screen-toolkit/plugin.toml
+++ b/screen-toolkit/plugin.toml
@@ -8,7 +8,7 @@
 
 id = "alexander/screen-toolkit"
 name = "Screen Toolkit"
-version = "1.2.1"
+version = "1.3.0"
 plugin_api = 13
 author = "alexander"
 license = "MIT"

--- a/screen-toolkit/plugin.toml
+++ b/screen-toolkit/plugin.toml
@@ -32,6 +32,7 @@ dependencies = [
   "pkill",
   "xdg-open",
   "hyprctl",
+  "niri",
   "swappy",
   "satty",
   "gimp",

--- a/screen-toolkit/scripts/capture-niri.sh
+++ b/screen-toolkit/scripts/capture-niri.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# capture-niri.sh <action>
+#
+# Niri window capture for Screen Toolkit. Niri screenshots the focused window
+# directly via its IPC, so no slurp crosshair or geometry math is needed.
+#
+# Actions:
+#   annotate-window          — capture the focused niri window
+#                              output: /tmp/screen-toolkit-annotate.png
+#                              stdout: "X,Y WxH" geometry string
+#
+# Exit codes:
+#   1 — missing / invalid arguments
+#   2 — capture failed
+#   3 — missing dependency (niri)
+#
+# Used by: service.luau
+
+set -euo pipefail
+
+ACTION="${1:-}"
+
+_require() {
+    command -v "$1" >/dev/null 2>&1 \
+        || { echo "ERROR: missing dependency: $1" >&2; exit 3; }
+}
+
+case "$ACTION" in
+
+  annotate-window)
+    _require niri
+    # niri msg needs the compositor's IPC socket. Prefer the ambient env var;
+    # fall back to auto-discovering the socket in the user runtime dir.
+    if [ -z "${NIRI_SOCKET:-}" ]; then
+        export NIRI_SOCKET
+        NIRI_SOCKET=$(ls /run/user/$(id -u)/niri*.sock 2>/dev/null | head -1) \
+            || { echo "ERROR: could not find niri socket" >&2; exit 2; }
+    fi
+    _tmp="/tmp/screen-toolkit-annotate-tmp-$$.png"
+    rm -f "$_tmp"
+    # niri writes the screenshot asynchronously; poll until the file appears.
+    niri msg action screenshot-window --path "$_tmp" \
+        || { rm -f "$_tmp"; echo "ERROR: niri screenshot-window failed" >&2; exit 2; }
+    _i=0; while [ ! -s "$_tmp" ] && [ "$_i" -lt 50 ]; do
+        sleep 0.1
+        _i=$((_i + 1))
+    done
+    [ -s "$_tmp" ] \
+        || { rm -f "$_tmp"; echo "ERROR: niri screenshot timed out" >&2; exit 2; }
+    mv "$_tmp" /tmp/screen-toolkit-annotate.png
+    printf '%s\n' "0,0 0x0"
+    ;;
+
+  *)
+    echo "ERROR: unknown action '${ACTION}'. Expected: annotate-window" >&2
+    exit 1
+    ;;
+
+esac

--- a/screen-toolkit/service.luau
+++ b/screen-toolkit/service.luau
@@ -20,6 +20,7 @@ local LEGACY_PANEL_ID = "alexander/screen-toolkit:panel-legacy"
 local RESULT_PANEL_ID = "alexander/screen-toolkit:result"
 
 local SCRIPT_CAPTURE = noctalia.pluginDir() .. "/scripts/capture.sh"
+local SCRIPT_CAPTURE_NIRI = noctalia.pluginDir() .. "/scripts/capture-niri.sh"
 local SCRIPT_OCR = noctalia.pluginDir() .. "/scripts/ocr.sh"
 local SCRIPT_LENS = noctalia.pluginDir() .. "/scripts/lens-upload.sh"
 local SCRIPT_RECORD = noctalia.pluginDir() .. "/scripts/record.sh"
@@ -53,6 +54,13 @@ end
 local function copyFileUri(path)
   local escaped = tostring(path):gsub(" ", "%%20"):gsub("'", "%%27"):gsub('"', "%%22")
   noctalia.copyToClipboard(`file://{escaped}`, "text/uri-list")
+end
+
+-- Compositor detection. `niri msg` talks over a socket whose path niri exports
+-- as NIRI_SOCKET; when that is set we route annotate-window through the niri
+-- capture script, otherwise we fall back to the Hyprland path (hyprctl).
+local function isNiri()
+  return (noctalia.getenv("NIRI_SOCKET") or "") ~= ""
 end
 
 -- Whether the cursor is excluded from recordings. Grim screenshots exclude the
@@ -543,11 +551,17 @@ local function annotateFullscreen()
 end
 
 local function annotateWindow()
-  if not noctalia.commandExists("hyprctl") then
-    noctalia.notifyError(noctalia.tr("messages.missing_dep", { dep = "hyprctl" }))
+  local script, dep
+  if isNiri() then
+    script, dep = SCRIPT_CAPTURE_NIRI, "niri"
+  else
+    script, dep = SCRIPT_CAPTURE, "hyprctl"
+  end
+  if not noctalia.commandExists(dep) then
+    noctalia.notifyError(noctalia.tr("messages.missing_dep", { dep = dep }))
     return
   end
-  noctalia.runAsync(`sleep {CAPTURE_DELAY}; {captureEnv()}{SCRIPT_CAPTURE} annotate-window`, function(res)
+  noctalia.runAsync(`sleep {CAPTURE_DELAY}; {captureEnv()}{script} annotate-window`, function(res)
     if res.exitCode ~= 0 then
       noctalia.notifyError(noctalia.tr("messages.capture_failed"))
       return

--- a/screen-toolkit/translations/en.json
+++ b/screen-toolkit/translations/en.json
@@ -197,7 +197,7 @@
   "tooltips": {
     "annotate": "Draw and annotate a region",
     "annotate_fullscreen": "Annotate the entire screen",
-    "annotate_window": "Annotate the focused window (Hyprland)",
+    "annotate_window": "Annotate the focused window",
     "colorpicker": "Pick a color from screen",
     "lens": "Search image with Google Lens",
     "measure": "Measure region size in pixels",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `alexander/screen-toolkit`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

it should fix issue number #402 for niri annotation , the code is tested on niri by @the-simen it should add window capture support to niri 

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0 beta 8
- **Plugin API level:** 13

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
