### PR TITLE
fix(mango_layouts): use correct mmsg syntax for layout retrieval and dispatch

### DIFF
--- a/mango_layouts/panel.luau
+++ b/mango_layouts/panel.luau
@@ -26,7 +26,7 @@ local function onPickAt(index)
 	local slot = pickSlots[index]
 	if slot == nil then return end
 	selectedLayout = slot.sym
-	noctalia.runAsync("mmsg dispatch setlayout," .. slot.entry.name)
+	noctalia.runAsync("mmsg -d setlayout," .. slot.entry.name)
 	panel.close()
 end
 
@@ -142,7 +142,7 @@ function onOpen(context)
 	selectedLayout = ""
 	render()
 	noctalia.runAsync(
-		"mmsg get all-monitors | jq -r '.monitors[] | select(.active == true and .last_open_surface != null) | .layout_symbol'",
+		'mmsg -g | awk -v active="" \'/selmon 1/{active=$1} $1==active && $2=="layout"{print $3}\'',
 		function(result)
 			if result == nil or result.exitCode ~= 0 then return end
 			local sym = result.stdout:gsub("%s+", "")

--- a/mango_layouts/plugin.toml
+++ b/mango_layouts/plugin.toml
@@ -1,6 +1,6 @@
 id         = "ezequiel/mango_layouts"
 name       = "Mango Layouts"
-version    = "1.0.0"
+version    = "1.0.1"
 plugin_api = 14
 author     = "ezequiel"
 license    = "MIT"

--- a/mango_layouts/widget.luau
+++ b/mango_layouts/widget.luau
@@ -26,7 +26,7 @@ local custom_color = noctalia.getConfig("custom_color")
 function update()
   noctalia.setUpdateInterval(1000)
   noctalia.runAsync(
-    "mmsg get all-monitors | jq -r '.monitors[] | select(.active == true) | .layout_symbol'",
+    'mmsg -g | awk -v active="" \'/selmon 1/{active=$1} $1==active && $2=="layout"{print $3}\'',
     function(result)
       if result and result.exitCode == 0 then
         local sym = result.stdout:gsub("%s+", "")


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `ezequiel/mango_layouts`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes broken `mmsg` IPC commands. Replaces invalid `mmsg get all-monitors | jq` with `mmsg -g | awk` to parse active monitor layout, and fixes `mmsg dispatch` to `mmsg -d setlayout`.

## External dependencies

mmsg, awk, jq (existing dependencies).

## Testing

Tested reading the layout and updating it via `mmsg` commands.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: MangoWC
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 14

## Screenshots / Videos

N/A - bug fix for background command

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
