### PR TITLE
Fix Spotify Media wide Unicode text scrolling

### DIFF
--- a/spotify-media/bar.luau
+++ b/spotify-media/bar.luau
@@ -32,6 +32,27 @@ local function utf8Chars(value)
   return chars
 end
 
+local function charWidth(char)
+  local cp = utf8.codepoint(char)
+
+  if cp == nil then
+    return 1
+  end
+
+  -- Common CJK / Japanese / Korean ranges.
+  if
+    (cp >= 0x1100 and cp <= 0x11FF) or
+    (cp >= 0x2E80 and cp <= 0xA4CF) or
+    (cp >= 0xAC00 and cp <= 0xD7A3) or
+    (cp >= 0xF900 and cp <= 0xFAFF) or
+    (cp >= 0xFE10 and cp <= 0xFE6F) or
+    (cp >= 0xFF00 and cp <= 0xFFEF)
+  then
+    return 2
+  end
+
+  return 1
+end
 
 local function scrollingText(value)
   local chars = utf8Chars(value)
@@ -48,9 +69,21 @@ local function scrollingText(value)
 
   local output = {}
 
-  for i = 0, SCROLL_WIDTH - 1 do
+  local usedWidth = 0
+  local i = 0
+
+  while usedWidth < SCROLL_WIDTH do
     local index = ((scrollOffset + i - 1) % sequenceLength) + 1
-    table.insert(output, sequence[index])
+    local char = sequence[index]
+    local width = charWidth(char)
+
+    if usedWidth + width > SCROLL_WIDTH then
+      break
+    end
+
+    table.insert(output, char)
+    usedWidth = usedWidth + width
+    i = i + 1
   end
 
   return table.concat(output)
@@ -62,7 +95,7 @@ local function stripNewline(value)
     return ""
   end
 
-  return value:gsub("[\r\n]+$", "")
+  return value:gsub("[\r\n]+", " ")
 end
 
 

--- a/spotify-media/plugin.toml
+++ b/spotify-media/plugin.toml
@@ -1,6 +1,6 @@
 id = "azokyen/spotify-media"
 name = "Spotify Media"
-version = "0.1.0"
+version = "0.1.1"
 plugin_api = 24
 author = "azokyen"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `azokyen/spotify-media`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Spotify Media provides Spotify playback controls, album artwork, and scrolling track metadata directly in the Noctalia bar.

### Changes in this update

- Fixes marquee overflow/wrapping with CJK and other wide Unicode characters.
- Wide characters are now accounted for when calculating the visible scrolling text width.
- Prevents mixed Latin/CJK metadata such as `Dxrk ダーク - RAVE` from wrapping onto a second line.
- Sanitizes embedded metadata newlines.
- Bumps the plugin version to `0.1.1`.

## External dependencies

- `playerctl` — Spotify metadata and playback control.
- `hyprctl` — detects and focuses the Spotify window.
- `spotify-launcher` — launches Spotify when it is not running.

### Runtime activity

- Spawns `playerctl` for Spotify metadata and playback control.
- Spawns `hyprctl` to detect and focus the Spotify window.
- Spawns `spotify-launcher` when Spotify is not running.
- Downloads Spotify album artwork from the MPRIS `artUrl`.
- Writes downloaded artwork to Noctalia's plugin data directory as cached cover images.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- Tested normal Latin metadata.
- Tested mixed Latin/Japanese metadata: `Dxrk ダーク - RAVE`.
- Confirmed marquee remains single-line and scrolls correctly.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `5.0.0_beta.9`
- **Plugin API level:** `24`

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
