### PR TITLE
opencodex-bar 1.0.1: reliable panel open, Accounts default

### DIFF
--- a/opencodex-bar/README.md
+++ b/opencodex-bar/README.md
@@ -26,7 +26,7 @@ Install from the Noctalia plugin store and add the `usage` widget to a bar. Clic
 noctalia msg panel-toggle wy3z/opencodex-bar:panel
 ```
 
-- Accounts: subscription plans, health, reauth, quota windows, active Codex account selection, and confirmed reset-credit use
+- Accounts (default): subscription plans, health, reauth, quota windows, active Codex account selection, and confirmed reset-credit use
 - Usage: today, 30-day request grid, provider/model totals, estimated cost
 
 Right-click the widget or use Refresh to force a quota refresh. The link button runs `xdg-open` on `base_url`.

--- a/opencodex-bar/panel.luau
+++ b/opencodex-bar/panel.luau
@@ -51,7 +51,7 @@ local currentSnapshot = noctalia.state.get("snapshot") or {
   providers = {},
 }
 local currentAction = noctalia.state.get("action") or { status = "idle" }
-local activeTab = "usage"
+local activeTab = "accounts"
 local panelOpen = false
 local renderPanel
 local hoveredUsageDate = nil
@@ -939,6 +939,9 @@ end)
 
 function onOpen()
   panelOpen = true
+  -- Accounts is the landing tab on every open. The panel runtime stays loaded
+  -- after close, so without this the last visited tab (often Usage) would stick.
+  activeTab = "accounts"
   -- Countdowns and the "updated Ns ago" line are the only live text here; a
   -- panel gets no update tick at all unless it asks for one.
   pcall(function() panel.setWantsSecondTicks(true) end)

--- a/opencodex-bar/plugin.toml
+++ b/opencodex-bar/plugin.toml
@@ -1,6 +1,6 @@
 id          = "wy3z/opencodex-bar"
 name        = "OpenCodexBar"
-version     = "1.0.0"
+version     = "1.0.1"
 plugin_api  = 24
 author      = "wy3z"
 license     = "MIT"
@@ -63,7 +63,10 @@ entry = "service.luau"
 id    = "usage"
 entry = "widget.luau"
 
-
+  # Host-side toggle: runs on the UI thread with the click's bar anchor, so the
+  # panel does not depend on a queued onClick() that can lose the press.
+  [widget.actions]
+  left = "panel-toggle wy3z/opencodex-bar:panel"
 
   [[widget.setting]]
   key             = "show_percentage"

--- a/opencodex-bar/widget.luau
+++ b/opencodex-bar/widget.luau
@@ -72,8 +72,15 @@ end
 local MARK_SIZE = 13
 local GAUGE_H = 12
 local GAUGE_W = 8
+-- Keep a chip large enough that bar hide/show (Control Center) cannot collapse
+-- the plugin InputArea to an unclickable sliver.
+local CHIP_MIN = 18
+
+local lastVisual = nil
+local lastTooltip = nil
 
 local function usedColorFor(used)
+  if used == nil then return "on_surface" end
   return used >= CRITICAL_USED and pick(RED) or "on_surface"
 end
 
@@ -81,21 +88,30 @@ end
 -- full gauge means no headroom left. ui.progress cannot do this: ProgressBar
 -- supports a Vertical orientation internally, but the reconciler never exposes
 -- it, so the gauge is a track column holding a level box pinned to the bottom.
+-- Always draw the track, even with no quota: a nil icon made the chip vanish
+-- after a bar hide/show until the next snapshot, which ate the first clicks.
 local function usageGauge(used)
-  if used == nil then return nil end
-  local level = math.max(0, math.min(100, used)) / 100
+  local level = type(used) == "number" and math.max(0, math.min(100, used)) / 100 or 0
   -- Keep a sliver visible at zero so the gauge never reads as "no data".
   local filled = level <= 0 and 1 or math.max(2, math.floor(GAUGE_H * level + 0.5))
   return ui.column({
     key = "gauge",
     width = GAUGE_W,
     height = GAUGE_H,
+    minWidth = GAUGE_W,
+    minHeight = GAUGE_H,
     radius = 3,
     fill = "on_surface/0.18",
     justify = "end",
     align = "stretch",
   }, {
-    ui.box({ key = "level", height = filled, radius = 2, fill = usedColorFor(used) }),
+    ui.box({
+      key = "level",
+      width = GAUGE_W,
+      height = filled,
+      radius = 2,
+      fill = usedColorFor(used),
+    }),
   })
 end
 
@@ -128,37 +144,61 @@ local function render(snapshot)
   local color = usedColor(used, status)
 
   local mode = configured("icon_source", "bars")
+  local showPct = configured("show_percentage", true)
   local critical = used ~= nil and used >= CRITICAL_USED
-
-  local icon = nil
-  if mode == "bars" then
-    icon = usageGauge(used)
-  else
-    local glyph = mode == "fixed"
+  local usedText = used ~= nil and string.format("%.0f%%", used) or "—"
+  local glyph = nil
+  if mode ~= "bars" then
+    glyph = mode == "fixed"
       and configured("glyph", "brand-openai")
       or common.providerGlyph(iconProvider(snapshot)) or "robot"
     if critical and mode ~= "fixed" then glyph = "alert-triangle-filled" end
-    icon = ui.glyph({ key = "glyph", name = glyph, size = MARK_SIZE, color = color })
   end
 
+  local tip = tooltip(snapshot, used, counted or 0)
+  local visual = table.concat({
+    mode, glyph or "", usedText, tostring(color), tostring(showPct), noctalia.isDarkMode() and "d" or "l",
+  }, "|")
+  if visual == lastVisual then
+    if tip ~= lastTooltip then
+      lastTooltip = tip
+      barWidget.setTooltip(tip)
+    end
+    return
+  end
+  lastVisual = visual
+  lastTooltip = tip
+
+  local icon = mode == "bars" and usageGauge(used)
+    or ui.glyph({ key = "glyph", name = glyph, size = MARK_SIZE, color = color })
+
   local children = { icon }
-  if configured("show_percentage", true) then
+  if showPct then
     table.insert(children, ui.label({
       key = "used",
-      text = used ~= nil and string.format("%.0f%%", used) or "—",
+      text = usedText,
       color = color,
     }))
   end
 
   local container = barWidget.isVertical() and ui.column or ui.row
-  barWidget.render(container({ gap = 4, align = "center" }, children))
-  barWidget.setTooltip(tooltip(snapshot, used, counted or 0))
+  barWidget.render(container({
+    key = "chip",
+    gap = 4,
+    align = "center",
+    minWidth = CHIP_MIN,
+    minHeight = CHIP_MIN,
+    paddingH = 4,
+  }, children))
+  barWidget.setTooltip(tip)
 end
 
 noctalia.state.watch("snapshot", function(value)
   render(value)
 end)
 
+-- Fallback when the left widget action is unbound. With the default
+-- `panel-toggle` binding, the host consumes left-click and this does not fire.
 function onClick()
   noctalia.togglePanel(PANEL_ID)
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `wy3z/opencodex-bar`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

OpenCodexBar is a bar indicator and attached panel for a local OpenCodex instance: account/quota/routing on Accounts, and request/cost history on Usage.

This 1.0.1 update fixes two UX bugs:

- The panel always opens on **Accounts**. 1.0.0 started on Usage and kept the last tab because the panel runtime stays loaded after close.
- Left-click uses a host `[widget.actions]` `panel-toggle` instead of a queued `onClick()`. The bar chip always draws the usage track, has a minimum size, and skips no-op re-renders so the hit target does not collapse after Control Center hide/show.

## External dependencies

Unchanged from 1.0.0:

- **OpenCodex 2.31.0:** polling uses authenticated `GET` requests. Confirmed account actions use `PUT /api/codex-auth/active` and `POST /api/codex-auth/reset-credits/consume`.
- **Admin token:** read from `OPENCODEX_ADMIN_AUTH_TOKEN`, or from the configured `admin_token_file` if the environment variable is unavailable. The plugin writes no local files; confirmed account actions mutate OpenCodex state.
- **`xdg-open`:** used by the link button to open the OpenCodex dashboard. It is called with an argument array rather than through a shell, and nothing else is spawned.

Plain HTTP is only allowed for loopback addresses. Anything remote has to use HTTPS.

## Testing

Click-tested on Hyprland against a live OpenCodex setup with Noctalia v5.0.0:

- Opening the panel from the bar widget after Control Center hide/show (the missed-click case).
- Confirming the landing tab is Accounts on each open.
- `noctalia msg panel-toggle wy3z/opencodex-bar:panel`

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0
- **Plugin API level:** 24

## Screenshots / Videos

Visual change is the Accounts landing tab and a slightly padded bar chip. Store thumbnail is unchanged. Same surfaces as 1.0.0:

### Accounts

<img width="471" height="542" alt="OpenCodex Accounts panel" src="https://github.com/user-attachments/assets/4d333838-7304-45e2-ba79-75cd04dfe6b6" />

### Usage

<img width="486" height="544" alt="OpenCodex Usage panel" src="https://github.com/user-attachments/assets/57dffe70-a0a8-493b-aff5-96d6db6818c5" />

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
