### PR TITLE
tailscale: add hide_when_healthy and flag_problem widget settings

### DIFF
--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -48,6 +48,8 @@ noctalia msg panel-toggle davemhammer/tailscale:manager
 | `admin_url` | `string` | _(empty)_ | Override admin console URL (default login.tailscale.com admin). |
 | `ssh_user` | `string` | _(empty)_ | Default user for `tailscale ssh`. |
 | `show_counts` | `bool` (widget) | `true` | Show online/total peers on the bar. |
+| `hide_when_healthy` | `bool` (widget) | `false` | Hide the widget entirely while Tailscale runs; it appears only when the daemon is stopped, needs login, or is unreachable. |
+| `flag_problem` | `bool` (widget) | `false` | Error-tinted status dot while Tailscale is not running, instead of the neutral grey one. |
 
 ## IPC
 

--- a/tailscale/plugin.toml
+++ b/tailscale/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/tailscale"
 name = "Tailscale"
-version = "1.0.6"
+version = "1.1.0"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"
@@ -61,6 +61,20 @@ entry = "widget.luau"
   label_key = "settings.show_counts.label"
   description_key = "settings.show_counts.description"
   default = true
+
+  [[widget.setting]]
+  key = "hide_when_healthy"
+  type = "bool"
+  label_key = "settings.hide_when_healthy.label"
+  description_key = "settings.hide_when_healthy.description"
+  default = false
+
+  [[widget.setting]]
+  key = "flag_problem"
+  type = "bool"
+  label_key = "settings.flag_problem.label"
+  description_key = "settings.flag_problem.description"
+  default = false
 
 [[panel]]
 id = "manager"

--- a/tailscale/translations/en.json
+++ b/tailscale/translations/en.json
@@ -135,6 +135,14 @@
     },
     "warn_color": {
       "label": "Disconnected color (grey)"
+    },
+    "hide_when_healthy": {
+      "label": "Hide when healthy",
+      "description": "Hide the widget entirely while Tailscale is running; show it only when the daemon is stopped, needs login, or is unreachable."
+    },
+    "flag_problem": {
+      "label": "Flag problems in red",
+      "description": "Show an error-tinted status dot while Tailscale is not running, instead of the neutral grey one."
     }
   },
   "status": {

--- a/tailscale/widget.luau
+++ b/tailscale/widget.luau
@@ -32,7 +32,30 @@ local function render()
   local exitNode = tostring(snapshot.exitNode or "")
   local hasExit = exitNode ~= ""
 
-  -- Connected = green logo, stopped = grey logo (never red).
+  -- Two independent, opt-in settings (both default false — behaviour is
+  -- unchanged unless a widget instance turns one on):
+  --   hide_when_healthy — collapse to nothing while running.
+  --   flag_problem      — error-tinted status dot while not running,
+  --                       instead of the neutral grey one.
+  -- They compose: a permanently-visible widget can still flag a problem,
+  -- and a hidden-while-healthy widget stays reachable via the /ts
+  -- launcher provider whenever it matters.
+  local hideWhenHealthy = noctalia.getConfig("hide_when_healthy") == true
+  local flagProblem = noctalia.getConfig("flag_problem") == true
+
+  if hideWhenHealthy then
+    if running then
+      barWidget.setVisible(false)
+      return
+    end
+    barWidget.setVisible(true)
+  end
+
+  -- Connected = green logo, stopped = grey logo (never red) — except
+  -- with flag_problem on, where the one non-connected state earns the
+  -- error colour, since that setting exists to make a permanently-
+  -- visible widget read as an alert.
+  local isProblem = flagProblem and not running
   local color = running and COLOR_CONNECTED or COLOR_DISCONNECTED
 
   local children = {
@@ -44,7 +67,17 @@ local function render()
     }),
   }
 
-  if showCounts and available then
+  if isProblem and not (showCounts and available) then
+    -- Restrained problem indicator when there is nothing else to show:
+    -- brand mark plus an error-tinted dot, no counts/exit-node detail —
+    -- that stays in the manager panel this widget opens on click.
+    table.insert(children, ui.box({
+      width = 7,
+      height = 7,
+      radius = 4,
+      fill = "error",
+    }))
+  elseif showCounts and available then
     table.insert(children, ui.label({
       text = `{online}/{total}`,
       fontWeight = "bold",
@@ -61,7 +94,7 @@ local function render()
       width = 7,
       height = 7,
       radius = 4,
-      fill = color,
+      fill = isProblem and "error" or color,
     }))
   end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/tailscale`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds two independent, opt-in settings to the status widget (both default
`false`, existing behaviour unchanged):

- **`hide_when_healthy`** — collapse the widget entirely while Tailscale
  is running; it appears only when the daemon is stopped, needs login,
  or is unreachable. For people who want a quiet bar unless something is
  wrong. The `/ts` launcher provider keeps working while hidden.
- **`flag_problem`** — error-tinted status dot while Tailscale is not
  running, instead of the neutral grey one, shown even with `show_counts`
  off (a restrained brand-mark + red dot; the detail stays in the manager
  panel the widget opens on click). For permanently-visible widgets that
  should read as an alert.

The two compose: a permanently-visible widget can flag problems, and a
hidden-while-healthy widget only ever appears in a state worth flagging.

## External dependencies

None added — pure rendering changes plus two `noctalia.getConfig` reads.

## Testing

- `python3 .github/workflows/scripts/validate-plugins.py` — clean.
- `widget.luau` parses and runs to the first host-API call under the
  stock `luau` CLI (the plugin has no test harness; this change mirrors
  the structure of the existing `show_counts` handling).
- The equivalent widget behaviour has run daily on the author's machine
  (Niri) via a local patch carrying these two settings; this PR ports it
  onto the current upstream widget structure.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.9
- **Plugin API level:** unchanged (existing plugin, no new API used)

## Screenshots / Videos

No visual change with both settings off (defaults). With `flag_problem`
on and Tailscale stopped, the widget shows the brand mark plus an
error-red dot; with `hide_when_healthy` on it is absent entirely while
healthy. Can attach screenshots on request.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
      (Plugin's existing thumbnail is untouched.)
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

---

### Notes for reviewers

@davemhammer — your call obviously; happy to adjust naming or split into
two PRs if you'd rather take one. Unrelated observation while in here:
`translations/en.json` carries `ok_color`/`warn_color` keys that no
manifest setting references any more (leftovers from a removed colour
setting?) — happy to prune them in a separate PR if you want.

Disclaimer: AI-assisted tooling was used.
