### PR TITLE
fix(screen-toolkit): fix multi-display OCR/Lens/Measure and fullscreen recording

### DIFF
--- a/screen-toolkit/plugin.toml
+++ b/screen-toolkit/plugin.toml
@@ -8,7 +8,7 @@
 
 id = "alexander/screen-toolkit"
 name = "Screen Toolkit"
-version = "1.3.1"
+version = "1.3.2"
 plugin_api = 13
 author = "alexander"
 license = "MIT"

--- a/screen-toolkit/service.luau
+++ b/screen-toolkit/service.luau
@@ -119,7 +119,7 @@ local function focusedGeometry()
 end
 
 local function parseGeometry(geom)
-  local gx, gy, gw, gh = geom:match("^(%d+),(%d+)%s+(%d+)x(%d+)$")
+  local gx, gy, gw, gh = geom:match("^(-?%d+),(-?%d+)%s+(%d+)x(%d+)$")
   if not gx then return nil end
   return tonumber(gx), tonumber(gy), tonumber(gw), tonumber(gh)
 end
@@ -659,15 +659,31 @@ local function buildRecorderCommand(bin, geom, out)
     local cursor = cursorHidden and "no" or "yes"
     local target = "-w screen"
     if isRegion then
-      local gx, gy, gw, gh = tostring(geom):match("^(%d+),(%d+) (%d+)x(%d+)$")
+      local gx, gy, gw, gh = tostring(geom):match("^(-?%d+),(-?%d+) (%d+)x(%d+)$")
       if gx then target = string.format("-w region -region %sx%s+%s+%s", gw, gh, gx, gy) end
+    else
+      local fg = focusedGeometry()
+      if fg then
+        local fx, fy, fw, fh = fg:match("^(-?%d+),(-?%d+) (%d+)x(%d+)$")
+        if fx then target = string.format("-w region -region %sx%s+%s+%s", fw, fh, fx, fy) end
+      end
     end
     return string.format("gpu-screen-recorder %s -f %d -k %s -bm qp -ffmpeg-opts qp=25 -cursor %s -cr limited %s -v no -o %s", target, fps, codec, cursor, gsrAudioFlags(), shellQuote(out))
   end
 
   local isWl = bin == "wl-screenrec"
   local parts = { bin }
-  if isRegion then table.insert(parts, "-g " .. shellQuote(geom)) end
+  if isRegion then
+    table.insert(parts, "-g " .. shellQuote(geom))
+  else
+    local focused = noctalia.focusedOutputName()
+    if focused and focused ~= "" then
+      table.insert(parts, "-o " .. shellQuote(focused))
+    else
+      local fg = focusedGeometry()
+      if fg then table.insert(parts, "-g " .. shellQuote(fg)) end
+    end
+  end
   table.insert(parts, "-f " .. shellQuote(out))
 
   if isWl then


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `alexander/screen-toolkit`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes multi-display regression reported in #455 where OCR, Lens and Measure did nothing after region selection, and GIF FS / Rec FS recorded the wrong monitor (DP-2 instead of focused DP-3).

sorry for being late (busy) better late than never , anyway that remove #455 

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0 beta 9-3
- **Plugin API level:** 13


## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
