### PR TITLE
fix(keybind-cheatsheet): update to v0.2.4 with arrow key symbols and keysym normalization (#398)

### DIFF
--- a/keybind-cheatsheet/panel.luau
+++ b/keybind-cheatsheet/panel.luau
@@ -77,22 +77,47 @@ local function callback(prefix, fn)
 end
 
 local KEY_LABELS = {
-  XF86AudioRaiseVolume = "Vol Up",
-  XF86AudioLowerVolume = "Vol Down",
-  XF86AudioMute = "Mute",
-  XF86AudioMicMute = "Mic Mute",
-  XF86MonBrightnessUp = "Bright Up",
-  XF86MonBrightnessDown = "Bright Down",
-  XF86AudioPlay = "Play/Pause",
-  XF86AudioPause = "Pause",
-  XF86AudioNext = "Next",
-  XF86AudioPrev = "Previous",
-  Print = "PrtSc",
-  Prior = "PgUp",
-  Next = "PgDn",
-  Return = "Enter",
-  Escape = "Esc",
+  xf86audioraisevolume = "Vol Up",
+  xf86audiolowervolume = "Vol Down",
+  xf86audiomute = "Mute",
+  xf86audiomicmute = "Mic Mute",
+  xf86monbrightnessup = "Bright Up",
+  xf86monbrightnessdown = "Bright Down",
+  xf86audioplay = "Play/Pause",
+  xf86audiopause = "Pause",
+  xf86audionext = "Next",
+  xf86audioprev = "Previous",
+  print = "PrtSc",
+  prtsc = "PrtSc",
+  prior = "PgUp",
+  page_up = "PgUp",
+  pageup = "PgUp",
+  next = "PgDn",
+  page_down = "PgDn",
+  pagedown = "PgDn",
+  ["return"] = "Enter",
+  enter = "Enter",
+  escape = "Esc",
+  esc = "Esc",
   space = "Space",
+  backspace = "Backspace",
+  delete = "Del",
+  del = "Del",
+  insert = "Ins",
+  ins = "Ins",
+  tab = "Tab",
+  home = "Home",
+  ["end"] = "End",
+  caps_lock = "CapsLock",
+  capslock = "CapsLock",
+  num_lock = "NumLock",
+  numlock = "NumLock",
+  scroll_lock = "ScrollLock",
+  scrolllock = "ScrollLock",
+  up = "↑",
+  down = "↓",
+  left = "←",
+  right = "→",
   btn_left = "Mouse Left",
   btn_right = "Mouse Right",
   btn_middle = "Mouse Middle",
@@ -101,7 +126,12 @@ local KEY_LABELS = {
 }
 
 local function formatKey(key)
-  return KEY_LABELS[key] or key:gsub("^mouse:", "Mouse ")
+  if key == nil or key == "" then return "" end
+  local exact = KEY_LABELS[key]
+  if exact ~= nil then return exact end
+  local lowered = KEY_LABELS[lower(key)]
+  if lowered ~= nil then return lowered end
+  return key:gsub("^mouse:", "Mouse ")
 end
 
 local function niriCategoryFor(action)
@@ -878,6 +908,7 @@ local function lifecycleState()
 end
 
 return {
+  formatKey = formatKey,
   bindingAvailableInView = bindingAvailableInView,
   bindingContentOpacity = bindingContentOpacity,
   hiddenBindingCount = hiddenBindingCount,

--- a/keybind-cheatsheet/plugin.toml
+++ b/keybind-cheatsheet/plugin.toml
@@ -1,6 +1,6 @@
 id = "kenn/keybind-cheatsheet"
 name = "Keybind Cheatsheet"
-version = "0.2.3"
+version = "0.2.4"
 plugin_api = 9
 author = "kenn"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** kenn/keybind-cheatsheet
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes #398 by mapping directional arrow keys (`up`, `down`, `left`, `right`) to arrow symbols (`↑`, `↓`, `←`, `→`) case-insensitively and normalizing common keysyms in `panel.luau`.

## External dependencies

None

## Testing

- [x] Tested on Niri
- [x] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** 9

## Screenshots / Videos

No UI layout structure changes; arrow keys are rendered as directional symbols (`↑`, `↓`, `←`, `→`).

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
