### PR TITLE
fix(tailscale): project status JSON fields before Luau decode

### DIFF
--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -61,7 +61,7 @@ noctalia msg plugin davemhammer/tailscale:service all toggle
 
 ## Notes
 
-- Shells out to `tailscale status --json | jq …` (same Mullvad-exit filter as text `status`; those nodes stay on the Exit tab via `exit-node list`), `tailscale debug prefs | jq …` (safe field projection), `tailscale exit-node list`, `tailscale set …`, `tailscale up` / `down`, optional `tailscale ping` / `tailscale ssh` in a terminal, and `xdg-open` for the admin URL. A raw `--json` dump on a Mullvad-enabled tailnet is large enough to trip Noctalia's plugin CPU budget and auto-disable the service.
+- Shells out to `tailscale status --json | jq …` (same Mullvad-exit filter as text `status`, then only the fields the service reads; unused Mullvad nodes stay on the Exit tab via `exit-node list`), `tailscale debug prefs | jq …` (safe field projection), `tailscale exit-node list`, `tailscale set …`, `tailscale up` / `down`, optional `tailscale ping` / `tailscale ssh` in a terminal, and `xdg-open` for the admin URL. A raw `--json` dump on a Mullvad-enabled tailnet is large enough to trip Noctalia's plugin CPU budget and auto-disable the service.
 - Advertise-exit state is read from prefs `AdvertiseRoutes` (`0.0.0.0/0` / `::/0`), not only `ExitNodeOption`.
 - Network: only through the Tailscale CLI/daemon (no separate HTTP client in the plugin).
 - Filesystem: no plugin-written credentials; uses local Tailscale state via the CLI.

--- a/tailscale/plugin.toml
+++ b/tailscale/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/tailscale"
 name = "Tailscale"
-version = "1.0.6"
+version = "1.0.7"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"

--- a/tailscale/service.luau
+++ b/tailscale/service.luau
@@ -48,6 +48,9 @@ local refreshAgain = false
 local refreshStartedAt = 0
 local actionBusy = false
 local dataSignature = ""
+local lastStatusRaw = ""
+local lastPrefsRaw = ""
+local lastExitsRaw = ""
 local prevOnline = {} -- id -> true
 
 local function trim(value)
@@ -111,7 +114,7 @@ local function statusJsonCommand(bin)
         Self: ((.Self // {}) | {ID, HostName, DNSName, Online, OS, Relay, ExitNodeOption, TailscaleIPs}),
         Peer: ((.Peer // {}) | with_entries(.value |= {
           ID, HostName, DNSName, Online, Active, OS, Relay,
-          ExitNode, ExitNodeOption, TailscaleIPs, RxBytes, TxBytes, LastSeen
+          ExitNode, ExitNodeOption, TailscaleIPs
         }))
       }
   ]]
@@ -440,7 +443,40 @@ local function forceUnstick(reason)
   publishSnapshot()
 end
 
-local function applyBag(statusData, prefsData, exitStdout, errors)
+local function applyBag(statusRaw, prefsRaw, exitStdout, errors)
+  statusRaw = statusRaw or ""
+  prefsRaw = prefsRaw or ""
+  exitStdout = exitStdout or ""
+  -- Traffic counters were in the JSON and changed every poll; the panel
+  -- does not show them. Same raw strings => skip decode/parse/state.set.
+  if statusRaw == lastStatusRaw and prefsRaw == lastPrefsRaw and exitStdout == lastExitsRaw then
+    snapshot.loading = false
+    refreshPending = false
+    refreshStartedAt = 0
+    noctalia.setUpdateInterval(refreshIntervalMs())
+    if snapshot.error ~= "" then
+      snapshot.error = ""
+      publishSnapshot()
+    end
+    return
+  end
+
+  local statusData = nil
+  if statusRaw ~= "" then
+    statusData = noctalia.json.decode(statusRaw)
+    if statusData == nil then
+      table.insert(errors, "invalid status JSON")
+    end
+  end
+  local prefsData = nil
+  if prefsRaw ~= "" then
+    prefsData = noctalia.json.decode(prefsRaw)
+  end
+
+  lastStatusRaw = statusRaw
+  lastPrefsRaw = prefsRaw
+  lastExitsRaw = exitStdout
+
   local st = {}
   local prefs = {}
   local exits = {}
@@ -582,7 +618,7 @@ refreshAll = function()
   noctalia.setUpdateInterval(1000)
 
   local pending = 3
-  local bag = { status = nil, prefs = nil, exits = "" }
+  local bag = { statusRaw = "", prefsRaw = "", exits = "" }
   local errors = {}
   local finished = false
 
@@ -595,7 +631,7 @@ refreshAll = function()
       return
     end
     finished = true
-    local okApply, errApply = pcall(applyBag, bag.status, bag.prefs, bag.exits, errors)
+    local okApply, errApply = pcall(applyBag, bag.statusRaw, bag.prefsRaw, bag.exits, errors)
     if not okApply then
       noctalia.log(`tailscale: apply failed: {tostring(errApply)}`)
       snapshot.loading = false
@@ -622,12 +658,7 @@ refreshAll = function()
         table.insert(errors, err ~= "" and err or "status failed")
         return
       end
-      local data = noctalia.json.decode(result.stdout or "")
-      if data == nil then
-        table.insert(errors, "invalid status JSON")
-        return
-      end
-      bag.status = data
+      bag.statusRaw = result.stdout or ""
     end)
     if not okInner then
       table.insert(errors, "status: " .. tostring(errInner))
@@ -644,7 +675,7 @@ refreshAll = function()
     end
     local okInner, errInner = pcall(function()
       if result and result.exitCode == 0 and trim(result.stdout) ~= "" then
-        bag.prefs = noctalia.json.decode(result.stdout)
+        bag.prefsRaw = result.stdout
       end
     end)
     if not okInner then

--- a/tailscale/service.luau
+++ b/tailscale/service.luau
@@ -96,7 +96,8 @@ end
 
 -- Same rule as `tailscale status` (text): unused Mullvad exits belong on
 -- `exit-node list`, not in Peer. `--json` does not apply this, and the raw
--- dump is large enough to trip Noctalia's 25ms plugin CPU budget.
+-- dump is large enough to trip Noctalia's 25ms plugin CPU budget. After the
+-- Peer filter, drop unused fields (sshHostKeys, CapMap, …) so decode stays small.
 local function statusJsonCommand(bin)
   local jq = [[
     .Peer |= with_entries(select(
@@ -104,6 +105,15 @@ local function statusJsonCommand(bin)
       or (.value.ExitNode == true)
       or ((.value.DNSName // "") | endswith("mullvad.ts.net.") | not)
     ))
+    | {
+        BackendState, Version, TailscaleIPs, MagicDNSSuffix, Health,
+        CurrentTailnet, ExitNodeStatus,
+        Self: ((.Self // {}) | {ID, HostName, DNSName, Online, OS, Relay, ExitNodeOption, TailscaleIPs}),
+        Peer: ((.Peer // {}) | with_entries(.value |= {
+          ID, HostName, DNSName, Online, Active, OS, Relay,
+          ExitNode, ExitNodeOption, TailscaleIPs, RxBytes, TxBytes, LastSeen
+        }))
+      }
   ]]
   return shellCommand({ bin, "status", "--json" }) .. " | jq -c " .. shellQuote(jq)
 end
@@ -518,6 +528,7 @@ local function applyBag(statusData, prefsData, exitStdout, errors)
   refreshStartedAt = 0
   noctalia.setUpdateInterval(refreshIntervalMs())
 
+  local prevRev = snapshot.revision
   updateRevision(table.concat({
     snapshot.backendState,
     snapshot.ipv4,
@@ -528,7 +539,9 @@ local function applyBag(statusData, prefsData, exitStdout, errors)
     asString(snapshot.runSSH),
     asString(snapshot.advertiseExitNode),
   }, "|"))
-  publishSnapshot()
+  if snapshot.revision ~= prevRev then
+    publishSnapshot()
+  end
 end
 
 refreshAll = function()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/tailscale`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Follow-up to #362. That PR filters unused Mullvad exits out of `tailscale status --json` before Luau decodes it. The leftover JSON is still fat: each remaining peer carries `sshHostKeys`, `Self` carries `CapMap`, and so on — fields `parseStatus` never reads.

On a loaded machine that leftover decode plus `state.set` of the snapshot can still exceed Noctalia's 25ms plugin CPU budget, which auto-disables the service (`script callback 'async command callback' exceeded its CPU budget`).

This keeps the existing Mullvad `Peer` filter as-is, then `jq`s the same pipe down to the fields the service actually uses (same idea as the existing `debug prefs` projection). `state.set` is skipped when the snapshot signature did not change. Version `1.0.6` → `1.0.7`.

## External dependencies

Unchanged: `tailscale`, `jq`, `xdg-open`. `jq` already filtered `status --json` after #362; it now also projects fields, still in that one pipe.

## Testing

Reproduced the CPU-budget `apply failed` log on Niri / NixOS with Mullvad exits in the netmap (raw `status --json` ~870 KB / 560 peers; after #362 ~15 KB; after this projection ~3.2 KB / 7 real machines). After the change, `noctalia msg plugin davemhammer/tailscale:service all refresh` succeeds and the bar/panel still show real machines plus the exit-node list.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 10

## Screenshots / Videos

None — no UI change. Same bar/panel; smaller JSON on the existing `jq` pipe.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html). (unchanged; not a new plugin)
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations). (no locale files touched)
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
