### PR TITLE
fix(cider): do not send apptoken to Apple artwork CDN

### DIFF
--- a/cider/plugin.toml
+++ b/cider/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "dragged/cider"
 name = "Cider"
-version = "1.8.3"
+version = "1.8.4"
 plugin_api = 23
 author = "dragged"
 license = "MIT"

--- a/cider/scripts/cider_bridge.py
+++ b/cider/scripts/cider_bridge.py
@@ -995,7 +995,9 @@ class CiderBridge:
             if dest.exists() and dest.stat().st_size > 0:
                 return str(dest)
             try:
-                resp = self._session.get(url, timeout=10)
+                # Tokened Session is only for Cider's local API. Artwork URLs are
+                # Apple Music CDN (*.mzstatic.com) — same bare get as LRCLIB.
+                resp = requests.get(url, timeout=10)
                 resp.raise_for_status()
                 if not resp.content:
                     return ""

--- a/cider/scripts/test_lyrics_display.py
+++ b/cider/scripts/test_lyrics_display.py
@@ -88,10 +88,18 @@ class ClockExtrapolationTests(unittest.TestCase):
         far = {"text": "thing", "start": 2_000, "end": 2_200}
         unsung_line = cfg.token_rgba_for_paint(far, 2_000, 2_200, 0, paint)
         self.assertAlmostEqual(unsung_line[0], cfg.NEXT_RGBA[0], places=2)
+        # Fixed palette so active vs sung stay distinct even when Noctalia
+        # theme tokens land on similar greens.
+        contrast = {
+            "sung": (1.0, 1.0, 1.0, 1.0),
+            "active": (1.0, 0.0, 0.0, 1.0),
+            "upcoming": cfg.NEXT_RGBA,
+            "next": cfg.NEXT_RGBA,
+        }
         later = {"text": "thing", "start": 200, "end": 400}
-        live_future = cfg.token_rgba_for_paint(later, 0, 400, 80, paint)
-        self.assertAlmostEqual(live_future[1], paint["active"][1], places=2)
-        self.assertNotAlmostEqual(live_future[1], paint["sung"][1], places=1)
+        live_future = cfg.token_rgba_for_paint(later, 0, 400, 80, contrast)
+        self.assertAlmostEqual(live_future[1], contrast["active"][1], places=2)
+        self.assertNotAlmostEqual(live_future[1], contrast["sung"][1], places=1)
         overlay = (ROOT / "scripts" / "lyrics_overlay.py").read_text(encoding="utf-8")
         self.assertNotIn('self._mul_a(self._paint["sung"], alpha)', overlay)
         self.assertIn("line_only_current_rgba", overlay)

--- a/cider/scripts/test_write_position.py
+++ b/cider/scripts/test_write_position.py
@@ -101,6 +101,13 @@ class DualTokenHeaderTests(unittest.TestCase):
         self.assertIn('self._session.headers["apptoken"]', text)
         self.assertIn('self._session.headers["apitoken"]', text)
 
+    def test_artwork_cdn_fetch_is_tokenless(self) -> None:
+        source = Path(__file__).resolve().parent / "cider_bridge.py"
+        text = source.read_text(encoding="utf-8")
+        # Remote CDN must not reuse the Cider-token Session (ItsLemmy review).
+        self.assertIn("resp = requests.get(url, timeout=10)", text)
+        self.assertNotIn("self._session.get(url, timeout=10)", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `dragged/cider`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Bump `dragged/cider` from **1.8.3 → 1.8.4**.

Artwork downloads from Apple Music CDN (`*.mzstatic.com`) no longer reuse the Cider-authenticated `requests.Session`. That session carries local `apptoken` / `apitoken` headers meant only for Cider’s Connectivity API; sending them to a third-party CDN was unintentional header reuse. Remote artwork now uses a bare `requests.get`, matching the existing LRCLIB fallback path. Local Cider API calls still use the tokened session.

Also hardens a theme-color unit test so active vs sung assertions stay deterministic when Noctalia theme tokens land on similar greens.

## External dependencies

Unchanged from the published plugin. Declared in `plugin.toml`:

- `python3` — runs `scripts/cider_bridge.py` and `scripts/lyrics_overlay.py`
- `gtk3` / `gtk-layer-shell` / `python-gobject` — lyrics overlay (PyGObject + cairo)

Pip packages (see `cider/requirements.txt`): `python-socketio`, `requests`, `websocket-client`.

Also spawned (not extra manifest names): `bash` (`scripts/start-bridge.sh`), `pkill` (bridge replace / disable), `python3`.

## Testing

- Local `python3 -m unittest` in `cider/scripts` (43 tests)
- `python3 .github/workflows/scripts/validate-plugins.py` (109 manifests OK)
- Review fix for ItsLemmy’s non-blocking note on `#406` (`cider_bridge.py` artwork fetch)

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.8+
- **Plugin API level:** 23

## Screenshots / Videos

No UI change in this update. Existing store card for context:

![Cider store thumbnail](https://raw.githubusercontent.com/noctalia-dev/community-plugins/main/cider/thumbnail.webp)

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

### Network, filesystem, processes

- **Network:** Cider Connectivity HTTP/Socket.IO on `base_url` (default `http://127.0.0.1:10767`) via the tokened Session. Lyrics via Cider `amapi/run-v3`; LRCLIB fallback and Apple Music CDN artwork via bare `requests.get` (no Cider token headers).
- **Filesystem writes:** `~/.cache/noctalia-cider/` (state, lyrics, artwork, HUD, `apptoken` file), `noctalia.pluginDataDir()` durable settings, `/tmp/noctalia-cider-bridge.log`, `/tmp/noctalia-cider-lyrics-overlay.log`. No writes into `pluginDir()`.
- **Processes:** `bash scripts/start-bridge.sh` → `python3 scripts/cider_bridge.py`; `python3 scripts/lyrics_overlay.py`; `pkill` of the bridge on replace/disable; overlay stop via pidfile.
