### PR TITLE
[pomodoro] fix panel layout

### DIFF
--- a/pomodoro/panel.luau
+++ b/pomodoro/panel.luau
@@ -102,13 +102,14 @@ local function render(state, sessionData)
 
             -- buttons
             ui.column({ gap = 8 }, {
-                ui.row({ gap = 8, justify = "space_between" }, {
+                ui.row({ gap = 8 }, {
                     ui.button({
                         variant = "primary",
                         text = startButtonText,
                         glyph = startButtonGlyph,
                         onClick = "onStartButtonClick",
-                        flexGrow = 1,
+                        width = 157,
+                        height = 35
                     }),
 
                     ui.button({
@@ -116,17 +117,19 @@ local function render(state, sessionData)
                         glyph = "player-skip-forward",
                         onClick = "onSkipButtonClick",
                         enabled = skipButtonEnabled,
-                        flexGrow = 1,
+                        width = 157,
+                        height = 35
                     }),
                 }),
 
-                ui.row({ gap = 8, justify = "space_between" }, {
+                ui.row({ gap = 8 }, {
                     ui.button({
                         text = noctalia.tr("button.reset"),
                         glyph = "refresh",
                         onClick = "onResetButtonClick",
                         enabled = resetButtonEnabled,
-                        flexGrow = 1,
+                        width = 157,
+                        height = 35
                     }),
 
                     ui.button({
@@ -134,7 +137,8 @@ local function render(state, sessionData)
                         glyph = "rotate",
                         onClick = "onResetAllButtonClick",
                         enabled = resetAllButtonEnabled,
-                        flexGrow = 1,
+                        width = 157,
+                        height = 35
                     }),
                 }),
             }),

--- a/pomodoro/plugin.toml
+++ b/pomodoro/plugin.toml
@@ -1,6 +1,6 @@
 id           = "thepunkoff/pomodoro"
 name         = "Pomodoro Timer"
-version      = "1.2.0"
+version      = "1.2.1"
 plugin_api   = 20
 author       = "thepunkoff"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `thepunkoff/pomodoro`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Changes panel buttons layout to absolute numbers to make sure the panel looks consistent for different users. Hope to fix https://github.com/noctalia-dev/community-plugins/issues/453 with this update.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5 beta9
- **Plugin API level:** 20 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
