### PR TITLE
Get Home Assistant to return sorted entities

### DIFF
--- a/hassio/panel.luau
+++ b/hassio/panel.luau
@@ -151,11 +151,11 @@ end
 -- per-callback CPU budget. The tab and newline outside the {{ }} are the record
 -- separators; the ones inside replace() are escapes for Jinja to interpret.
 local ENTITY_LIST_TEMPLATE =
-    "{% for s in states %}{{ s.entity_id }}\t{{ s.name | replace('\\t',' ') | replace('\\n',' ') }}\n{% endfor %}"
+    "{% for s in (states | sort(attribute='entity_id')) %}{{ s.entity_id }}\t{{ s.name | replace('\\t',' ') | replace('\\n',' ') }}\n{% endfor %}"
 
 -- Same shape minus the friendly names, for instances that reject the template above.
 local ENTITY_ID_TEMPLATE =
-    "{% for s in states %}{{ s.entity_id }}\n{% endfor %}"
+    "{% for s in (states | sort(attribute='entity_id')) %}{{ s.entity_id }}\n{% endfor %}"
 
 local MAX_ENTITY_ID_LENGTH = 255
 local MAX_FRIENDLY_NAME_LENGTH = 255

--- a/hassio/plugin.toml
+++ b/hassio/plugin.toml
@@ -1,6 +1,6 @@
 id = "pozzoo/hassio"
 name = "Home Assistant"
-version = "2.0.6"
+version = "2.0.7"
 plugin_api = 9
 author = "Pozzoo"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `pozzoo/hassio`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

For large amounts of entities, sorting them is too expensive for our CPU budget. But Home Assistant's Jinja2 templating engine is perfectly capable of sorting them for us.

This fixes #440. Tested against a Home Assistant installation with 1,791 entities.

## External dependencies

No additional dependencies.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.9
- **Plugin API level:** 9

## Screenshots / Videos

No change

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
