### PR TITLE
fix(cider): support Umbriel in window probe

### DIFF
--- a/cider/scripts/cider_bridge.py
+++ b/cider/scripts/cider_bridge.py
@@ -309,6 +309,43 @@ def probe_cider_window() -> dict[str, Any]:
             "t": time.time(),
         }
 
+    if shutil.which("umbriel"):
+        try:
+            listing = subprocess.check_output(
+                ["umbriel", "windows"],
+                stderr=subprocess.DEVNULL,
+                timeout=1.5,
+            ).decode("utf-8", "replace")
+        except Exception as exc:
+            log.debug("umbriel probe failed: %s", exc)
+            empty["compositor"] = "umbriel"
+            return empty
+        cider = None
+        for line in listing.splitlines():
+            # Format: [*]app_id<TAB>Title<TAB>[tile|float WxH+X+Y]; '*' = focused
+            focused = line.startswith("*")
+            app_id = line[1:].split("\t", 1)[0].strip() if focused else line.split("\t", 1)[0].strip()
+            title = ""
+            if "\t" in line:
+                rest = line[1:] if focused else line
+                parts = rest.split("\t")
+                if len(parts) >= 2:
+                    title = parts[1].strip()
+            if _is_cider_window(app_id, title):
+                cider = {"app_id": app_id, "title": title, "focused": focused}
+        if cider is None:
+            empty["compositor"] = "umbriel"
+            return empty
+        focused = cider["focused"]
+        return {
+            "present": True,
+            "focused": focused,
+            "on_screen": focused,
+            "suppress_notify": focused,
+            "compositor": "umbriel",
+            "t": time.time(),
+        }
+
     if shutil.which("hyprctl"):
         try:
             clients = json.loads(


### PR DESCRIPTION
## Summary

The cider bridge's `probe_cider_window()` only handled **niri** and **Hyprland**. On an **Umbriel** session where `hyprctl` happens to be installed (e.g. after switching compositors), the probe selected the Hyprland branch, `hyprctl clients -j` failed with `HYPRLAND_INSTANCE_SIGNATURE not set`, and the probe returned `present: false`.

Result: the Noctalia bar chip showed the current track for ~600 ms and then hid as "nothing playing", even though Cider was actively playing. Every new track event briefly re-showed the chip before the window probe wiped it again.

## Fix

Add an `umbriel` branch **before** the `hyprctl` branch that parses the plain-text output of `umbriel windows`:

- Format: `[*]app_id<TAB>title<TAB>[tile|float WxH+X+Y]`, where the leading `*` marks the focused window
- Reuses the existing `_is_cider_window()` matcher (app_id or exact title "cider")

Presence detection is what the plugin needs; focus detection drives notification suppression, which now correctly suppresses toasts only while the Cider window is focused.

## Test Plan

- [x] `probe_cider_window()` on a live Umbriel session returns `{"present": true, "compositor": "umbriel", ...}` (previously `present: false` via the failing Hyprland branch)
- [x] With the patched bridge running, the Noctalia bar chip stays visible while Cider plays and position keeps ticking (no more "nothing playing" flip)
- [x] Synthetic parse checks: focused/unfocused cider window, app_id match, title match, non-cider windows ignored
- [x] niri/Hyprland branches untouched