### PR TITLE
arch-updater: fix flatpak update always declining in terminal mode

### DIFF
--- a/arch-updater/CHANGELOG.md
+++ b/arch-updater/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Arch Updater are documented here. The panel's changelog
 icon (the history icon next to Check) shows this same file.
 
+## 2.0.2 - 2026-08-28
+
+- Fixed: Update in terminal mode always failed on the Flatpak step, auto-declining its confirmation prompt with "n" (exit 1) even when nothing was typed. flatpak's prompt refuses to be interactive once its stdout isn't a real terminal, which is the case here since the whole run is piped into `tee` for the log; pacman/AUR prompts aren't affected by this. The Flatpak step now runs non-interactively (`-y --noninteractive`) in terminal mode too, same as background mode already did; pacman/AUR review stays fully interactive.
+
 ## 2.0.1 - 2026-08-21
 
 - Added: a changelog view in the panel. Click the history icon next to Check to see what changed in each release. It also opens automatically once an update finishes, unless turned off in settings (Show changelog after updating).

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "2.0.1"
+version = "2.0.2"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -1073,7 +1073,12 @@ local function buildTerminalCommand()
         table.insert(parts, "sudo pacman -Syu" .. ignoreFlag)
     end
     if cfg("flatpak_enabled") == true and noctalia.commandExists("flatpak") then
-        table.insert(parts, flatpakUpdateCommand(""))
+        -- flatpak's own Y/n prompt gates on isatty(stdout); since this whole
+        -- command is piped into `tee` for the log, flatpak sees a non-tty
+        -- stdout and auto-declines with "n" no matter what's typed
+        -- (flatpak/flatpak#4409). There's no real interactivity to preserve
+        -- here, so just make it non-interactive like the background mode.
+        table.insert(parts, flatpakUpdateCommand(" -y --noninteractive"))
     end
     return table.concat(parts, " && ")
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `yuuto/arch-updater`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes an issue where Update in terminal mode always fails on the Flatpak step: it auto-declines its own `[Y/n]` confirmation with "n" and exits 1, no matter what is typed. pacman/AUR prompts in the same run are unaffected.


## External dependencies

None new. The Flatpak leg still shells out to the same `flatpak update` already listed in `dependencies` in `plugin.toml`, just with different flags.

## Testing

Reproduced on my own machine (CachyOS, Niri, arch-updater 2.0.1, `update_mode = terminal`, `flatpak_enabled = true`): triggered Update from the bar widget with pending pacman/AUR and Flatpak updates. pacman/AUR update applied normally with interactive prompts; the Flatpak update prompt appeared, then auto-answered "n" on its own, and the run ended with `::EXIT 1`.

Applied this fix locally against the installed plugin and re-ran Update the same way: pacman/AUR stayed fully interactive (PKGBUILD review, conflict prompts, etc. untouched), the Flatpak updates applied without any prompt, and the run completed with `::EXIT 0`.

Root cause: `buildTerminalCommand()` pipes the whole run's output into `tee` for the log (`{ ...; } 2>&1 | tee -a $log`). flatpak's own Y/n confirmation gates on `isatty(stdout)`, so once stdout is a pipe into `tee` it always treats itself as non-interactive and auto-answers "n" — a known flatpak behavior, see [flatpak/flatpak#4409](https://github.com/flatpak/flatpak/issues/4409). pacman and the AUR helpers don't gate their prompts on stdout being a tty, so they're unaffected by the same `tee`. Since real interactivity for the Flatpak step isn't achievable here, this passes `-y --noninteractive` to it in terminal mode too, matching what `buildBackgroundCommand()` already does.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0 (5.0.0_beta.9-3)
- **Plugin API level:** 9

## Screenshots / Videos

No visual/UI surface changes — this only changes the flags passed to an existing shell command; the panel and widget are unchanged.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
