### PR TITLE
feature(config-swap): change export path in json file

### DIFF
--- a/config-swap/config-swap-panel.luau
+++ b/config-swap/config-swap-panel.luau
@@ -298,7 +298,7 @@ local function saveConfig()
 	local settingFile: infoConfig = {
 		name = name,
 		description = "save for reset",
-		path = configBox .. "/" .. name,
+		path = "config/" .. name,
 		origin = "not give",
 		wallpaperPath = nil,
 		depedencie = false,

--- a/config-swap/config-swap-panel.luau
+++ b/config-swap/config-swap-panel.luau
@@ -395,7 +395,6 @@ local function renderInfoStore()
 end
 
 local function renderList()
-
 	pickSlots = {}
 	local tiles = {}
 	local list = listConfig or {}
@@ -409,28 +408,30 @@ local function renderList()
 
 		local imagePath = previewCache[data.name] or previewImage
 
-		table.insert(tiles, ui.column({ gap = 4, key = data.path, align = "center" }, {
+		table.insert(tiles, ui.column({ gap = 8, key = data.path, align = "stretch", width = previewWidth }, {
 			ui.image({
-      			path = imagePath,
+				path = imagePath,
 				width = previewWidth,
 				height = previewHeight,
 				fit = "cover",
 				radius = 8,
-      			onClick = ""
-  			}),
-			ui.row( {gap = 12, align = "start"}, {
-				ui.button({ text = tr("install"), onClick = function()
+			}),
+			ui.label({
+				text = data.name,
+				fontSize = 14,
+				fontWeight = "medium",
+				color = "on_surface",
+				textAlign = "center",
+				maxLines = 1,
+			}),
+			ui.button({
+				text = tr("install"),
+				variant = "primary",
+				width = previewWidth,
+				onClick = function()
 					downloadConfig(data)
 				end
-				}),
-				ui.label({
-				text = data.name,
-				fontSize = 11,
-				maxLines = 1,
-				maxWidth = 120,
-				textAlign = "center",
-				}),
-			} ), 
+			}),
 		}))
 	end
 	local rows = {}
@@ -445,8 +446,8 @@ local function renderList()
 
 	panel.render(ui.column({ flexGrow = 1, gap = 16 }, {
 		ui.row({ align = "center", justify = "space_between", gap = 8 }, {
-			ui.label({ text = tr("title"), align = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
-			ui.label({ text = tr("store_title"), align = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
+			ui.label({ text = tr("title"), textAlign = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
+			ui.label({ text = tr("store_title"), textAlign = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
 			ui.button({ text = tr("show_list"), onClick = function()
 				selectedView = 1
 				render()
@@ -530,8 +531,6 @@ function getListInstall()
 	return listShow
 end
 
--- Render installed configs grid
-
 local function renderInstall()
 	pickSlots = {}
 	local tiles = {}
@@ -540,34 +539,36 @@ local function renderInstall()
 		local data = list[count]
 		local slotIndex = count - 1
 		pickSlots[slotIndex] = data.path
-		table.insert(tiles, ui.column({ gap = 4, key = data.path, align = "center" }, {
+
+		table.insert(tiles, ui.column({ gap = 8, key = data.path, align = "stretch", width = previewWidth }, {
 			ui.image({
-      			path = configBox .. "/" .. data.name .. "/preview.png",
+				path = configBox .. "/" .. data.name .. "/preview.png",
 				width = previewWidth,
 				height = previewHeight,
 				fit = "cover",
 				radius = 8,
-      			onClick = function()
+				onClick = function()
 					renderConfig(data)
 				end
-  			}),
-			ui.row( {gap = 12, align = "start"}, {
-				ui.button({ text = "delete", onClick = function()
+			}),
+			ui.label({
+				text = data.name,
+				fontSize = 14,
+				fontWeight = "medium",
+				color = "on_surface",
+				textAlign = "center",
+				maxLines = 1,
+			}),
+			ui.row({ gap = 8, justify = "space_between", align = "center" }, {
+				ui.button({ text = "delete", variant = "outline", onClick = function()
 					renderDeleteConfirmation(data.name)
 				end
 				}),
-				ui.label({
-				text = data.name,
-				fontSize = 11,
-				maxLines = 1,
-				maxWidth = 120,
-				textAlign = "center",
-				}),
-				ui.button({ text = "apply", onClick = function()
+				ui.button({ text = "apply", variant = "primary", onClick = function()
 					renderConfirmApply(data)
 				end
 				}),
-			} ), 
+			}),
 		}))
 	end
 	local rows = {}
@@ -581,8 +582,8 @@ local function renderInstall()
 	end
 	panel.render(ui.column({ flexGrow = 1, gap = 16 }, {
 		ui.row({ align = "center", justify = "space_between", gap = 8 }, {
-			ui.label({ text = tr("title"), align = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
-			ui.label({ text = tr("installed_title"), align = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
+			ui.label({ text = tr("title"), textAlign = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
+			ui.label({ text = tr("installed_title"), textAlign = "center", fontSize = 16, fontWeight = "bold", color = "on_surface", flexGrow = 1 }),
 			ui.button({ text = tr("show_store"), onClick = function()
 				selectedView = 2
 				render()

--- a/config-swap/plugin.toml
+++ b/config-swap/plugin.toml
@@ -1,6 +1,6 @@
 id = "tadomika_ari/config-swap"
 name = "Config Swap"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 4
 author = "TadomiKa-Ari"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `<author>/<plugin>`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

I change the export path in json file after a save. 
The old path have a path like ~/config-swap/{name}
But for share a config on config swap box repositories and pass the cli, the path require is config/{name}
Now its fix.

Also i change visual for button in installed section and Store Section
<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
