### PR TITLE
Update QR Code Encoder plugin

### DIFF
--- a/qrcode/README.md
+++ b/qrcode/README.md
@@ -7,7 +7,7 @@ Transform any text or URL into a QR code completely offline. Then scan or copy t
 | Field | Value |
 | --- | --- |
 | ID | `yocraft/qrcode` |
-| Entries | Bar widget: `widget`; panel: `panel` |
+| Entries | Bar widget: `widget`; panel: `panel`; shortcut: `shortcut` |
 
 ## Requirements
 
@@ -15,7 +15,7 @@ Install `qrencode` on `PATH`.
 
 ## Usage
 
-Open the panel from the bar widget or with this command:
+Open the panel from the `QR Code Encoder` bar widget, the control center tile, or with this command:
 ```sh
 noctalia msg panel-toggle yocraft/qrcode:panel
 ```

--- a/qrcode/panel.luau
+++ b/qrcode/panel.luau
@@ -9,6 +9,7 @@ local imageSize = 400
 local generateButton = noctalia.getConfig("generate_button")
 local keepOnClose = noctalia.getConfig("keep_on_close")
 local notifyConf = noctalia.getConfig("notify")
+local corner_radius_scale = 1.0
 
 -- when toggling off keep_on_close, the image will not be deleted, so this runs every config change
 if not keepOnClose then
@@ -88,7 +89,7 @@ local function render()
                     path = imagePath,
                     width = imageSize,
                     height = imageSize,
-                    radius = 24,
+                    radius = 24 * corner_radius_scale,
                     onClick = "onImageClick",
                 })
             })
@@ -187,9 +188,13 @@ local function generate(text)
 end
 
 function onOpen(_context)
+    -- here because it needs to be reloaded when the setting is changed
+    corner_radius_scale = noctalia.getSetting("shell.corner_radius_scale") or 1.0
+
     if not keepOnClose then
         status = "idle"
     end
+
     render()
 end
 

--- a/qrcode/plugin.toml
+++ b/qrcode/plugin.toml
@@ -1,6 +1,6 @@
 id = "yocraft/qrcode"
 name = "QR Code Encoder"
-version = "1.0.1"
+version = "1.1.0"
 plugin_api = 15
 author = "yocraft"
 license = "MIT"
@@ -31,6 +31,10 @@ entry = "widget.luau"
     description_key = "widget.custom_image.description"
     default = ""
     extensions = [".png", ".jpg", ".jpeg", ".webp", ".svg"]
+
+[[shortcut]]
+id = "shortcut"
+entry = "shortcut.luau"
 
 [[panel]]
 id = "panel"

--- a/qrcode/shortcut.luau
+++ b/qrcode/shortcut.luau
@@ -1,0 +1,10 @@
+local function render()
+    shortcut.setLabel("QR Code")
+    shortcut.setIcon("qrcode")
+end
+
+render()
+
+function onClick()
+  noctalia.togglePanel("yocraft/qrcode:panel")
+end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yocraft/qrcode`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Add control center tile. Make the image corner roundness consistent with noctalia setting.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
qrencode

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** <!-- must match plugin_api in plugin.toml --> 15

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
