### PR TITLE
niri-ribbon 0.1.0: viewport position indicator for niri scrollable-tiling

### DIFF
--- a/niri-ribbon/README.md
+++ b/niri-ribbon/README.md
@@ -1,0 +1,38 @@
+# Niri Ribbon
+
+A bar widget for niri's scrollable-tiling layout: it draws the focused workspace's whole scrolling ribbon as a slim overview strip and highlights the region currently inside the viewport, so you can see at a glance how many columns are hidden to the left and right — and scrolling over the widget moves the focused column.
+
+## Plugin
+
+| Field | Value |
+| --- | --- |
+| ID | `luochen1990/niri-ribbon` |
+| Entries | Bar widget: `ribbon` |
+
+## Requirements
+
+- The [niri](https://github.com/YaLTeR/niri) compositor (declared as the `niri` dependency; the widget shells out to `niri msg`).
+- Noctalia `5.0.0-beta.4` or newer for the scroll interaction (the `onScroll` bar-widget API).
+
+## Usage
+
+Add the widget via Noctalia Settings → Bar → widgets: pick **Niri Ribbon** and place it in the start/center/end section. It renders the focused workspace's scrolling ribbon; the highlighted segment is the current viewport.
+
+Scroll up/left or down/right over the widget to move the focused column (equivalent to `focus-column-left` / `focus-column-right`).
+
+## Settings
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `bar_color` | `color` | `outline` | Color of the ribbon track (the non-visible area). |
+| `viewport_color` | `color` | `primary` | Color of the viewport highlight. |
+| `thickness` | `double` | `4.0` | Vertical thickness of the ribbon (logical pixels). |
+| `radius` | `double` | `2.0` | Corner radius of the viewport highlight (logical pixels). |
+| `viewport_model` | `select` | `fit` | How the viewport position is estimated; must match your niri `center-focused-column` setting: `fit` for `never` (niri default), `center` for `always`. |
+| `gaps` | `double` | `0.0` | The `layout.gaps` value from your niri config (logical pixels); used for accurate canvas-width estimation. |
+
+## Notes
+
+- **Viewport position is estimated.** The niri IPC currently exposes neither the live viewport offset nor a viewport-scroll event, so the highlight is derived geometrically from the focused column (see the "Viewport estimation" section in `ribbon.luau` for the full model and its limitations). In short: the `fit` model is accurate for the common left-to-right focus flow and slightly off when focusing columns right-to-left or clicking a non-adjacent column inside the viewport. Exact rendering is tracked in [niri#4147](https://github.com/niri-wm/niri/pull/4147).
+- **Spawned processes:** read-only `niri msg` IPC queries (`windows`, `workspaces`, `outputs`), one persistent `niri msg -j event-stream` subscription, and `focus-column-*` actions on scroll. No network access, no filesystem writes.
+- **Credits:** the algorithm idea originates from [ews/noctalia-niri-ribbon](https://github.com/ews/noctalia-niri-ribbon) by J Pablo Puerta (quickshell/QML era); this plugin is a ground-up rewrite for the Noctalia v5 Luau plugin API.

--- a/niri-ribbon/plugin.toml
+++ b/niri-ribbon/plugin.toml
@@ -1,0 +1,101 @@
+# Niri Ribbon - viewport position indicator for niri scrollable-tiling layout.
+#
+# Draws an overview of the focused workspace's whole scrolling ribbon on the
+# bar and highlights where the current viewport sits and how wide it is — so
+# you can tell at a glance how many windows are hidden to the left and right.
+#
+# Acknowledgement: the core idea originates from ews/noctalia-niri-ribbon by
+# J Pablo Puerta <ews@folksonomy.com>
+# (https://github.com/ews/noctalia-niri-ribbon). That project targeted the
+# legacy quickshell-era QML plugin API; this plugin is a ground-up rewrite for
+# the Noctalia v5 spec (plugin.toml + Luau) that keeps the algorithm idea.
+#
+# Important: the niri IPC (26.04 through HEAD) exposes neither the live
+# viewport offset nor a "viewport scrolled" event (the WorkspaceViewChanged
+# event assumed by the original ews project never existed upstream). This
+# plugin estimates the resting viewport position geometrically — see the
+# "Viewport estimation" section at the top of ribbon.luau.
+
+id = "luochen1990/niri-ribbon"
+name = "Niri Ribbon"
+version = "0.1.0"
+plugin_api = 3
+author = "luochen1990"
+license = "MIT"
+dependencies = ["niri"]
+icon = "view-column"
+description = "Viewport position indicator for niri scrollable-tiling layout."
+tags = ["bar", "indicator", "niri"]
+
+[[widget]]
+id = "ribbon"
+entry = "ribbon.luau"
+
+  [[widget.setting]]
+  key = "bar_color"
+  type = "color"
+  label_key = "settings.bar_color.label"
+  description_key = "settings.bar_color.description"
+  # Not surface_variant: it sits in the same color family as the capsule
+  # background and becomes nearly invisible inside the capsule. outline is the
+  # Material border color and contrasts clearly with the surface family in
+  # both light and dark themes.
+  default = "outline"
+
+  [[widget.setting]]
+  key = "viewport_color"
+  type = "color"
+  label_key = "settings.viewport_color.label"
+  description_key = "settings.viewport_color.description"
+  default = "primary"
+
+  [[widget.setting]]
+  key = "thickness"
+  type = "double"
+  label_key = "settings.thickness.label"
+  description_key = "settings.thickness.description"
+  default = 4.0
+  min = 1.0
+  max = 12.0
+  step = 0.5
+
+  [[widget.setting]]
+  key = "radius"
+  type = "double"
+  label_key = "settings.radius.label"
+  description_key = "settings.radius.description"
+  default = 2.0
+  min = 0.0
+  max = 6.0
+  step = 0.5
+
+  # Viewport estimation model; should match niri `center-focused-column`:
+  #   fit    — niri `never` (default): focused column snapped near the edge
+  #   center — niri `always`: focused column always centered
+  # See the "Viewport estimation" section at the top of ribbon.luau.
+  [[widget.setting]]
+  key = "viewport_model"
+  type = "select"
+  label_key = "settings.viewport_model.label"
+  description_key = "settings.viewport_model.description"
+  default = "fit"
+
+    [[widget.setting.options]]
+    value = "fit"
+    label_key = "settings.viewport_model.option.fit"
+
+    [[widget.setting.options]]
+    value = "center"
+    label_key = "settings.viewport_model.option.center"
+
+  # The niri `layout.gaps` value (logical pixels), used to estimate the total
+  # canvas width and padding. Defaults to 0.0 (the niri upstream default).
+  [[widget.setting]]
+  key = "gaps"
+  type = "double"
+  label_key = "settings.gaps.label"
+  description_key = "settings.gaps.description"
+  default = 0.0
+  min = 0.0
+  max = 64.0
+  step = 1.0

--- a/niri-ribbon/ribbon.luau
+++ b/niri-ribbon/ribbon.luau
@@ -1,0 +1,394 @@
+--!nonstrict
+-- Niri Ribbon - viewport position indicator for niri scrollable-tiling layout.
+--
+-- Acknowledgement: the core idea originates from ews/noctalia-niri-ribbon by
+-- J Pablo Puerta <ews@folksonomy.com>
+-- (https://github.com/ews/noctalia-niri-ribbon). That project targeted the
+-- legacy quickshell-era QML+manifest.json plugin API (since removed upstream);
+-- this file is a ground-up rewrite against the Noctalia v5 plugin spec
+-- (plugin.toml + Luau).
+--
+-- Mechanism: subscribe to `niri msg -j event-stream`; on structural changes
+-- fetch windows/workspaces/outputs via three concurrent runAsync queries;
+-- once all callbacks arrive, compute ratioStart/ratioWidth and render the
+-- ribbon overview with a row + 3 boxes (left gap / viewport highlight /
+-- right gap).
+--
+-- Key design notes:
+--   * runStream is killed automatically by Noctalia when the widget unmounts;
+--     no manual lifecycle management needed.
+--   * fetchAll debounces via an inFlight + dirty flag: when events arrive
+--     while a query round is in flight, one more round runs right after it
+--     completes, so the final state is never missed.
+--
+-- ── Viewport estimation (the hard part) ───────────────────────────────────
+-- The niri IPC (26.04 through current HEAD) exposes neither the live viewport
+-- offset (view_pos) nor any "viewport scrolled" event. The WorkspaceViewChanged
+-- event assumed by the original ews implementation has never existed upstream,
+-- so this plugin estimates the resting viewport position from the focused
+-- window plus geometry.
+--
+-- Estimation models (selected via `viewport_model`; should match niri
+-- `center-focused-column`):
+--   * "fit"    — matches niri `center-focused-column: never` (niri default).
+--                niri behavior: focusing an off-screen column snaps it near a
+--                viewport edge (left or right, whichever moves less); columns
+--                already visible stay put. We approximate the steady state of
+--                the common interaction (focusing columns left to right) as
+--                "focused column right-aligned to the viewport":
+--                  view_pos = clamp(col_x + col_w + padding - view_w, 0, canvas)
+--                This simplified formula deviates from a per-column simulation
+--                (focusing from the leftmost column up to the focused one) by
+--                at most one gaps value (usually <= 8px) — imperceptible on a
+--                ribbon ~80px wide.
+--   * "center" — matches niri `center-focused-column: always`.
+--                niri behavior: the focused column is always centered.
+--                Formula:
+--                  view_pos = col_x + col_w/2 - view_w/2
+--
+-- Known limitations (inherent without live viewport data; exact rendering
+-- would need niri to expose view_pos upstream):
+--   (1) When focusing columns right-to-left, niri's actual steady state tends
+--       toward "focused column left-aligned", while the "fit" model still
+--       assumes right-alignment — a visible deviation.
+--   (2) When the newly focused column is already inside the viewport (niri
+--       keeps the view unchanged for visible columns), the "fit" model still
+--       recomputes as right-aligned, which does not match niri's "keep it".
+--       Root cause: the IPC does not expose the current view_pos, so "already
+--       visible" cannot be detected. Typical trigger: clicking a non-adjacent
+--       column inside the viewport.
+--
+-- Upstream progress: niri PR#4147 (https://github.com/niri-wm/niri/pull/4147,
+-- 2026-06) proposes Workspace.scrolling_view_pos + Event::WorkspaceViewPosChanged
+-- — exactly what this plugin needs (per-workspace view_pos with a resting
+-- target to avoid animation-interpolated IPC spam). The maintainer (YaLTeR)
+-- acknowledged the problem in #2381 but opposed a per-tile approach, and has
+-- not commented on that PR yet. Once it lands in a stable release, this plugin
+-- can consume the real view_pos and drop the estimation, removing both
+-- limitations above.
+
+-- ── Configuration ─────────────────────────────────────────────────────────
+local BAR_COLOR = noctalia.getConfig("bar_color") or "outline"
+local VIEWPORT_COLOR = noctalia.getConfig("viewport_color") or "primary"
+local THICKNESS = noctalia.getConfig("thickness") or 4.0
+local RADIUS = noctalia.getConfig("radius") or 2.0
+-- Viewport estimation model: "fit" (niri default `never`) | "center" (`always`)
+local VIEWPORT_MODEL = noctalia.getConfig("viewport_model") or "fit"
+-- The niri `layout.gaps` value (logical pixels), used to estimate the total
+-- canvas width and padding. Defaults to 0.0 (the niri upstream default).
+local GAPS = noctalia.getConfig("gaps") or 0.0
+
+-- ── Viewport state ────────────────────────────────────────────────────────
+local ratioStart = 0.0
+local ratioWidth = 1.0
+
+-- ── Rendering ─────────────────────────────────────────────────────────────
+local function render()
+  local leftFlex = ratioStart
+  local vpFlex = ratioWidth
+  local rightFlex = math.max(0.0, 1.0 - ratioStart - ratioWidth)
+  -- 3 boxes: flexGrow distributes the row's fixed width proportionally.
+  -- Note: the row needs an explicit width; otherwise the bar plugin_widget
+  -- sizes it with uiHost.width() (= 0) and the whole widget stays invisible
+  -- (flexGrow has no effect inside a zero-width parent).
+  barWidget.render(ui.row({ width = 80, height = THICKNESS, gap = 0, padding = 0 }, {
+    ui.box({ flexGrow = leftFlex, fill = BAR_COLOR }),
+    ui.box({ flexGrow = vpFlex, fill = VIEWPORT_COLOR, radius = RADIUS }),
+    ui.box({ flexGrow = rightFlex, fill = BAR_COLOR }),
+  }))
+end
+
+-- ── Algorithm ─────────────────────────────────────────────────────────────
+-- Returns (ratioStart, ratioWidth), both clamped to [0, 1] with sum <= 1.
+-- ratioStart/ratioWidth describe the viewport highlight as the
+-- [start, start+width] fraction of the ribbon.
+local function computeRatios(windows, workspaces, outputs)
+  if not windows or not workspaces or not outputs then
+    return 0.0, 1.0
+  end
+
+  -- Find the focused workspace, fall back to the first active one
+  local focusedWs = nil
+  for _, ws in ipairs(workspaces) do
+    if ws.is_focused then
+      focusedWs = ws
+      break
+    end
+  end
+  if not focusedWs then
+    for _, ws in ipairs(workspaces) do
+      if ws.is_active then
+        focusedWs = ws
+        break
+      end
+    end
+  end
+  if not focusedWs then
+    return 0.0, 1.0
+  end
+
+  local wsId = focusedWs.id
+  local outputName = focusedWs.output
+  local activeWinId = focusedWs.active_window_id
+
+  local output = outputs[outputName]
+  if not output or not output.logical then
+    return 0.0, 1.0
+  end
+  -- Note: strictly the view width should be working_area.size.w (minus
+  -- struts), but the niri IPC does not expose working_area, so
+  -- output.logical.width is an approximation. Non-empty struts (external
+  -- panels on the sides) introduce a deviation; most configurations have
+  -- empty struts, where it is negligible.
+  local viewWidth = (output.logical.width or 1920)
+  if viewWidth <= 0 then
+    return 0.0, 1.0
+  end
+
+  -- Collect the workspace's non-floating windows
+  local wsWindows = {}
+  for _, w in ipairs(windows) do
+    if w.workspace_id == wsId and not w.is_floating then
+      table.insert(wsWindows, w)
+    end
+  end
+  if #wsWindows == 0 then
+    return 0.0, 1.0
+  end
+
+  -- Collect column widths: pos_in_scrolling_layout[1] is the column index
+  -- (niri positions are 1-indexed)
+  local columns = {} -- { [col_idx] = width }
+  for _, w in ipairs(wsWindows) do
+    local layout = w.layout or {}
+    local pos = layout.pos_in_scrolling_layout
+    if type(pos) == "table" and #pos >= 1 then
+      local colIdx = pos[1]
+      local tileSize = layout.tile_size or {}
+      local width = (#tileSize >= 1) and tileSize[1] or 0
+      if columns[colIdx] == nil then
+        columns[colIdx] = width
+      end
+    end
+  end
+
+  -- Sort column indices
+  local colIndices = {}
+  for k in pairs(columns) do
+    table.insert(colIndices, k)
+  end
+  table.sort(colIndices)
+
+  -- Single column or none: viewport fills the whole ribbon
+  if #colIndices <= 1 then
+    return 0.0, 1.0
+  end
+
+  -- Total canvas width = sum(column widths) + (columns-1)*gaps
+  -- (niri inserts one gaps between every two adjacent columns)
+  local sumWidths = 0
+  for _, idx in ipairs(colIndices) do
+    sumWidths = sumWidths + columns[idx]
+  end
+  local gapsTotal = (#colIndices - 1) * GAPS
+  local canvasWidth = math.max(sumWidths + gapsTotal, viewWidth)
+
+  -- Locate the focused column (prefer workspace.active_window_id, fall back
+  -- to the globally focused window)
+  local targetWinId = activeWinId
+  if targetWinId == nil then
+    for _, w in ipairs(windows) do
+      if w.is_focused and w.workspace_id == wsId then
+        targetWinId = w.id
+        break
+      end
+    end
+  end
+  local targetWin = nil
+  for _, w in ipairs(wsWindows) do
+    if w.id == targetWinId then
+      targetWin = w
+      break
+    end
+  end
+  -- wsWindows[1] always exists: #wsWindows == 0 returned early above
+  targetWin = targetWin or wsWindows[1]
+
+  -- Left x of the focused column on the canvas (preceding widths + gaps)
+  local fLayout = targetWin.layout or {}
+  local fPos = fLayout.pos_in_scrolling_layout or {1}
+  local fIdx = fPos[1] or 1
+  local fWidth = columns[fIdx] or 0
+  local colX = 0
+  for _, idx in ipairs(colIndices) do
+    if idx == fIdx then
+      break
+    end
+    colX = colX + (columns[idx] or 0) + GAPS
+  end
+
+  -- Estimate the viewport's left edge in canvas coordinates (view_pos)
+  local viewPos
+  if VIEWPORT_MODEL == "center" then
+    -- Focused column always centered: viewport center = column center
+    viewPos = colX + fWidth / 2 - viewWidth / 2
+  else
+    -- "fit" model (steady-state approximation of niri `never`): focused
+    -- column right-aligned to the viewport, left edge clamped to 0.
+    -- Right-alignment puts the focused column at the right viewport edge and
+    -- reveals previously focused columns to the left — the typical steady
+    -- state of focusing columns left to right. If the focused column is wider
+    -- than the viewport, fall back to left alignment (matches niri).
+    if fWidth >= viewWidth then
+      viewPos = colX
+    else
+      -- padding = min((view_w - col_w)/2, gaps), matching niri's
+      -- compute_new_view_offset
+      local padding = math.min((viewWidth - fWidth) / 2, GAPS)
+      viewPos = colX + fWidth + padding - viewWidth
+    end
+    -- Clamp to [0, inf): niri actually allows view_pos < 0 (viewport left
+    -- edge beyond the canvas, background visible on the left), but ribbon
+    -- rendering requires rStart in [0, 1], so negatives clamp to 0 (the
+    -- highlight starts at the ribbon's left end). This is a rendering
+    -- constraint of the plugin, not upstream behavior.
+    if viewPos < 0 then
+      viewPos = 0
+    end
+  end
+
+  local rStart = viewPos / canvasWidth
+  local rWidth = viewWidth / canvasWidth
+
+  -- Clamp to [0, 1] and keep rStart + rWidth <= 1
+  rStart = math.max(0.0, math.min(1.0, rStart))
+  rWidth = math.max(0.01, math.min(1.0, rWidth))
+  if rStart + rWidth > 1.0 then
+    rStart = 1.0 - rWidth
+  end
+
+  return rStart, rWidth
+end
+
+-- ── Data fetching (concurrent + debounced) ────────────────────────────────
+local inFlight = false
+local dirty = false
+local snapshot = { windows = nil, workspaces = nil, outputs = nil }
+
+local function fetchAll()
+  if inFlight then
+    dirty = true
+    return
+  end
+  inFlight = true
+  dirty = false
+  snapshot = { windows = nil, workspaces = nil, outputs = nil }
+
+  local remaining = 3
+
+  local function onPart(key, result)
+    if result.exitCode == 0 and result.stdout ~= "" then
+      local ok, data = pcall(noctalia.json.decode, result.stdout)
+      if ok then
+        snapshot[key] = data
+      end
+    end
+    remaining = remaining - 1
+    if remaining == 0 then
+      inFlight = false
+      ratioStart, ratioWidth = computeRatios(snapshot.windows, snapshot.workspaces, snapshot.outputs)
+      render()
+      if dirty then
+        -- More events arrived during the query round; run one more round to
+        -- capture the final state
+        fetchAll()
+      end
+    end
+  end
+
+  noctalia.runAsync("niri msg -j windows", function(r)
+    onPart("windows", r)
+  end)
+  noctalia.runAsync("niri msg -j workspaces", function(r)
+    onPart("workspaces", r)
+  end)
+  noctalia.runAsync("niri msg -j outputs", function(r)
+    onPart("outputs", r)
+  end)
+end
+
+-- ── Event stream ──────────────────────────────────────────────────────────
+-- The niri event-stream emits no "viewport scrolled" event (no such event
+-- type exists in the upstream niri IPC), so every structural change triggers
+-- a full recomputation. The viewport position can only come from the
+-- geometric estimation inside computeRatios.
+-- Structural event types that trigger recomputation (tagged-union keys of
+-- the niri event-stream)
+local STRUCTURAL_EVENTS = {
+  WorkspaceActivated = true,
+  WindowOpenedOrChanged = true,
+  WindowClosed = true,
+  WorkspaceActiveWindowChanged = true,
+  WindowFocusChanged = true,
+  WindowsChanged = true,
+  WorkspacesChanged = true,
+  WindowLayoutsChanged = true,
+}
+local function onEventLine(line)
+  if not line or line == "" then
+    return
+  end
+  local ok, event = pcall(noctalia.json.decode, line)
+  if not ok or type(event) ~= "table" then
+    return
+  end
+  -- The event is a tagged union; hitting any structural key triggers a
+  -- recompute (pairs only iterates keys with non-nil values, equivalent to
+  -- the original `event.X ~= nil` checks)
+  for key in pairs(event) do
+    if STRUCTURAL_EVENTS[key] then
+      fetchAll()
+      return
+    end
+  end
+end
+
+-- ── Startup ───────────────────────────────────────────────────────────────
+local function start()
+  if not noctalia.commandExists("niri") then
+    noctalia.notifyError("Niri Ribbon", "niri command not found in PATH")
+    render()
+    return
+  end
+
+  -- Initial computation + event-stream subscription (Noctalia kills the
+  -- stream automatically when the widget unmounts)
+  fetchAll()
+  if not noctalia.runStream("niri msg -j event-stream", onEventLine) then
+    noctalia.notifyError("Niri Ribbon", "Unable to subscribe to niri event-stream")
+  end
+end
+
+-- ── Scroll interaction ────────────────────────────────────────────────────
+-- Noctalia native API (PR#3428, merged 2026-07): fires once per wheel detent
+-- (axis = "vertical"|"horizontal", steps is the step count (negative =
+-- up/left), startsGesture is true on the first step after the scroll stream
+-- goes quiet or reverses direction — not limited to touchpad flicks). Users
+-- can override or disable this callback via gesture bindings (scroll_up/...)
+-- or enable_scroll = false.
+-- niri-ribbon is a horizontal ribbon: both axes map to focus-column changes:
+--   steps < 0 (scroll up / left)    -> focus-column-left
+--   steps > 0 (scroll down / right) -> focus-column-right
+-- (In niri scrollable-tiling the focused column auto-centers, so "moving the
+-- focused column" is equivalent to "scrolling the viewport sideways".)
+function onScroll(_axis, steps, _startsGesture)
+  -- Noctalia guarantees steps is non-zero (continuous sources only fire the
+  -- callback once a full detent accrues); this check is purely defensive
+  if steps == 0 then
+    return
+  end
+  local action = (steps < 0) and "focus-column-left" or "focus-column-right"
+  noctalia.runAsync("niri msg action " .. action)
+end
+
+start()

--- a/niri-ribbon/translations/en.json
+++ b/niri-ribbon/translations/en.json
@@ -1,0 +1,16 @@
+{
+  "settings.bar_color.label": "Background Color",
+  "settings.bar_color.description": "Color of the ribbon track (the non-visible area).",
+  "settings.viewport_color.label": "Viewport Color",
+  "settings.viewport_color.description": "Color of the highlighted viewport region.",
+  "settings.thickness.label": "Thickness",
+  "settings.thickness.description": "Vertical thickness of the ribbon (logical pixels).",
+  "settings.radius.label": "Corner Radius",
+  "settings.radius.description": "Corner radius of the viewport highlight (logical pixels).",
+  "settings.viewport_model.label": "Viewport Model",
+  "settings.viewport_model.description": "How the viewport position is estimated. Should match your niri 'center-focused-column' setting. 'Fit' (default) works with niri's default 'never'; 'Center' works with 'always'.",
+  "settings.viewport_model.option.fit": "Fit (niri: never)",
+  "settings.viewport_model.option.center": "Center (niri: always)",
+  "settings.gaps.label": "Layout Gaps",
+  "settings.gaps.description": "The 'layout.gaps' value from your niri config, in logical pixels. Used for accurate canvas width and padding calculation."
+}

--- a/niri-ribbon/translations/zh-Hans.json
+++ b/niri-ribbon/translations/zh-Hans.json
@@ -1,0 +1,16 @@
+{
+  "settings.bar_color.label": "背景色",
+  "settings.bar_color.description": "Ribbon 轨道 (非可视区域) 的颜色。",
+  "settings.viewport_color.label": "视口色",
+  "settings.viewport_color.description": "当前可视区域高亮的颜色。",
+  "settings.thickness.label": "厚度",
+  "settings.thickness.description": "Ribbon 的垂直厚度 (逻辑像素)。",
+  "settings.radius.label": "圆角",
+  "settings.radius.description": "视口高亮区的圆角半径 (逻辑像素)。",
+  "settings.viewport_model.label": "视口推算模型",
+  "settings.viewport_model.description": "视口位置的推算方式, 应与 niri 的 center-focused-column 设置一致。Fit (默认) 对应 niri 默认的 never; Center 对应 always。",
+  "settings.viewport_model.option.fit": "Fit (niri: never)",
+  "settings.viewport_model.option.center": "Center (niri: always)",
+  "settings.gaps.label": "布局间距",
+  "settings.gaps.description": "niri 配置中 layout.gaps 的值 (逻辑像素), 用于精确推算画布总宽和内边距。"
+}


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `luochen1990/niri-ribbon`
- [x] New plugin
- [ ] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

A bar widget for niri's scrollable-tiling layout: draws the focused workspace's whole scrolling ribbon as a slim strip and highlights the region currently inside the viewport, so you can see at a glance how many columns are hidden to the left and right. Scrolling over the widget moves the focused column (`focus-column-left`/`right`).

The highlight is estimated geometrically from the niri IPC state (the IPC exposes no live viewport offset yet — exact viewport offsets are being implemented in [niri#4147](https://github.com/niri-wm/niri/pull/4147)); the estimation model and its limits are documented in detail at the top of `ribbon.luau` and in the README Notes.

## External dependencies

- `niri` — declared in `dependencies`. The plugin shells out to: read-only `niri msg -j windows/workspaces/outputs` queries on structural changes, one persistent `niri msg -j event-stream` subscription (killed automatically on widget unmount), and `niri msg action focus-column-left|right` on scroll. No network access, no filesystem writes.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** development build pinned 2026-08-26 (after 5.0.0-beta.8; `onScroll` requires ≥ beta.4)
- **Plugin API level:** 3

Daily-driven on my own machine for weeks (originally as a locally packaged plugin; this is the same code prepared for upstreaming). `noctalia plugins lint` passes with 0 errors / 0 warnings.

## Screenshots / Videos

TODO before ready-for-review: `thumbnail.webp` will be generated with the official thumbnail generator from a live screenshot. The widget itself renders a slim horizontal strip (see README for a description).

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.

---

**Draft note — why three boxes stay unchecked.**

- `thumbnail.webp` (ships / created): pending a live screenshot + the official thumbnail generator; this PR stays draft until it is in place.
- Right to publish: the core idea (geometric viewport estimation from niri IPC state) originates from [ews/noctalia-niri-ribbon](https://github.com/ews/noctalia-niri-ribbon) by J Pablo Puerta. That repository ships no license, so I opened [ews/noctalia-niri-ribbon#1](https://github.com/ews/noctalia-niri-ribbon/issues/1) asking the author to add one. This plugin is a ground-up rewrite (Python+QML → Luau; zero shared code — only the algorithm idea carries over). I will check this box once the licensing question is settled.
- `zh-Hans.json` is self-authored; Chinese is my native language.
