### PR TITLE
ocr: no temp-file leak on cancelled selection (v1.0.4)

### DIFF
--- a/ocr/README.md
+++ b/ocr/README.md
@@ -61,7 +61,8 @@ Each widget instance also has:
 - Processes spawned per capture: one `/bin/sh` pipeline running `mktemp`,
   `slurp`, `grim`, `tesseract` and `rm`.
 - Filesystem writes: a single temporary PNG in `$XDG_RUNTIME_DIR` (falling
-  back to `/tmp`), deleted immediately after recognition, success or failure.
+  back to `/tmp`). It is created only after the region selection succeeds and
+  an `EXIT` trap removes it on every path — cancel, failure, or success.
   Nothing else is written or read.
 - A cancelled selection (Esc in `slurp`) is silent by design.
 - The capture must finish within 60 s (the runtime's subprocess timeout cap) —

--- a/ocr/ocr.luau
+++ b/ocr/ocr.luau
@@ -8,6 +8,8 @@
 -- The whole pipeline runs as one shell command through noctalia.runAsync so
 -- the UI thread is never blocked. Exit codes partition the failure modes:
 --   40 = selection cancelled (silent), 41 = mktemp, 42 = grim, 43 = tesseract.
+-- The temp PNG is created only after the slurp selection succeeds, and an
+-- EXIT trap removes it on every path (cancel, failure, success).
 
 local busy = false
 local available = noctalia.commandExists("grim")
@@ -47,20 +49,20 @@ local function buildCommand(wholeOutput)
 		psm = "6"
 	end
 
-	local capture
+	local mktemp = 'img="$(mktemp "${XDG_RUNTIME_DIR:-/tmp}/noctalia-ocr-XXXXXX.png")" || exit 41; '
+	local pipeline
 	if wholeOutput then
 		local out = noctalia.focusedOutputName()
 		local target = if out then "-o " .. shellQuote(out) .. " " else ""
-		capture = 'grim ' .. target .. '"$img"'
+		pipeline = mktemp .. 'grim ' .. target .. '"$img" || exit 42; '
 	else
-		capture = 'geom="$(slurp)" || exit 40; grim -g "$geom" "$img"'
+		pipeline = 'geom="$(slurp)" || exit 40; ' .. mktemp .. 'grim -g "$geom" "$img" || exit 42; '
 	end
 
-	return 'img="$(mktemp "${XDG_RUNTIME_DIR:-/tmp}/noctalia-ocr-XXXXXX.png")" || exit 41; '
-		.. capture
-		.. ' || { rm -f "$img"; exit 42; }; '
+	return 'trap \'rm -f "$img" 2>/dev/null\' EXIT; '
+		.. pipeline
 		.. 'txt="$(tesseract "$img" stdout -l ' .. langs .. ' --psm ' .. psm .. ' 2>/dev/null)"; rc=$?; '
-		.. 'rm -f "$img"; [ "$rc" -ne 0 ] && exit 43; printf "%s" "$txt"'
+		.. '[ "$rc" -ne 0 ] && exit 43; printf "%s" "$txt"'
 end
 
 local function handleResult(result)

--- a/ocr/plugin.toml
+++ b/ocr/plugin.toml
@@ -10,7 +10,7 @@
 
 id = "fel/ocr"
 name = "OCR"
-version = "1.0.3"
+version = "1.0.4"
 plugin_api = 3
 author = "Fel"
 license = "MIT"

--- a/ocr/shortcut.luau
+++ b/ocr/shortcut.luau
@@ -31,20 +31,20 @@ local function buildCommand(wholeOutput)
 		psm = "6"
 	end
 
-	local capture
+	local mktemp = 'img="$(mktemp "${XDG_RUNTIME_DIR:-/tmp}/noctalia-ocr-XXXXXX.png")" || exit 41; '
+	local pipeline
 	if wholeOutput then
 		local out = noctalia.focusedOutputName()
 		local target = if out then "-o " .. shellQuote(out) .. " " else ""
-		capture = 'grim ' .. target .. '"$img"'
+		pipeline = mktemp .. 'grim ' .. target .. '"$img" || exit 42; '
 	else
-		capture = 'geom="$(slurp)" || exit 40; grim -g "$geom" "$img"'
+		pipeline = 'geom="$(slurp)" || exit 40; ' .. mktemp .. 'grim -g "$geom" "$img" || exit 42; '
 	end
 
-	return 'img="$(mktemp "${XDG_RUNTIME_DIR:-/tmp}/noctalia-ocr-XXXXXX.png")" || exit 41; '
-		.. capture
-		.. ' || { rm -f "$img"; exit 42; }; '
+	return 'trap \'rm -f "$img" 2>/dev/null\' EXIT; '
+		.. pipeline
 		.. 'txt="$(tesseract "$img" stdout -l ' .. langs .. ' --psm ' .. psm .. ' 2>/dev/null)"; rc=$?; '
-		.. 'rm -f "$img"; [ "$rc" -ne 0 ] && exit 43; printf "%s" "$txt"'
+		.. '[ "$rc" -ne 0 ] && exit 43; printf "%s" "$txt"'
 end
 
 local function handleResult(result)


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `fel/ocr`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Version 1.0.4 fixes a temp-file leak in the capture pipeline, addressing the
non-blocking review note on #468. The temp PNG was created by `mktemp` before
`slurp` ran, so a cancelled selection (Esc, `slurp` exits non-zero → exit 40)
left a 0-byte file in `$XDG_RUNTIME_DIR` (tmpfs) or `/tmp`.

Now `slurp` runs first — a cancelled selection never creates the file — and an
`EXIT` trap removes it on every remaining path (grim failure, tesseract
failure, success). The documented side-effect accounting ("deleted immediately
after recognition — success or failure") now matches the code.

Complete accounting of side effects (unchanged, but restated for review):

- **Network calls:** none.
- **Filesystem writes:** one temporary PNG created via `mktemp` in
  `$XDG_RUNTIME_DIR` (fallback `/tmp`), created only after the selection
  succeeds and removed by an `EXIT` trap on every path. Nothing else is
  written or read.
- **Spawned processes:** one `/bin/sh` pipeline per capture running `mktemp`,
  `slurp`, `grim`, `tesseract` and `rm` (via the trap).
- **Clipboard:** recognized text written as `text/plain` (setting, on by default).
- **Notifications:** local notification with a ≤160-character preview of the
  recognized text (setting, on by default).

## External dependencies

- `grim` — Wayland screenshot capture
- `slurp` — region selection
- `tesseract` — OCR engine, plus a tessdata language package for each enabled
  language (e.g. `tesseract-data-eng`)

All three are listed in `dependencies` in `plugin.toml`.

## Testing

Verified every exit path of the exact generated shell pipeline with stubbed
`slurp`/`grim`/`tesseract` on `PATH`:

- region success → rc 0, text on stdout, no temp file left
- whole-output success → rc 0, text on stdout, no temp file left
- selection cancelled (slurp fails) → rc 40, **no temp file created**
- grim failure → rc 42, no temp file left
- tesseract failure → rc 43, no temp file left

Also hot-reloaded the plugin on Hyprland (path source rescan) and re-ran the
liveness probe `noctalia msg plugin fel/ocr:ocr all ping` — entry matched.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.9 (v5.0.0-beta.9-3-g69a90183531d)
- **Plugin API level:** 3

## Screenshots / Videos

No visual change — same thumbnail as #468:

![fel/ocr thumbnail](https://raw.githubusercontent.com/Fel-2/community-plugins/add-ocr/ocr/thumbnail.webp)

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.