### PR TITLE
layout-fix 1.0.1: make the keybinding hint real

### DIFF
--- a/layout-fix/README.md
+++ b/layout-fix/README.md
@@ -100,7 +100,12 @@ of your layouts is missing:
 | --- | --- | --- | --- |
 | `auto` | `bool` | `true` | Correct a word as soon as it is finished. Off: only the keybindings correct. |
 | `dictionaries` | `select` | `notify` | What to do about missing dictionaries: notify, install, or ignore. |
-| `hotkey_hint` | `bool` | `true` | Show once how to bind the fix and undo actions. |
+| `hotkey_hint` | `bool` | `true` | Show once how to bind the fix and undo actions — see below. |
+
+The hint is a single notification on the first start, and only for a config
+that does not already spawn this plugin's IPC: with no widget and no panel,
+it is the one place the manual actions can be mentioned at all. Having shown
+it once, the plugin remembers and stays quiet.
 
 ## IPC
 

--- a/layout-fix/plugin.toml
+++ b/layout-fix/plugin.toml
@@ -1,6 +1,6 @@
 id = "umedbazarov/layout-fix"
 name = "Layout Fix"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 9
 author = "umedbazarov"
 license = "MIT"

--- a/layout-fix/service.luau
+++ b/layout-fix/service.luau
@@ -18,6 +18,7 @@
 --   noctalia msg plugin umedbazarov/layout-fix:service all undo
 --   noctalia msg plugin umedbazarov/layout-fix:service all auto
 
+local PLUGIN_ID = "umedbazarov/layout-fix"
 local CHECK_INTERVAL_TICKS = 15 -- seconds between "is the daemon alive?" probes
 local STARTUP_DELAY_TICKS = 5
 
@@ -45,6 +46,10 @@ end
 
 local function shellQuote(value)
     return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
+end
+
+local function trim(value)
+    return (tostring(value or ""):gsub("^%s+", ""):gsub("%s+$", ""))
 end
 
 local function scriptPath()
@@ -112,6 +117,51 @@ local function applyAutoSetting()
     local wanted = cfg("auto", true) == true and "on" or "off"
     noctalia.runAsync(shellQuote(daemonPath) .. " auto " .. wanted .. " >/dev/null 2>&1",
         function() end)
+end
+
+-- ── The keybinding hint ──────────────────────────────────────────────────────
+
+-- Nothing about this plugin is visible: no widget, no panel, and the manual
+-- actions exist only as IPC. So a person who installs it has no way of
+-- learning that `fix` and `undo` are there unless they are told once.
+local function hintPath()
+    local dir = noctalia.pluginDataDir()
+    return dir ~= nil and (dir .. "/hint-shown") or nil
+end
+
+local function markHintShown()
+    local path = hintPath()
+    if path ~= nil then
+        noctalia.writeFile(path, "1\n")
+    end
+end
+
+-- Someone whose config already spawns this plugin's IPC has clearly found
+-- the keybindings, and a notification would only be noise. The marker is
+-- written either way, so the search runs once per installation.
+local function hintIfUnbound()
+    local path = hintPath()
+    if path == nil or noctalia.fileExists(path) then
+        return
+    end
+    if cfg("hotkey_hint", true) ~= true then
+        return
+    end
+    local cmd = "grep -rlF " .. shellQuote(PLUGIN_ID .. ":service")
+        .. " \"$HOME\"/.config/niri \"$HOME\"/.config/hypr \"$HOME\"/.config/sway"
+        .. " 2>/dev/null | head -1"
+    local started = noctalia.runAsync(cmd, function(result)
+        if trim(result.stdout or "") == "" then
+            noctalia.notify(tr("title"), tr("notify_hotkey_hint"))
+        end
+        markHintShown()
+    end, 10000)
+    if not started then
+        -- No shell to ask with: better one hint than none, and the marker
+        -- still keeps it to one.
+        noctalia.notify(tr("title"), tr("notify_hotkey_hint"))
+        markHintShown()
+    end
 end
 
 -- ── Keyboard access and dictionaries ─────────────────────────────────────────
@@ -248,6 +298,7 @@ function update()
                 end
                 applyAutoSetting()
                 checkAccess()
+                hintIfUnbound()
             end)
         end)
         return

--- a/layout-fix/tests/cases/01-startup.luau
+++ b/layout-fix/tests/cases/01-startup.luau
@@ -1,0 +1,15 @@
+--!nonstrict
+-- Startup: the daemon is copied to a stable path, started when it is not
+-- already running, and told which mode the settings ask for.
+
+boot()
+
+contains("daemon installed from the plugin dir", commandMatching("cp -f"), "/plugin/scripts/layout-fix")
+contains("installed into the data dir", commandMatching("cp -f"), "/data/layout-fix")
+check("it is made executable", commandMatching("chmod +x") ~= nil)
+check("liveness probed", commandMatching("/data/layout-fix' status") ~= nil)
+check("daemon launched detached", commandMatching("setsid") ~= nil)
+contains("automatic mode is on by default", commandMatching("auto on"), "auto on")
+equals("no error notifications", #LayoutTest.errors, 0)
+
+finish()

--- a/layout-fix/tests/cases/02-hint-unbound.luau
+++ b/layout-fix/tests/cases/02-hint-unbound.luau
@@ -1,0 +1,13 @@
+--!nonstrict
+-- Nothing about this plugin is visible, so a person whose compositor has no
+-- keybinding for it is told once how to make one.
+
+boot()
+
+contains("the hint was shown", notificationBodies(), "notify_hotkey_hint")
+equals("shown once", #LayoutTest.notifications, 1)
+equals("and remembered", LayoutTest.files["/data/hint-shown"], "1\n")
+contains("the search looked for this plugin's IPC",
+         commandMatching("grep -rlF"), "umedbazarov/layout-fix:service")
+
+finish()

--- a/layout-fix/tests/cases/03-hint-bound.luau
+++ b/layout-fix/tests/cases/03-hint-bound.luau
@@ -1,0 +1,11 @@
+--!nonstrict
+-- Someone whose config already spawns the plugin's IPC has clearly found the
+-- keybindings; telling them about it would be noise.
+
+LayoutTest.respond("grep -rlF", "/home/user/.config/niri/config.kdl\n")
+boot()
+
+equals("no hint", #LayoutTest.notifications, 0)
+equals("but the search is not repeated later", LayoutTest.files["/data/hint-shown"], "1\n")
+
+finish()

--- a/layout-fix/tests/cases/04-hint-already-shown.luau
+++ b/layout-fix/tests/cases/04-hint-already-shown.luau
@@ -1,0 +1,10 @@
+--!nonstrict
+-- The marker survives restarts: the hint is a one-time thing, not a nag.
+
+LayoutTest.files["/data/hint-shown"] = "1\n"
+boot()
+
+equals("no hint on the next start", #LayoutTest.notifications, 0)
+equals("and no config search either", commandMatching("grep -rlF"), nil)
+
+finish()

--- a/layout-fix/tests/cases/05-hint-disabled.luau
+++ b/layout-fix/tests/cases/05-hint-disabled.luau
@@ -1,0 +1,12 @@
+--!nonstrict
+-- Turned off in settings: no hint, and no marker either — turning it back on
+-- should still be able to show it.
+
+LayoutTest.config.hotkey_hint = false
+boot()
+
+equals("no hint", #LayoutTest.notifications, 0)
+equals("nothing remembered", LayoutTest.files["/data/hint-shown"], nil)
+equals("no config search", commandMatching("grep -rlF"), nil)
+
+finish()

--- a/layout-fix/tests/lib.luau
+++ b/layout-fix/tests/lib.luau
@@ -1,0 +1,66 @@
+--!nonstrict
+-- Helpers shared by the cases. The service keeps its state in locals that
+-- nothing can reset, so each case file gets its own luau process and a
+-- genuinely fresh service — see run-tests.sh.
+
+local T = LayoutTest
+
+Result = { passed = 0, failed = 0 }
+
+function check(name, ok, detail)
+    if ok then
+        Result.passed += 1
+        print("  ok   " .. name)
+    else
+        Result.failed += 1
+        print("  FAIL " .. name .. (detail ~= nil and ("  — " .. tostring(detail)) or ""))
+    end
+end
+
+function equals(name, actual, expected)
+    check(name, actual == expected,
+        "expected " .. tostring(expected) .. ", got " .. tostring(actual))
+end
+
+function contains(name, haystack, needle)
+    check(name, string.find(tostring(haystack), needle, 1, true) ~= nil, haystack)
+end
+
+function absent(name, haystack, needle)
+    check(name, string.find(tostring(haystack), needle, 1, true) == nil, haystack)
+end
+
+function ticks(count)
+    for _ = 1, count do
+        update()
+    end
+end
+
+-- Past the startup delay, so everything the service does on startup has run.
+function boot()
+    ticks(8)
+end
+
+function commandMatching(pattern)
+    for _, cmd in ipairs(T.commands) do
+        if string.find(cmd, pattern, 1, true) ~= nil then
+            return cmd
+        end
+    end
+    return nil
+end
+
+function notificationBodies()
+    local bodies = {}
+    for _, entry in ipairs(T.notifications) do
+        table.insert(bodies, entry.body)
+    end
+    return table.concat(bodies, " | ")
+end
+
+function finish()
+    print(string.format("%d passed, %d failed", Result.passed, Result.failed))
+    if Result.failed > 0 then
+        error("case failed", 0)
+    end
+end

--- a/layout-fix/tests/prelude.luau
+++ b/layout-fix/tests/prelude.luau
@@ -1,0 +1,93 @@
+--!nonstrict
+-- Test harness: a fake Noctalia runtime for service.luau.
+--
+-- The service talks to the host through a handful of functions (runAsync,
+-- notify, the plugin's own directories, getConfig). Stub those and it runs
+-- in a plain luau interpreter, with shell commands answered from a table.
+-- run-tests.sh concatenates this file, service.luau and one case.
+
+LayoutTest = {}
+local T = LayoutTest
+
+T.files = {}          -- path -> contents
+T.notifications = {}  -- { title, body } in order
+T.errors = {}         -- the same for notifyError
+T.commands = {}       -- every command string the service ran, in order
+T.config = {}         -- what getConfig answers
+T.logs = {}
+T.installedCommands = { pkexec = true, grep = true }
+T.failNextRun = false
+
+-- Commands are matched by substring, most recently registered first, so a
+-- case can override a general answer with a specific one.
+T.responses = {}
+T.responseOrder = {}
+
+function T.respond(pattern, stdout)
+    T.responses[pattern] = stdout
+    table.insert(T.responseOrder, 1, pattern)
+end
+
+local function answerFor(cmd)
+    for _, pattern in ipairs(T.responseOrder) do
+        if string.find(cmd, pattern, 1, true) ~= nil then
+            local answer = T.responses[pattern]
+            if type(answer) == "function" then
+                return answer(cmd)
+            end
+            return answer
+        end
+    end
+    return ""
+end
+
+noctalia = {
+    -- Synchronous on purpose: the callback runs before runAsync returns, so
+    -- a case reads the outcome on the next line instead of pumping a loop.
+    runAsync = function(cmd, callback, _timeout)
+        table.insert(T.commands, cmd)
+        if T.failNextRun then
+            T.failNextRun = false
+            return false
+        end
+        callback({ stdout = answerFor(cmd), stderr = "", exitCode = 0 })
+        return true
+    end,
+
+    getConfig = function(key)
+        return T.config[key]
+    end,
+
+    -- Keys, not sentences: a case asserting on English wording would break
+    -- the moment the wording improves.
+    tr = function(key, args)
+        if args == nil then
+            return key
+        end
+        local parts = {}
+        for name, value in pairs(args) do
+            table.insert(parts, name .. "=" .. tostring(value))
+        end
+        table.sort(parts)
+        return key .. "(" .. table.concat(parts, ",") .. ")"
+    end,
+
+    notify = function(title, body)
+        table.insert(T.notifications, { title = title, body = body })
+    end,
+    notifyError = function(title, body)
+        table.insert(T.errors, { title = title, body = body })
+    end,
+
+    fileExists = function(path) return T.files[path] ~= nil end,
+    readFile = function(path) return T.files[path] or "" end,
+    writeFile = function(path, content) T.files[path] = content end,
+
+    commandExists = function(name) return T.installedCommands[name] == true end,
+
+    pluginDir = function() return "/plugin" end,
+    pluginDataDir = function() return "/data" end,
+
+    log = function(line) table.insert(T.logs, tostring(line)) end,
+    setUpdateInterval = function() end,
+}

--- a/layout-fix/tests/run-tests.sh
+++ b/layout-fix/tests/run-tests.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# The plugin's whole test suite:
+#
+#   sh tests/run-tests.sh
+#
+# Two halves, because the plugin has two halves. The daemon's correction
+# logic is Python and is tested against the real keymap compiled from
+# libxkbcommon (tests/test-layout-fix.py). The service is Luau and runs here
+# against a fake Noctalia host: no compositor, no shell, no daemon.
+#
+# Each service case gets its own luau process — the service keeps its state
+# in locals that nothing can reset, so a fresh process is the only way to
+# start a case from a genuinely fresh plugin.
+
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(dirname "$here")
+
+total_passed=0
+total_failed=0
+failed_cases=""
+
+if command -v luau >/dev/null 2>&1; then
+    bundle=$(mktemp -t layout-fix-tests-XXXXXX.luau)
+    trap 'rm -f "$bundle"' EXIT
+
+    for case_file in "$here"/cases/*.luau; do
+        name=$(basename "$case_file" .luau)
+        echo "$name"
+        # The service goes inside a do...end block so that its top-level
+        # locals stay its own: a helper named like one of them would
+        # otherwise assign to the plugin's local instead of a global.
+        {
+            cat "$here/prelude.luau"
+            echo "do"
+            cat "$root/service.luau"
+            echo "end"
+            cat "$here/lib.luau" "$case_file"
+        } >"$bundle"
+
+        if output=$(luau "$bundle" 2>&1); then
+            :
+        else
+            failed_cases="$failed_cases $name"
+        fi
+        echo "$output" | sed 's/^/  /'
+
+        counts=$(echo "$output" | grep -E '^[0-9]+ passed, [0-9]+ failed$' | tail -1)
+        if [ -n "$counts" ]; then
+            total_passed=$((total_passed + $(echo "$counts" | cut -d' ' -f1)))
+            total_failed=$((total_failed + $(echo "$counts" | cut -d' ' -f3)))
+        else
+            failed_cases="$failed_cases $name(crashed)"
+        fi
+    done
+else
+    echo "luau is not installed (Arch: pacman -S luau) — skipping the service cases" >&2
+fi
+
+echo
+echo "correction logic"
+if python3 "$here/test-layout-fix.py" "$@"; then
+    :
+else
+    failed_cases="$failed_cases test-layout-fix.py"
+fi
+
+echo
+echo "service cases: $total_passed passed, $total_failed failed"
+if [ -n "$failed_cases" ] || [ "$total_failed" -gt 0 ]; then
+    echo "failing:$failed_cases"
+    exit 1
+fi

--- a/layout-fix/translations/en.json
+++ b/layout-fix/translations/en.json
@@ -3,6 +3,7 @@
   "err_no_input_access": "No access to the keyboard devices. Run: sudo usermod -aG input $USER — then log out and back in.",
   "err_dicts_install": "Could not install the dictionaries, see the system log",
   "notify_dicts_installed": "Dictionaries installed — corrections are now dictionary-accurate",
+  "notify_hotkey_hint": "Corrections work already. For the manual ones, bind in your compositor: spawn \"noctalia\" \"msg\" \"plugin\" \"umedbazarov/layout-fix:service\" \"all\" \"fix\" — and the same with \"undo\" and \"auto\". The README has ready-made lines.",
   "notify_dicts_missing": "For accurate corrections install: {list} (hunspell dictionaries). Set Dictionaries to \"install automatically\" in the plugin settings, or install them yourself.",
   "settings": {
     "auto": {

--- a/layout-fix/translations/ru.json
+++ b/layout-fix/translations/ru.json
@@ -3,6 +3,7 @@
   "err_no_input_access": "Нет доступа к устройствам клавиатуры. Выполни: sudo usermod -aG input $USER — и перезайди в сессию.",
   "err_dicts_install": "Не удалось установить словари, подробности в системном логе",
   "notify_dicts_installed": "Словари установлены — исправления стали точными",
+  "notify_hotkey_hint": "Исправления уже работают. Для ручных повесь в компоузиторе: spawn \"noctalia\" \"msg\" \"plugin\" \"umedbazarov/layout-fix:service\" \"all\" \"fix\" — и то же с \"undo\" и \"auto\". Готовые строки есть в README.",
   "notify_dicts_missing": "Для точных исправлений установи: {list} (словари hunspell). Либо переключи «Словари» на «устанавливать автоматически» в настройках плагина.",
   "settings": {
     "auto": {


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `umedbazarov/layout-fix`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Follow-up to the review note on #538: the `hotkey_hint` setting was declared in the manifest, documented in the README and translated, but nothing read it, so the hint it promised never appeared. Implemented rather than dropped — the plugin has no widget and no panel, so a notification is the only place it can mention that the manual `fix`, `undo` and `auto` actions exist at all.

On the first start the service looks for its own IPC string (`umedbazarov/layout-fix:service`) in `~/.config/niri`, `~/.config/hypr` and `~/.config/sway`. Finding it means the keybindings are already there and the person needs no telling; finding nothing shows one notification with the line to bind. Either way a marker file in the plugin's data directory records that the question is settled, so it is a one-time hint rather than a nag. Switching the setting off writes no marker, so switching it back on can still show the hint.

Nothing else changed: the daemon, the correction logic and the dictionaries are exactly as merged.

## External dependencies

Unchanged from #538, plus `grep` (already declared) for the one-time config search. No new dependency.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.0-beta.10 (noctalia-git 5.0.0.r5344.g74e6c2790)
- **Plugin API level:** 9

On this machine, where the keybindings are already in `config.kdl`: the service starts, finds its IPC string, shows nothing, and writes the marker — which is the intended quiet path for anyone who already bound the actions.

The rest is covered by tests, because the noisy path cannot be exercised on a machine that is already bound. The service now runs under a fake Noctalia host (`tests/prelude.luau`, one `luau` process per case so each starts from a genuinely fresh plugin — the same shape as the daemon's own suite), with cases for startup and for every way the hint can go: unbound (notification shown once, marker written, search looked for the right string), already bound (silent, marker written), already shown (silent, no search at all), switched off (silent, no marker).

`sh tests/run-tests.sh` now runs both halves of the plugin: **18 service checks**, then the correction logic against a keymap compiled from libxkbcommon — **67 word decisions, 5 whole phrases, no false positives**.

## Screenshots / Videos

Nothing to show — the plugin still has no visual surface. The hint is a single system notification whose text is in `translations/en.json` (`notify_hotkey_hint`).

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
