### PR TITLE
[System Updates Manager] Add adapters for pipx, xbps, and gearlever

### DIFF
--- a/system-updater/README.md
+++ b/system-updater/README.md
@@ -1,10 +1,10 @@
 # System Updates Manager
 
-Manage system updates inside the noctalia panel. Currently supported PackageKit, Flatpak and Cargo.
+Manage system updates inside the noctalia panel. Currently supported PackageKit, Flatpak, Cargo, pipx, Gear Lever, and XBPS.
 
 # Features
 
-* Check updates with [PackageKit](https://www.freedesktop.org/software/PackageKit), [Flatpak](https://flatpak.org/) and Cargo.
+* Check updates with [PackageKit](https://www.freedesktop.org/software/PackageKit), [Flatpak](https://flatpak.org/), [Cargo](https://doc.rust-lang.org/cargo/), [pipx](https://pipx.pypa.io/latest/index.html), [Gear Lever](https://gearlever.mijorus.it/), and [XBPS](https://github.com/void-linux/xbps).
 * Extensible with user created adapters
 * Support for offline updates with PackageKit
 * Single package update is supported
@@ -43,6 +43,18 @@ Flatpak update adapter requires  ```python``` and ```flatpak``` to be installed 
 
 Cargo update adapter requires  ```cargo```, ```python```, ```cargo-install-update```, `awk` and `bash` to be installed into ```$PATH```.
 
+### pipx
+
+pipx update adapter requires ```pipx```, ```jq```, and ```grep``` to be installed into ```$PATH```. The adapter can update pipx itself if [your pipx installation is self-managed](https://pipx.pypa.io/latest/how-to/install-pipx.html#self-managed-pipx).
+
+### Gear Lever
+
+Gear Lever update adapter requires ```gearlever```, ```sed```, and ```coreutils``` (```echo```, ```tr```, ```head```) to be installed into ```$PATH```.
+
+### XBPS
+
+XBPS update adapter requires ```xbps``` (```xbps-install```, ```xbps-query```), ```jq```, ```bash```, ```grep```, and ```coreutils``` (```echo```, ```cut```) to be installed into ```$PATH```.
+
 ## Usage
 
 Add the system-updater widget from Noctalia's widget picker, then click it to open the panel. You can also open the panel directly or bind it in your compositor:
@@ -66,9 +78,11 @@ noctalia msg panel-toggle tordex/system-updater:panel
 | `enable_packagekit` | `bool` | `true` | Enable the PackageKit adapter for managing system updates. |
 | `enable_flatpak` | `bool` | `true` | Enable the Flatpak adapter for managing system updates. |
 | `enable_cargo` | `bool` | `true` | Enable the Cargo adapter for managing system updates. |
+| `enable_pipx` | `bool` | `true` | Enable the pipx adapter for managing system updates. |
+| `enable_gearlever` | `bool` | `true` | Enable the Gear Lever adapter for managing system updates. |
+| `enable_xbps` | `bool` | `true` | Enable the XBPS adapter for managing system updates. |
 | `auto_check_minutes` | `int` | `60` | Check for updates automatically every N minutes. if <= 10 never checks on its own — nothing runs until you ask for it. |
 | `adapters_folder` | `folder` |  | The folder where adapters definitions are stored. One adapter per subfolder. Each adapter folder must contain an adapter.json with the adapter definition. |
-| `notify_on_updates` | `bool` | `true` | Send a desktop notification when a check finds packages to upgrade or after applying updates. |
 | `notify_on_updates` | `bool` | `true` | Send a desktop notification when a check finds packages to upgrade or after applying updates. |
 | `glyph` | `glyph` | `package` | The glyph shown for the system updater widget on the bar. |
 | `show_count` | `bool` | `true` | Show the number of pending updates next to the bar glyph. |

--- a/system-updater/adapters/gearlever/adapter.json
+++ b/system-updater/adapters/gearlever/adapter.json
@@ -1,7 +1,7 @@
 {
     "name": "Gear Lever",
     "enabled": true,
-    "dependencies": ["gearlever"],
+    "dependencies": ["gearlever", "sed", "echo", "tr", "head"],
     "check_command": "echo '{\"updates\":[' ; gearlever --list-updates 2>/dev/null | sed -r 's/\\//:/g' | sed -r 's/(([^ ]+ ?)*[^ ]+) +\\[.*\\] +([^ ]*)/{\"id\":\"\\3\",\"name\":\"\\1\",\"glyph\":\"settings-down\",\"from_version\":\"??\",\"to_version\":\"???\",\"description\":\"\",\"icon\":\"\"}/' | tr '\\n' ',' | head -c -1 ; echo ']}'",
     "update_package_command": "gearlever --update --yes \"$(echo \"{package_name}\" | sed -r 's/:/\\//g')\"",
     "update_all_command": "gearlever --update --all --yes",

--- a/system-updater/adapters/gearlever/adapter.json
+++ b/system-updater/adapters/gearlever/adapter.json
@@ -1,0 +1,9 @@
+{
+    "name": "Gear Lever",
+    "enabled": true,
+    "dependencies": ["gearlever"],
+    "check_command": "echo '{\"updates\":[' ; gearlever --list-updates 2>/dev/null | sed -r 's/\\//:/g' | sed -r 's/(([^ ]+ ?)*[^ ]+) +\\[.*\\] +([^ ]*)/{\"id\":\"\\3\",\"name\":\"\\1\",\"glyph\":\"settings-down\",\"from_version\":\"??\",\"to_version\":\"???\",\"description\":\"\",\"icon\":\"\"}/' | tr '\\n' ',' | head -c -1 ; echo ']}'",
+    "update_package_command": "gearlever --update --yes \"$(echo \"{package_name}\" | sed -r 's/:/\\//g')\"",
+    "update_all_command": "gearlever --update --all --yes",
+    "actions": {}
+}

--- a/system-updater/adapters/pipx/adapter.json
+++ b/system-updater/adapters/pipx/adapter.json
@@ -1,0 +1,9 @@
+{
+    "name": "pipx",
+    "enabled": true,
+    "dependencies": ["pipx", "jq"],
+    "check_command": "pipx list --json --outdated | grep -v \"Error\" | jq '.data | {\"info\": \"\", \"updates\": .packages | map({\"id\": .environment, \"name\": .package, \"from_version\": .version, \"to_version\": .latest_version, \"description\": \"\", \"icon\": \"\", \"glyph\": \"brand-python\"})}'",
+    "update_package_command": "pipx upgrade \"{package_name}\"",
+    "update_all_command": "pipx upgrade-all",
+    "actions": {}
+}

--- a/system-updater/adapters/pipx/adapter.json
+++ b/system-updater/adapters/pipx/adapter.json
@@ -1,7 +1,7 @@
 {
     "name": "pipx",
     "enabled": true,
-    "dependencies": ["pipx", "jq"],
+    "dependencies": ["pipx", "jq", "grep"],
     "check_command": "pipx list --json --outdated | grep -v \"Error\" | jq '.data | {\"info\": \"\", \"updates\": .packages | map({\"id\": .environment, \"name\": .package, \"from_version\": .version, \"to_version\": .latest_version, \"description\": \"\", \"icon\": \"\", \"glyph\": \"brand-python\"})}'",
     "update_package_command": "pipx upgrade \"{package_name}\"",
     "update_all_command": "pipx upgrade-all",

--- a/system-updater/adapters/xbps/adapter.json
+++ b/system-updater/adapters/xbps/adapter.json
@@ -1,0 +1,9 @@
+{
+    "name": "xbps",
+    "enabled": true,
+    "dependencies": ["xbps-install", "jq", "bash"],
+    "check_command": "{adapter_dir}/check.bash",
+    "update_package_command": "sudo xbps-install -Suy \"{package_name}\"",
+    "update_all_command": "sudo xbps-install -Suy",
+    "actions": {}
+}

--- a/system-updater/adapters/xbps/adapter.json
+++ b/system-updater/adapters/xbps/adapter.json
@@ -1,7 +1,7 @@
 {
-    "name": "xbps",
+    "name": "XBPS",
     "enabled": true,
-    "dependencies": ["xbps-install", "jq", "bash"],
+    "dependencies": ["xbps-install", "xbps-query", "jq", "grep", "bash", "echo", "cut"],
     "check_command": "{adapter_dir}/check.bash",
     "update_package_command": "sudo xbps-install -Suy \"{package_name}\"",
     "update_all_command": "sudo xbps-install -Suy",

--- a/system-updater/adapters/xbps/adapter.json
+++ b/system-updater/adapters/xbps/adapter.json
@@ -3,7 +3,7 @@
     "enabled": true,
     "dependencies": ["xbps-install", "jq", "bash"],
     "check_command": "{adapter_dir}/check.bash",
-    "update_package_command": "sudo xbps-install -Suy \"{package_name}\"",
-    "update_all_command": "sudo xbps-install -Suy",
+    "update_package_command": "pkexec xbps-install -Suy \"{package_name}\"",
+    "update_all_command": "pkexec xbps-install -Suy",
     "actions": {}
 }

--- a/system-updater/adapters/xbps/check.bash
+++ b/system-updater/adapters/xbps/check.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+PACKAGES=$(xbps-install -Mnu | jq -Rr '. | match("(.*?)-([^-]*?) ").captures | map(.string) | join("|")')
+PREFIX=""
+echo '{"updates":['
+for PACKAGE in $PACKAGES
+do
+    echo $PREFIX
+    PREFIX=","
+    PACKAGE_NAME=$(echo $PACKAGE | cut -d '|' -f1)
+    PACKAGE_NEW_VERSION=$(echo $PACKAGE | cut -d '|' -f2)
+    PACKAGE_CURRENT_VERSION=$(xbps-query "$PACKAGE_NAME" | grep 'pkgver:' | jq -Rr '.| match("pkgver: (.*?)-([^-]*?)$").captures[1].string')
+    echo {\"id\": \"$PACKAGE_NAME\"", \"name\": \"$PACKAGE_NAME\", \"from_version\": \"$PACKAGE_CURRENT_VERSION\", \"to_version\": \"$PACKAGE_NEW_VERSION\", \"description\": \"\", \"icon\": \"\", \"glyph\": \"brand-node\"}"
+done
+echo "]}"

--- a/system-updater/adapters/xbps/check.bash
+++ b/system-updater/adapters/xbps/check.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 PACKAGES=$(xbps-install -Mnu | jq -Rr '. | match("(.*?)-([^-]*?) ").captures | map(.string) | join("|")')
 PREFIX=""
 echo '{"updates":['

--- a/system-updater/plugin.toml
+++ b/system-updater/plugin.toml
@@ -1,10 +1,10 @@
 id = "tordex/system-updater"
 name = "System Updates Manager"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 20
 author = "tordex"
 license = "MIT"
-dependencies = ["pkgcli", "cargo", "cargo-install-update", "python", "flatpak", "awk", "bash"]
+dependencies = ["pkgcli", "cargo", "cargo-install-update", "python", "flatpak", "awk", "bash", "jq", "grep", "coreutils", "sed"]
 tags = ["bar", "panel", "service", "system"]
 icon = "package"
 description = "Manage system updates (PackageKit, Flatpak, Cargo etc.)."
@@ -28,6 +28,27 @@ key = "enable_cargo"
 type = "bool"
 label_key = "settings.enable_cargo.label"
 description_key = "settings.enable_cargo.description"
+default = true
+
+[[setting]]
+key = "enable_pipx"
+type = "bool"
+label_key = "settings.enable_pipx.label"
+description_key = "settings.enable_pipx.description"
+default = true
+
+[[setting]]
+key = "enable_gearlever"
+type = "bool"
+label_key = "settings.enable_gearlever.label"
+description_key = "settings.enable_gearlever.description"
+default = true
+
+[[setting]]
+key = "enable_xbps"
+type = "bool"
+label_key = "settings.enable_xbps.label"
+description_key = "settings.enable_xbps.description"
 default = true
 
 [[setting]]

--- a/system-updater/service.luau
+++ b/system-updater/service.luau
@@ -89,6 +89,12 @@ local function load_adapters()
                             adapter.enabled = false
                         elseif adapter.name == "Cargo" and cfg("enable_cargo") == false then
                             adapter.enabled = false
+                        if adapter.name == "pipx" and cfg("enable_pipx") == false then
+                            adapter.enabled = false
+                        elseif adapter.name == "Gear LEver" and cfg("enable_gearlever") == false then
+                            adapter.enabled = false
+                        elseif adapter.name == "XBPS" and cfg("enable_xbps") == false then
+                            adapter.enabled = false
                         end
 
                         for _, dep in ipairs(adapter.dependencies or {}) do

--- a/system-updater/translations/en.json
+++ b/system-updater/translations/en.json
@@ -50,6 +50,18 @@
       "description": "Enable the PackageKit adapter for managing system updates.",
       "label": "Enable PackageKit adapter"
     },
+    "enable_pipx": {
+      "description": "Enable the pipx adapter for managing Python application updates.",
+      "label": "Enable pipx adapter"
+    },
+    "enable_gearlever": {
+      "description": "Enable the Gear Lever adapter for managing AppImage updates.",
+      "label": "Enable Gear Lever adapter"
+    },
+    "enable_xbps": {
+      "description": "Enable the XBPS adapter for managing system updates.",
+      "label": "Enable XBPS adapter"
+    },
     "glyph": {
       "description": "The glyph shown for the system updater widget on the bar.",
       "label": "Bar glyph"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `tordex/system-updater`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

This PR adds three new adapters:

 - pipx, for managing Python applications
 - Gear Lever, for managing AppImages
 - XBPS, for managing system packages in Void Linux

## External dependencies

`jq`, `grep`, `sed,` and `coreutils`.

## Testing

I have tried checking for updates, installing an update to one package, and installing all updates for each of the three adapters.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.9
- **Plugin API level:** 20

## Screenshots / Videos

No significant changes

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
