### PR TITLE
Update GitHub Activity to v1.4.0

### DIFF
--- a/github-activity/README.md
+++ b/github-activity/README.md
@@ -41,6 +41,11 @@ gh auth login -h github.com
 | Automatic refresh interval | 15, 30, or 60 minutes | 30 minutes |
 | Widget display | Icon and value, or icon only | Icon and value |
 | Widget metric | Today's contributions, current streak, or annual total | Today's contributions |
+| Show today's contributions | On or off | On |
+| Show current streak | On or off | On |
+| Show best streak | On or off | On |
+| Show annual total | On or off | On |
+| Show profile button | On or off | On |
 
 Changing the interval applies it immediately and requests a refresh unless a
 request is already in progress. The widget tooltip and calendar panel show the
@@ -49,6 +54,15 @@ last update time and selected automatic refresh interval.
 Widget display and metric choices belong to each bar-widget instance. Multiple
 copies of GitHub Activity can therefore show different metrics. The metric
 selector is relevant only when the widget is configured to show a value.
+
+Panel content choices apply to the shared calendar panel. Hiding the annual
+total leaves the hovered-day detail available. Hiding today's contributions,
+the current streak, and the best streak together adds row spacing and centers
+the ready content for a more legible focused view.
+
+Plugin interface text comes from `translations/en.json` and is translated
+through Noctalia Translate. Calendar month and weekday labels instead use
+Noctalia's date formatter and follow the process `LC_TIME` locale.
 
 The panel can also be toggled through IPC:
 

--- a/github-activity/lib/activity.luau
+++ b/github-activity/lib/activity.luau
@@ -62,6 +62,32 @@ function Activity.flatten(weeks)
   return days
 end
 
+-- Parse an ISO calendar date as local noon. Noon avoids DST boundary changes,
+-- while the round trip rejects values that os.time would otherwise normalize.
+function Activity.dateTimestamp(value)
+  if type(value) ~= "string" then
+    return nil
+  end
+
+  local year, month, day = string.match(value, "^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
+  if year == nil then
+    return nil
+  end
+
+  local timestamp = os.time({
+    year = tonumber(year),
+    month = tonumber(month),
+    day = tonumber(day),
+    hour = 12,
+  })
+
+  if type(timestamp) ~= "number" or os.date("%Y-%m-%d", timestamp) ~= value then
+    return nil
+  end
+
+  return timestamp
+end
+
 function Activity.streaks(days, todayDate)
   local best = 0
   local running = 0

--- a/github-activity/lib/settings.luau
+++ b/github-activity/lib/settings.luau
@@ -39,4 +39,15 @@ function Settings.widgetDisplayMetric(value)
     or DEFAULT_WIDGET_DISPLAY_METRIC
 end
 
+function Settings.panelElementVisible(value)
+  if type(value) == "boolean" then
+    return value
+  end
+  return true
+end
+
+function Settings.calendarExpanded(showToday, showCurrentStreak, showBestStreak)
+  return not showToday and not showCurrentStreak and not showBestStreak
+end
+
 return Settings

--- a/github-activity/panel.luau
+++ b/github-activity/panel.luau
@@ -20,20 +20,18 @@ local gridPreparingDay = 1
 local gridReady = false
 local open = false
 local tr = noctalia.tr
-local monthNames = {
-  tr("panel.months.jan"),
-  tr("panel.months.feb"),
-  tr("panel.months.mar"),
-  tr("panel.months.apr"),
-  tr("panel.months.may"),
-  tr("panel.months.jun"),
-  tr("panel.months.jul"),
-  tr("panel.months.aug"),
-  tr("panel.months.sep"),
-  tr("panel.months.oct"),
-  tr("panel.months.nov"),
-  tr("panel.months.dec"),
-}
+local showToday = Settings.panelElementVisible(noctalia.getConfig("show_today"))
+local showCurrentStreak = Settings.panelElementVisible(noctalia.getConfig("show_current_streak"))
+local showBestStreak = Settings.panelElementVisible(noctalia.getConfig("show_best_streak"))
+local showYearTotal = Settings.panelElementVisible(noctalia.getConfig("show_year_total"))
+local showProfileButton = Settings.panelElementVisible(noctalia.getConfig("show_profile_button"))
+local calendarExpanded = Settings.calendarExpanded(showToday, showCurrentStreak, showBestStreak)
+local calendarCellWidth = 10
+local calendarCellHeight = 12
+local calendarColumnGap = 1
+local calendarRowGap = calendarExpanded and 4 or 3
+local calendarHeaderHeight = calendarExpanded and 14 or 12
+local weekdayLabelFontSize = calendarExpanded and 12 or 11
 
 local function requestRefresh()
   noctalia.state.set("refresh_request", noctalia.nowMs())
@@ -61,13 +59,35 @@ local function resetGrid(source)
   gridWeekCount = 0
 end
 
-local function monthForWeek(week)
+local function detailDate(day, week)
+  local rawDetail = (gridDetails[day] or {})[week] or ""
+  return string.match(rawDetail, "^([^|]+)|")
+end
+
+local function formatDate(pattern, date)
+  local timestamp = Activity.dateTimestamp(date)
+  if timestamp == nil then
+    return ""
+  end
+  return noctalia.formatTime(pattern, timestamp)
+end
+
+local function representativeDateForWeek(week)
   local preferredDays = { 4, 1, 2, 3, 5, 6, 7 }
   for _, day in ipairs(preferredDays) do
-    local rawDetail = (gridDetails[day] or {})[week] or ""
-    local date = string.match(rawDetail, "^([^|]+)|")
+    local date = detailDate(day, week)
     if date ~= nil then
-      return tonumber(string.sub(date, 6, 7))
+      return date
+    end
+  end
+  return nil
+end
+
+local function representativeDateForDay(day)
+  for week = 1, gridWeekCount do
+    local date = detailDate(day, week)
+    if date ~= nil then
+      return date
     end
   end
   return nil
@@ -75,21 +95,22 @@ end
 
 local function buildMonthHeader()
   local segments = {}
-  local segmentMonth = nil
+  local segmentKey = nil
+  local segmentDate = nil
   local segmentWeeks = 0
 
   local function appendSegment()
-    if segmentMonth == nil or segmentWeeks == 0 then
+    if segmentKey == nil or segmentWeeks == 0 then
       return
     end
     table.insert(segments, ui.column({
-      width = segmentWeeks * 11 - 1,
-      height = 12,
+      width = segmentWeeks * (calendarCellWidth + calendarColumnGap) - calendarColumnGap,
+      height = calendarHeaderHeight,
       align = "center",
       justify = "center",
     }, {
       ui.label({
-        text = segmentWeeks >= 2 and (monthNames[segmentMonth] or "") or "",
+        text = segmentWeeks >= 2 and formatDate("%b", segmentDate) or "",
         fontSize = 10,
         color = "on_surface_variant",
         textAlign = "center",
@@ -98,38 +119,40 @@ local function buildMonthHeader()
   end
 
   for week = 1, gridWeekCount do
-    local month = monthForWeek(week)
-    if segmentMonth ~= nil and month ~= segmentMonth then
+    local date = representativeDateForWeek(week)
+    local monthKey = date ~= nil and string.sub(date, 1, 7) or nil
+    if segmentKey ~= nil and monthKey ~= nil and monthKey ~= segmentKey then
       appendSegment()
       segmentWeeks = 0
     end
-    segmentMonth = month or segmentMonth
+    segmentKey = monthKey or segmentKey
+    segmentDate = date or segmentDate
     segmentWeeks = segmentWeeks + 1
   end
   appendSegment()
 
-  return ui.row({ gap = 1, align = "center" }, segments)
+  return ui.row({ gap = calendarColumnGap, align = "center" }, segments)
 end
 
 local function buildWeekdayLabels()
-  local names = { "", tr("panel.weekdays.mon"), "", tr("panel.weekdays.wed"), "", tr("panel.weekdays.fri"), "" }
   local labels = {}
   for day = 1, 7 do
+    local date = (day == 2 or day == 4 or day == 6) and representativeDateForDay(day) or nil
     table.insert(labels, ui.column({
       width = 30,
-      height = 12,
+      height = calendarCellHeight,
       align = "end",
       justify = "center",
     }, {
       ui.label({
-        text = names[day],
-        fontSize = 11,
+        text = date ~= nil and formatDate("%a", date) or "",
+        fontSize = weekdayLabelFontSize,
         color = "on_surface_variant",
         textAlign = "end",
       }),
     }))
   end
-  return ui.column({ gap = 3, align = "end" }, labels)
+  return ui.column({ gap = calendarRowGap, align = "end" }, labels)
 end
 
 local function prepareGridDay()
@@ -164,18 +187,18 @@ local function prepareGridColumns()
           key = key,
           fill = Activity.color(gridLevels[day][gridWeek]),
           radius = 2,
-          width = 10,
-          height = 12,
+          width = calendarCellWidth,
+          height = calendarCellHeight,
           onHover = "onDayHover",
         }))
       end
     end
-    table.insert(gridColumns, ui.column({ key = "week-" .. tostring(gridWeek), gap = 3, align = "center" }, cells))
+    table.insert(gridColumns, ui.column({ key = "week-" .. tostring(gridWeek), gap = calendarRowGap, align = "center" }, cells))
     gridWeek = gridWeek + 1
   end
 
   if gridWeek > gridWeekCount then
-    cachedHeatmap = ui.row({ gap = 1, align = "start" }, gridColumns)
+    cachedHeatmap = ui.row({ gap = calendarColumnGap, align = "start" }, gridColumns)
     cachedCalendar = ui.row({ gap = 10, align = "end", justify = "center" }, {
       buildWeekdayLabels(),
       ui.column({ gap = 6, align = "start" }, {
@@ -272,25 +295,48 @@ function render()
     local day = selectedDay()
     local selectedText = day ~= nil
       and tr("panel.day_total", { date = day.date, count = day.count })
-      or tr("panel.year_total", { login = data.login, count = data.total })
+      or (showYearTotal and tr("panel.year_total", { login = data.login, count = data.total }) or "")
     table.insert(body, ui.label({ text = selectedText, height = 14, fontSize = 11, color = "on_surface_variant", textAlign = "center" }))
     table.insert(body, ui.label({ text = refreshSchedule(), height = 12, fontSize = 10, color = "on_surface_variant", textAlign = "center" }))
-    table.insert(body, ui.separator({ thickness = 1, color = "outline/0.35" }))
-    table.insert(body, ui.row({ gap = 14, align = "stretch" }, {
-      metric(tr("metric.today"), data.today, activityBlocks(data.today > 0 and 1 or 0, 1)),
-      ui.separator({ orientation = "vertical", thickness = 1, color = "outline/0.35" }),
-      metric(
+
+    local metrics = {}
+    if showToday then
+      table.insert(metrics, metric(tr("metric.today"), data.today, activityBlocks(data.today > 0 and 1 or 0, 1)))
+    end
+    if showCurrentStreak then
+      table.insert(metrics, metric(
         tr("metric.current_streak"),
         data.currentStreak,
         activityBlocks(math.min(data.currentStreak, 12), math.max(1, math.min(data.currentStreak, 12)))
-      ),
-      ui.separator({ orientation = "vertical", thickness = 1, color = "outline/0.35" }),
-      metric(tr("metric.best_streak"), data.bestStreak, activityBlocks(math.min(data.bestStreak, 12), 12)),
-    }))
+      ))
+    end
+    if showBestStreak then
+      table.insert(metrics, metric(tr("metric.best_streak"), data.bestStreak, activityBlocks(math.min(data.bestStreak, 12), 12)))
+    end
+
+    if #metrics > 0 then
+      local metricChildren = {}
+      for index, item in ipairs(metrics) do
+        if index > 1 then
+          table.insert(metricChildren, ui.separator({ orientation = "vertical", thickness = 1, color = "outline/0.35" }))
+        end
+        table.insert(metricChildren, item)
+      end
+      table.insert(body, ui.separator({ thickness = 1, color = "outline/0.35" }))
+      table.insert(body, ui.row({ gap = 14, align = "stretch" }, metricChildren))
+    end
   end
 
-  table.insert(root, ui.column({ gap = 12, paddingH = 18, paddingV = 14, fill = "surface", flexGrow = 1 }, body))
-  if data ~= nil and cachedCalendar ~= nil then
+  local centerReadyContent = calendarExpanded and data ~= nil and cachedCalendar ~= nil
+  table.insert(root, ui.column({
+    gap = centerReadyContent and 8 or 12,
+    paddingH = 18,
+    paddingV = 14,
+    fill = "surface",
+    flexGrow = 1,
+    justify = centerReadyContent and "center" or "start",
+  }, body))
+  if data ~= nil and cachedCalendar ~= nil and showProfileButton then
     table.insert(root, ui.separator({ thickness = 1, color = "outline/0.35" }))
     table.insert(root, ui.row({ justify = "end", paddingH = 14, paddingV = 10 }, {
       ui.button({ text = tr("action.open_profile"), glyph = "external-link", variant = "outline", onClick = "onOpenProfile" }),

--- a/github-activity/plugin.toml
+++ b/github-activity/plugin.toml
@@ -1,6 +1,6 @@
 id = "alexmnrs/github-activity"
 name = "GitHub Activity"
-version = "1.3.0"
+version = "1.4.0"
 plugin_api = 24
 author = "AlexMnrs"
 license = "MIT"
@@ -58,6 +58,41 @@ placement = "attached"
 position = "auto"
 open_near_click = true
 dismiss_on_outside_click = true
+
+[[panel.setting]]
+key = "show_today"
+type = "bool"
+label_key = "settings.panel_content.show_today.label"
+description_key = "settings.panel_content.show_today.description"
+default = true
+
+[[panel.setting]]
+key = "show_current_streak"
+type = "bool"
+label_key = "settings.panel_content.show_current_streak.label"
+description_key = "settings.panel_content.show_current_streak.description"
+default = true
+
+[[panel.setting]]
+key = "show_best_streak"
+type = "bool"
+label_key = "settings.panel_content.show_best_streak.label"
+description_key = "settings.panel_content.show_best_streak.description"
+default = true
+
+[[panel.setting]]
+key = "show_year_total"
+type = "bool"
+label_key = "settings.panel_content.show_year_total.label"
+description_key = "settings.panel_content.show_year_total.description"
+default = true
+
+[[panel.setting]]
+key = "show_profile_button"
+type = "bool"
+label_key = "settings.panel_content.show_profile_button.label"
+description_key = "settings.panel_content.show_profile_button.description"
+default = true
 
 [[service]]
 id = "sync"

--- a/github-activity/translations/en.json
+++ b/github-activity/translations/en.json
@@ -29,6 +29,28 @@
         "current_streak": "Current streak",
         "year_total": "Contributions in the last year"
       }
+    },
+    "panel_content": {
+      "show_today": {
+        "label": "Show today's contributions",
+        "description": "Show the contribution count for today below the calendar."
+      },
+      "show_current_streak": {
+        "label": "Show current streak",
+        "description": "Show the current contribution streak below the calendar."
+      },
+      "show_best_streak": {
+        "label": "Show best streak",
+        "description": "Show the longest contribution streak below the calendar."
+      },
+      "show_year_total": {
+        "label": "Show annual total",
+        "description": "Show the annual contribution total when no calendar day is selected."
+      },
+      "show_profile_button": {
+        "label": "Show profile button",
+        "description": "Show the button for opening the GitHub profile."
+      }
     }
   },
   "widget": {
@@ -40,26 +62,7 @@
     "title": "GitHub Activity",
     "year_total": "{login} · {count} contributions in the last year",
     "day_total": "{date} · {count} contributions",
-    "preparing": "Preparing interactive calendar…",
-    "months": {
-      "jan": "Jan",
-      "feb": "Feb",
-      "mar": "Mar",
-      "apr": "Apr",
-      "may": "May",
-      "jun": "Jun",
-      "jul": "Jul",
-      "aug": "Aug",
-      "sep": "Sep",
-      "oct": "Oct",
-      "nov": "Nov",
-      "dec": "Dec"
-    },
-    "weekdays": {
-      "mon": "Mon",
-      "wed": "Wed",
-      "fri": "Fri"
-    }
+    "preparing": "Preparing interactive calendar…"
   },
   "metric": {
     "today": "Today",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `alexmnrs/github-activity`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->


<!-- noctalia-github-activity-cli: generated details -->
Updates alexmnrs/github-activity to v1.4.0. A native GitHub contribution calendar for your Noctalia bar.

Changes prepared from the source changelog:

### Added
- Per-panel controls for contribution summaries, streak metrics, and the
  profile action, including a centered, expanded calendar layout when all
  metrics are hidden.
### Changed
- Calendar month and weekday labels now follow the system date locale through
  Noctalia's date formatter.
## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->


<!-- noctalia-github-activity-cli: generated details -->
- Declared in `plugin.toml`: `gh, xdg-open`.
## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** 24


<!-- noctalia-github-activity-cli: generated details -->
Automated checks run locally: `luau tests/activity_spec.luau`, `luau tests/settings_spec.luau`, and the community manifest validator.
Manual compositor testing remains to be completed before review.
## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->


<!-- noctalia-github-activity-cli: generated details -->
<img width="820" height="499" alt="image" src="https://github.com/user-attachments/assets/952dcde8-19a7-434a-be2c-cd4e3d53e585" />
<img width="700" height="453" alt="image" src="https://github.com/user-attachments/assets/486a5e4a-fbbe-4906-99ed-7bf90b7dbc86" />
## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
