### PR TITLE
fix(thunderbird-companion): make native host launchable

### DIFF
--- a/thunderbird-companion/bridge-version.json
+++ b/thunderbird-companion/bridge-version.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bridgeProtocol": 1,
   "extensionId": "thunderbird-companion@mdj2812.github.io",
   "nativeHostName": "dev.noctalia.thunderbird_companion"

--- a/thunderbird-companion/companion/manifest.json
+++ b/thunderbird-companion/companion/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Noctalia Thunderbird Companion",
   "description": "Publishes unread message metadata and handles Noctalia mail actions through a local native bridge.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "browser_specific_settings": {
     "gecko": {
       "id": "thunderbird-companion@mdj2812.github.io",

--- a/thunderbird-companion/native-host/host.py
+++ b/thunderbird-companion/native-host/host.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Native-messaging bridge between Thunderbird and Noctalia.
 
 Thunderbird owns stdin/stdout using the native-messaging framing protocol.

--- a/thunderbird-companion/plugin.toml
+++ b/thunderbird-companion/plugin.toml
@@ -1,6 +1,6 @@
 id = "mdj2812/thunderbird-companion"
 name = "Thunderbird Companion"
-version = "0.1.0"
+version = "0.1.1"
 plugin_api = 9
 author = "mdj2812"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `mdj2812/thunderbird-companion`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

add a python interpreter shebang directive to the native host.

the installer registers the host script as a directly executable native-messaging application. without the directive, linux cannot start the script.

bump the plugin, bridge, and extension versions to 0.1.1. this prompts existing users to reinstall the corrected bridge.

## External dependencies

None

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** recent main (via nix flake)
- **Plugin API level:** 9

automated checks:

- validated all 138 plugin manifests.
- passed all 79 workflow unit tests.
- compiled the native host with py_compile.
- installed the bridge in a temporary home directory.
- confirmed that the installed host is executable.
- started the installed host through its shebang.


## Screenshots / Videos

n/a

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
