### PR TITLE
Install PyGithub for validator tests

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+      - name: Install workflow test dependencies
+        run: python3 -m pip install -r .github/workflows/scripts/PyGithub-requirement.txt
 
       - name: Validate plugin manifests
         run: python3 .github/workflows/scripts/validate-plugins.py


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** N/A — shared CI workflow repair; this PR adds no plugin.
- [ ] New plugin
- [ ] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Installs the repository's existing pinned PyGithub test dependency before the validator workflow runs Python unit-test discovery. This fixes `ModuleNotFoundError: No module named 'github'` in workflow-maintenance tests; no plugin code, manifest, catalog, or plugin directory changes.

## External dependencies

`PyGithub==2.9.1` is already pinned in `.github/workflows/scripts/PyGithub-requirement.txt`. The workflow now installs that file before tests that import `github.Auth` and `github.Github`.

## Testing

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** N/A — CI workflow only
- **Plugin API level:** N/A — no plugin

Created an isolated Python environment, installed `.github/workflows/scripts/PyGithub-requirement.txt`, and ran `python -m unittest discover -s .github/workflows/scripts -p 'test_*.py'`. Result: 79 tests passed. The GitHub Actions validation run for this branch also passed.

## Screenshots / Videos

Not applicable: this PR changes only CI setup and has no visual surface.

## Checklist

- [ ] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [ ] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [ ] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [ ] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [ ] I did not edit `catalog.toml`; CI generates it.
- [ ] This PR touches exactly one plugin directory.

## Code review attestation

- [ ] The code is readable and not obfuscated, minified, or generated.
- [ ] It does not download and execute remote code.
- [ ] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [ ] I have the right to publish this code under the `license` declared in `plugin.toml`.
