### PR TITLE
feat(audio-switcher): open panel from launcher

### DIFF
--- a/audio-switcher/README.md
+++ b/audio-switcher/README.md
@@ -17,7 +17,8 @@ through visible inputs. Scrolling over it changes the output volume.
 | Field | Value |
 | --- | --- |
 | ID | `blackbartblues/audio-switcher` |
-| Entries | Widget: `widget`; panel: `audio-switcher`; service: `service` |
+| Entries | Widget: `widget`; panel: `audio-switcher`; launcher provider: `launcher`; service: `service` |
+| Launcher Prefix | `/audio` |
 
 ## Requirements
 
@@ -34,6 +35,10 @@ Open the panel from a configured bar widget or run:
 ```sh
 noctalia msg panel-toggle blackbartblues/audio-switcher:audio-switcher
 ```
+
+You can also open Noctalia's launcher and search globally for **Audio Switcher**,
+or type `/audio`, then activate **Open Audio Switcher**. This provides full
+keyboard access to the panel without placing the plugin widget on a bar.
 
 The top sliders control the default output and input volume. Select **Outputs**
 or **Inputs**, then choose **Use**. For a disconnected Bluetooth output the same

--- a/audio-switcher/launcher.luau
+++ b/audio-switcher/launcher.luau
@@ -1,0 +1,33 @@
+--!nonstrict
+
+local PANEL_ID = "blackbartblues/audio-switcher:audio-switcher"
+local RESULT_ID = "open-panel"
+
+local function resultFor(query)
+  local title = noctalia.tr("launcher.open")
+  local subtitle = noctalia.tr("launcher.description")
+  local trimmed = noctalia.string.trim(tostring(query or ""))
+  local score = 0
+
+  if trimmed ~= "" then
+    score = noctalia.fuzzyScore(trimmed, title .. " " .. subtitle)
+    if score == nil then return nil end
+  end
+
+  return {
+    id = RESULT_ID,
+    title = title,
+    subtitle = subtitle,
+    glyph = "switch-horizontal",
+    score = score,
+  }
+end
+
+function onQuery(query)
+  local result = resultFor(query)
+  launcher.setResults(query, result and { result } or {})
+end
+
+function onActivate(id)
+  if id == RESULT_ID then noctalia.togglePanel(PANEL_ID) end
+end

--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,12 +1,12 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
-version = "0.5.0"
+version = "0.6.0"
 plugin_api = 15
 author = "blackbartblues"
 license = "MIT"
 icon = "switch-horizontal"
 description = "Switch audio inputs and outputs, hand off Bluetooth devices, and control them from compositor keybinds."
-tags = ["audio", "bar", "hardware", "panel", "service", "system", "utility"]
+tags = ["audio", "bar", "hardware", "launcher", "panel", "service", "system", "utility"]
 dependencies = ["pactl", "bluetoothctl", "sleep"]
 
 [[setting]]
@@ -49,6 +49,13 @@ height = 650
 placement = "attached"
 position = "top_right"
 open_near_click = true
+
+[[launcher_provider]]
+id = "launcher"
+entry = "launcher.luau"
+prefix = "audio"
+glyph = "switch-horizontal"
+include_in_global_search = true
 
 [[service]]
 id = "service"

--- a/audio-switcher/tests/launcher_test.lua
+++ b/audio-switcher/tests/launcher_test.lua
@@ -1,0 +1,46 @@
+local published = {}
+local toggled = {}
+
+noctalia = {
+  tr = function(key)
+    return ({
+      ["launcher.open"] = "Open Audio Switcher",
+      ["launcher.description"] = "Switch the default audio input (microphone) or output.",
+    })[key]
+  end,
+  string = {
+    trim = function(value) return value:match("^%s*(.-)%s*$") end,
+  },
+  fuzzyScore = function(pattern, text)
+    if text:lower():find(pattern:lower(), 1, true) then return 42 end
+    return nil
+  end,
+  togglePanel = function(id) table.insert(toggled, id) end,
+}
+
+launcher = {
+  setResults = function(query, results) published[query] = results end,
+}
+
+dofile("launcher.luau")
+
+onQuery("")
+assert(#published[""] == 1)
+assert(published[""][1].id == "open-panel")
+assert(published[""][1].score == 0)
+
+onQuery("microphone")
+assert(#published.microphone == 1)
+assert(published.microphone[1].score == 42)
+
+onQuery("wallpaper")
+assert(#published.wallpaper == 0)
+
+onActivate("ignored")
+assert(#toggled == 0)
+
+onActivate("open-panel")
+assert(#toggled == 1)
+assert(toggled[1] == "blackbartblues/audio-switcher:audio-switcher")
+
+print("audio-switcher launcher tests: ok")

--- a/audio-switcher/translations/en.json
+++ b/audio-switcher/translations/en.json
@@ -80,6 +80,10 @@
     "scan_complete": "Bluetooth scan complete.",
     "slot_saved": "Keybind number {slot} saved."
   },
+  "launcher": {
+    "description": "Switch the default audio input (microphone) or output.",
+    "open": "Open Audio Switcher"
+  },
   "panel": {
     "group_hint": "{count} selected. Choose at least two available outputs.",
     "hidden": "Hidden",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `blackbartblues/audio-switcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a launcher provider that opens the Audio Switcher panel without requiring
the bar widget. Users can find **Open Audio Switcher** in global launcher search
or type `/audio`; activating the result closes the launcher and opens the plugin
panel. The provider uses native fuzzy matching and is searchable by terms such
as audio, input, microphone, and output.

Fixes #559.

## External dependencies

No new dependencies or subprocesses. The existing plugin dependencies remain:

- `pactl` for audio discovery and control.
- `bluetoothctl` for Bluetooth handoff.
- `sleep` while waiting for newly connected Bluetooth endpoints.

The new launcher entry opens the panel in-process with
`noctalia.togglePanel()`.

## Testing

- `python3 .github/workflows/scripts/validate-plugins.py` — validated 137 manifests.
- `python3 -m unittest discover -s .github/workflows/scripts -p 'test_*.py'` — 79 tests passed with the workflow dependencies installed.
- Ran all four `audio-switcher/tests/*.lua` tests, including the new launcher provider test.
- Added the branch as a temporary path source on Hyprland, opened the launcher with `/audio`, activated the result with Enter, and verified `activePanelId` changed to `blackbartblues/audio-switcher:audio-switcher`.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `v5.0.0-beta.9-2-g791e557417ce`
- **Plugin API level:** 15

## Screenshots / Videos

Not included: this adds a single row to Noctalia's native launcher and does not
change the plugin panel or other plugin-owned visual surfaces.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
