### PR TITLE
keybind-cheatsheet: focus the search box when the panel opens

### DIFF
--- a/keybind-cheatsheet/panel.luau
+++ b/keybind-cheatsheet/panel.luau
@@ -776,7 +776,10 @@ local function renderHeader()
       searchRevision += 1
       render()
     end)
-    table.insert(children, ui.input({ key = "search-" .. searchRevision, value = query, placeholder = tr("search_placeholder"), controlSize = "sm", width = 300, onChange = searchChanged }))
+    -- The panel is opened to look something up, so typing goes straight to the
+    -- search box without clicking it first. Dropped while a description is
+    -- being edited, so that row's own input keeps the caret.
+    table.insert(children, ui.input({ key = "search-" .. searchRevision, value = query, placeholder = tr("search_placeholder"), controlSize = "sm", width = 300, onChange = searchChanged, focus = editingId == nil }))
     table.insert(children, ui.button({ glyph = "x", width = 26, variant = "ghost", controlSize = "sm", enabled = query ~= "", tooltip = tr("clear"), onClick = clearSearch }))
   end
   if not loading or #bindings > 0 then

--- a/keybind-cheatsheet/plugin.toml
+++ b/keybind-cheatsheet/plugin.toml
@@ -1,6 +1,6 @@
 id = "kenn/keybind-cheatsheet"
 name = "Keybind Cheatsheet"
-version = "0.2.4"
+version = "0.2.5"
 plugin_api = 9
 author = "kenn"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `kenn/keybind-cheatsheet`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Focuses the search box when the panel opens, so the first keystroke starts filtering instead of being swallowed. Right now the panel has to be clicked in the search field first, which is a small but constant friction for the plugin's main use ("what was that shortcut again?").

One line: the search input gets `focus = editingId == nil`. The condition keeps the behavior out of the way while a description is being edited in edit mode — that row's own input keeps the caret.

Happy to put it behind a setting (e.g. `focus_search_on_open`, default on) if you prefer it optional.

## External dependencies

None.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.10 (noctalia-git 5.0.0.r5344.g74e6c2790)
- **Plugin API level:** 9

Opened the panel and typed immediately (no click): the text lands in the search box and the list filters as expected; the clear button and Escape still behave as before, and edit mode keeps its own input focused.

Note on `focus`: it is the property the runtime accepts on `ui.input` — `autoFocus`, `focused` and `selectAll` are rejected with `ui tree: 'input' has no prop '…', ignored`, so this is the one that works today.

## Screenshots / Videos

Panel right after opening, with only keystrokes (no click): the search box holds the caret and the list is already filtered.

![Search focused on open](https://github.com/UmedjonBA/community-plugins/releases/download/pr-webapp-assets/pr-kbcs-autofocus.png)

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

---

Both this and #534 branch off `main` and bump to 0.2.5, since either can land on its own. Whichever you merge first, I will rebase the other and bump its version accordingly — just say the word.
