### PR TITLE
feat(lyrics): add per-widget text alignment

### DIFF
--- a/lyrics/CHANGELOG.md
+++ b/lyrics/CHANGELOG.md
@@ -11,11 +11,37 @@
 - Existing 1.4 display settings must be reapplied for each lyrics widget after
   upgrading; source and service settings are unchanged.
 
+## 1.4.6
+
+- Fix MPRIS player detection on systems where `/bin/sh` is `dash` rather than
+  Bash, contributed by @Dioxane123 in [#404](https://github.com/noctalia-dev/community-plugins/pull/404).
+
+## 1.4.5
+
+- Add a per-widget option to hide the lyrics widget when no lyrics are
+  available, contributed by @NullSeile in [#216](https://github.com/noctalia-dev/community-plugins/pull/216).
+- Keep the widget visible in track-only mode when that option is enabled.
+
+## 1.4.4
+
+- Add ranked, selectable LRCLIB results through an attached selector panel and
+  `open_selector` shortcut.
+- Bind candidate requests and selected results to the current track so stale
+  responses cannot replace current lyrics.
+
 ## 1.4.3
 
-- Add an option to hide the fallback glyph when album artwork is unavailable.
-- Hide the glyph picker while fallback glyph display is disabled.
-- Add vertical mouse-wheel controls for switching to the next or previous track.
+- Add controls to hide the fallback glyph and its picker when it is disabled.
+- Add mouse-wheel previous/next track controls.
+- Use Noctalia's host scroll handling for the widget.
+
+## 1.4.2
+
+- Add Simplified Chinese translations.
+- Restore `splayer` in the automatic-source settings help text.
+- Add matched-provider and iTunes Search artwork fallbacks when MPRIS artwork is
+  unavailable, with content-type detection, bounded cache cleanup, and stale
+  request protection.
 
 ## 1.4.1
 

--- a/lyrics/CHANGELOG.md
+++ b/lyrics/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## 1.5.0
+
+- Move display mode, lyric layers, karaoke, animation, scrolling, sizing,
+  typography, spacing, cue text, and alignment into per-widget settings.
+- Keep lyric sources, player selection, timing, polling, and credentials shared
+  by the singleton background service.
+- Continue fetching lyrics when one widget uses track-only mode so other widget
+  instances can display synchronized lyrics.
+- Existing 1.4 display settings must be reapplied for each lyrics widget after
+  upgrading; source and service settings are unchanged.
+
+## 1.4.3
+
+- Add an option to hide the fallback glyph when album artwork is unavailable.
+- Hide the glyph picker while fallback glyph display is disabled.
+- Add vertical mouse-wheel controls for switching to the next or previous track.
+
+## 1.4.1
+
+- Add an SPlayer preset that consumes SPlayer's complete current lyric data,
+  including line and word timing, translations, romanization, background lines,
+  and duet markers.
+- Preserve SPlayer word boundaries and expose character timing for karaoke
+  highlighting without tying the preset to a specific upstream music service.
+- Pass MPRIS track IDs and media URLs through the service for stable track
+  identity.
+- Detect pseudo word-timed lines whose inferred end time is stretched to the
+  next LRC timestamp, restoring instrumental-break cues without changing real
+  multi-word timing.
+
+## 1.4.0
+
+- Add English and Simplified Chinese localization following Noctalia's global
+  language, without exposing unsupported per-plugin language overrides.
+- Add translation and romanization lyric layers with double-line display,
+  independent visibility controls, and secondary-line priorities.
+- Add unified LRCLIB, NetEase, QQ Music, Kugou, Qishui, Apple Music, Spotify,
+  Musixmatch, MPRIS, custom HTTP, and external IPC source handling.
+- Add manually supplied Spotify, Apple Music, Musixmatch, and Qishui credentials
+  without automatic browser-cookie discovery or credential logging.
+- Add lyrics timing offset and configurable MPRIS polling interval.
+- Add cover shape, custom radius, and cover size controls.
+- Add track-only mode, per-character karaoke toggle, font family/size/weight,
+  secondary font size, supported baseline styles, line spacing, and side padding.
+- Add typewriter, pulse, and blink transitions alongside existing animations.
+- Cancel stale source callbacks when changing sources on the same track, and
+  show credential settings only for their selected source.
+- Add independent primary/secondary lyric font sizes and inter-line spacing.
+- Reorganize settings into a focused common view and a collapsed advanced view
+  for credentials, source ordering, polling, marquee metrics, and fine layout.
+
+## 1.3.0
+
+- Add an option for intro/interlude characters to follow the interface font or
+  use a custom installed font family.
+- Change the default active lyric color to `on_surface`.
+- Change the default maximum visible character count to 15.
+
+## 1.2.0
+
+- Select the active MPRIS player across all available `playerctl` players.
+- Add optional player allowlist and blocklist settings with wildcard matching.
+- Send play/pause commands to the selected player instead of the global default.
+- Prevent stale lyric and artwork requests from replacing the current track.
+
+## 1.1.0
+
+- Add per-widget active and inactive lyric color controls.
+- Keep theme-aware semantic colors as defaults while allowing custom colors.
+
+## 1.0.0
+
+- Initial public release.
+- Synchronized status-bar lyric widget with karaoke highlighting and animated
+  line transitions (karaoke, cascade, wave, fade, none).
+- Long-line smooth marquee scrolling with end pauses.
+- Intro/instrumental cue text with configurable characters.
+- Lyric sources: auto, LRCLIB, public NetEase, MPRIS text, custom HTTP, and
+  external IPC push.
+- Album artwork display with circular crop and runtime cache.
+- Track-information fallback (`title + artist`) when no lyrics are available.
+- Right-click pause/resume via `playerctl` with dimmed paused state.
+- KRC dynamic-lyric parsing (plain, prefixed, and three-argument formats).

--- a/lyrics/README.md
+++ b/lyrics/README.md
@@ -1,4 +1,4 @@
-# Noctalia Lyrics 1.4.6
+# Noctalia Lyrics 1.5.0
 
 Synchronized lyrics for the Noctalia bar, with multiple MPRIS players,
 translation and romanization layers, configurable sources, karaoke highlighting,
@@ -132,15 +132,23 @@ request directory before writing any credential-bearing file.
 
 The plugin settings control source selection and fallback order, translation
 language, lyric timing offset in milliseconds, MPRIS polling interval in
-milliseconds, double-line translation and romanization, karaoke highlighting,
-marquee behavior, transitions, fonts, spacing, and side padding.
+milliseconds, player filters, and source credentials.
 
 Per-widget settings control the fallback glyph, artist visibility, paused-state
 visibility, visibility when no lyrics are available, album-cover shape and size,
-and primary, inactive, and secondary lyric colors. Credential and source-specific
-fields are shown only when their matching source is selected; source order,
-credentials, polling, marquee metrics, player filters, and fine layout controls
-are under Advanced settings.
+primary, inactive, and secondary lyric colors, display mode, lyric layers,
+karaoke behavior, scrolling, fixed lyric width, transitions, typography, spacing,
+padding, cue text, and text alignment. Credential and source-specific fields are
+shown only when their matching source is selected; source order, credentials,
+polling, marquee metrics, player filters, and fine layout controls are under
+Advanced settings.
+
+### 1.5 configuration change
+
+Display settings are now stored per lyrics widget. After upgrading from 1.4,
+open each lyrics widget's settings and reapply its preferred display, animation,
+scrolling, typography, and layout options. Source, player, timing, and credential
+settings remain plugin-wide.
 
 ## Feature test checklist
 
@@ -170,13 +178,15 @@ polling, marquee metrics, player filters, and fine padding.
 9. Karaoke: toggle `karaoke_enabled`; line transitions must continue when off.
 10. Hide layers: independently disable `show_translation` and
     `show_romanization`.
-11. Track-only: select `display_mode=track`; no lyric source request should run.
+11. Track-only: select `display_mode=track`; other lyrics widget instances still
+    fetch and display lyrics normally.
 12. Font and double-line sizing: test `font_family`, `primary_font_size`,
     `secondary_font_size`, `line_gap`, `font_weight`, and `font_style`.
 13. Animations: test karaoke, cascade, wave, fade, typewriter, pulse, blink, and
     none.
-14. Layout: test `padding_left`, `padding_right`, and `line_gap` on horizontal and
-    vertical bars.
+14. Layout: test `max_chars` and `text_alignment` with short and long lyrics,
+    plus `padding_left`, `padding_right`, and `line_gap` on horizontal and vertical
+    bars.
 15. LRCLIB selection: play a track with multiple results, briefly hover over the widget,
     and switch between synchronized and plain entries without changing tracks.
 

--- a/lyrics/lyrics.luau
+++ b/lyrics/lyrics.luau
@@ -24,6 +24,7 @@ local marqueeSpeed = tonumber(noctalia.getConfig("marquee_speed")) or 30
 local maxLines = tonumber(noctalia.getConfig("max_lines")) or 1
 local maxChars = tonumber(noctalia.getConfig("max_chars")) or 15
 local charWidth = tonumber(noctalia.getConfig("char_width")) or 9
+local textAlignment = noctalia.getConfig("text_alignment") or "left"
 local gradientOn = noctalia.getConfig("gradient")
 if gradientOn == nil then gradientOn = true end
 local animation = noctalia.getConfig("animation") or "karaoke"
@@ -429,6 +430,7 @@ local function buildLineRow(line, opts)
     key = opts.key or "line",
     gap = 0,
     align = "center",
+    justify = textAlignment == "right" and "end" or textAlignment == "center" and "center" or "start",
     minWidth = maxChars * charWidth,
     opacity = opts.opacity or 1,
   }, labels)

--- a/lyrics/lyrics_service.luau
+++ b/lyrics/lyrics_service.luau
@@ -32,7 +32,6 @@ local customUrl = noctalia.getConfig("custom_url") or ""
 local customJsonField = noctalia.getConfig("custom_json_field") or "syncedLyrics"
 local pollIntervalMs = tonumber(noctalia.getConfig("poll_interval_ms")) or 500
 local lyricsOffsetMs = tonumber(noctalia.getConfig("lyrics_offset_ms")) or 0
-local displayMode = noctalia.getConfig("display_mode") or "toggle"
 local credentialSignature = ""
 local currentTrack = nil
 local currentEmbeddedLyrics = ""
@@ -876,13 +875,7 @@ local function poll()
       noctalia.state.set("playing", playing)
 
       local cached = cache[tk]
-      if displayMode == "track" then
-        noctalia.state.set("lyrics", nil)
-        noctalia.state.set("lyrics_source_used", nil)
-        candidateCache[tk] = nil
-        selectedCandidateCache[tk] = nil
-        publishCandidates(tk)
-      elseif cached then
+      if cached then
         noctalia.state.set("lyrics", cached)
         noctalia.state.set("lyrics_source_used", "cache")
         publishCandidates(tk)
@@ -930,7 +923,6 @@ function onConfigChanged()
   local nextSources = noctalia.getConfig("lyrics_sources") or lyricsSources
   local nextPollInterval = tonumber(noctalia.getConfig("poll_interval_ms")) or 500
   local nextOffset = tonumber(noctalia.getConfig("lyrics_offset_ms")) or 0
-  local nextDisplayMode = noctalia.getConfig("display_mode") or "toggle"
   local nextCredentialSignature = table.concat({
     noctalia.getConfig("spotify_sp_dc") or "",
     noctalia.getConfig("spotify_access_token") or "",
@@ -948,7 +940,6 @@ function onConfigChanged()
   local sourceChanged = nextSource ~= lyricsSource or nextUrl ~= customUrl or nextField ~= customJsonField
     or table.concat(nextSources, "\n") ~= table.concat(lyricsSources, "\n")
     or nextCredentialSignature ~= credentialSignature
-    or nextDisplayMode ~= displayMode
   local playersChanged = table.concat(nextAllowlist, "\n") ~= table.concat(playerAllowlist, "\n")
     or table.concat(nextBlocklist, "\n") ~= table.concat(playerBlocklist, "\n")
   lyricsSource = nextSource
@@ -957,7 +948,6 @@ function onConfigChanged()
   lyricsSources = nextSources
   pollIntervalMs = math.max(100, nextPollInterval)
   lyricsOffsetMs = nextOffset
-  displayMode = nextDisplayMode
   credentialSignature = nextCredentialSignature
   playerAllowlist = nextAllowlist
   playerBlocklist = nextBlocklist
@@ -976,7 +966,7 @@ function onConfigChanged()
     selectedCandidateCache = {}
     noctalia.state.set("lyrics", nil)
     publishCandidates(trackKey(currentTrack))
-    if displayMode ~= "track" then fetchLyricsNetEase(currentTrack, currentEmbeddedLyrics) end
+    fetchLyricsNetEase(currentTrack, currentEmbeddedLyrics)
   end
 end
 

--- a/lyrics/plugin.toml
+++ b/lyrics/plugin.toml
@@ -1,6 +1,6 @@
 id = "h465855hgg/lyrics"
 name = "Lyrics"
-version = "1.4.6"
+version = "1.5.0"
 plugin_api = 3
 author = "h465855hgg"
 license = "MIT"
@@ -169,34 +169,6 @@ visible_when = { key = "lyrics_source", values = ["custom"] }
 advanced = true
 
 [[setting]]
-key = "cue_text"
-type = "string"
-label_key = "settings.cue_text.label"
-description_key = "settings.cue_text.description"
-default = "•••••"
-
-[[setting]]
-key = "cue_font_mode"
-type = "select"
-label_key = "settings.cue_font_mode.label"
-description_key = "settings.cue_font_mode.description"
-default = "follow"
-advanced = true
-options = [
-  { value = "follow", label_key = "settings.cue_font_mode.options.follow" },
-  { value = "custom", label_key = "settings.cue_font_mode.options.custom" },
-]
-
-[[setting]]
-key = "cue_font_family"
-type = "string"
-label_key = "settings.cue_font_family.label"
-description_key = "settings.cue_font_family.description"
-default = "sans-serif"
-visible_when = { key = "cue_font_mode", values = ["custom"] }
-advanced = true
-
-[[setting]]
 key = "lyrics_offset_ms"
 type = "int"
 label_key = "settings.lyrics_offset_ms.label"
@@ -213,242 +185,6 @@ description_key = "settings.poll_interval_ms.description"
 default = 500
 min = 100
 max = 5000
-advanced = true
-
-[[setting]]
-key = "display_mode"
-type = "select"
-label_key = "settings.display_mode.label"
-description_key = "settings.display_mode.description"
-default = "toggle"
-options = [
-  { value = "toggle", label_key = "settings.display_mode.options.toggle" },
-  { value = "lyrics", label_key = "settings.display_mode.options.lyrics" },
-  { value = "track", label_key = "settings.display_mode.options.track" },
-]
-
-[[setting]]
-key = "double_line"
-type = "bool"
-label_key = "settings.double_line.label"
-description_key = "settings.double_line.description"
-default = true
-
-[[setting]]
-key = "double_line_auto_fit"
-type = "bool"
-label_key = "settings.double_line_auto_fit.label"
-description_key = "settings.double_line_auto_fit.description"
-default = true
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "double_line_height_budget"
-type = "int"
-label_key = "settings.double_line_height_budget.label"
-description_key = "settings.double_line_height_budget.description"
-default = 26
-min = 18
-max = 40
-visible_when = { key = "double_line", values = ["true"] }
-advanced = true
-
-[[setting]]
-key = "show_translation"
-type = "bool"
-label_key = "settings.show_translation.label"
-description_key = "settings.show_translation.description"
-default = true
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "show_romanization"
-type = "bool"
-label_key = "settings.show_romanization.label"
-description_key = "settings.show_romanization.description"
-default = false
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "secondary_line_mode"
-type = "select"
-label_key = "settings.secondary_line_mode.label"
-description_key = "settings.secondary_line_mode.description"
-default = "translation_first"
-options = [
-  { value = "translation_first", label_key = "settings.secondary_line_mode.options.translation_first" },
-  { value = "romanization_first", label_key = "settings.secondary_line_mode.options.romanization_first" },
-  { value = "translation", label_key = "settings.secondary_line_mode.options.translation" },
-  { value = "romanization", label_key = "settings.secondary_line_mode.options.romanization" },
-]
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "karaoke_enabled"
-type = "bool"
-label_key = "settings.karaoke_enabled.label"
-description_key = "settings.karaoke_enabled.description"
-default = true
-
-[[setting]]
-key = "scroll_mode"
-type = "select"
-label_key = "settings.scroll_mode.label"
-default = "auto"
-description_key = "settings.scroll_mode.description"
-options = [
-  { value = "auto", label_key = "settings.scroll_mode.options.auto" },
-  { value = "marquee", label_key = "settings.scroll_mode.options.marquee" },
-  { value = "static", label_key = "settings.scroll_mode.options.static" },
-]
-
-[[setting]]
-key = "marquee_speed"
-type = "int"
-label_key = "settings.marquee_speed.label"
-default = 30
-min = 10
-max = 120
-description_key = "settings.marquee_speed.description"
-advanced = true
-
-[[setting]]
-key = "max_lines"
-type = "int"
-label_key = "settings.max_lines.label"
-default = 1
-min = 1
-max = 3
-description_key = "settings.max_lines.description"
-advanced = true
-
-[[setting]]
-key = "gradient"
-type = "bool"
-label_key = "settings.gradient.label"
-default = true
-description_key = "settings.gradient.description"
-
-[[setting]]
-key = "animation"
-type = "select"
-label_key = "settings.animation.label"
-default = "karaoke"
-description_key = "settings.animation.description"
-options = [
-  { value = "karaoke", label_key = "settings.animation.options.karaoke" },
-  { value = "cascade", label_key = "settings.animation.options.cascade" },
-  { value = "wave", label_key = "settings.animation.options.wave" },
-  { value = "fade", label_key = "settings.animation.options.fade" },
-  { value = "typewriter", label_key = "settings.animation.options.typewriter" },
-  { value = "pulse", label_key = "settings.animation.options.pulse" },
-  { value = "blink", label_key = "settings.animation.options.blink" },
-  { value = "none", label_key = "settings.animation.options.none" },
-]
-
-[[setting]]
-key = "max_chars"
-type = "int"
-label_key = "settings.max_chars.label"
-default = 15
-min = 8
-max = 80
-description_key = "settings.max_chars.description"
-advanced = true
-
-[[setting]]
-key = "char_width"
-type = "int"
-label_key = "settings.char_width.label"
-default = 9
-min = 4
-max = 24
-description_key = "settings.char_width.description"
-advanced = true
-
-[[setting]]
-key = "font_family"
-type = "string"
-label_key = "settings.font_family.label"
-description_key = "settings.font_family.description"
-default = ""
-
-[[setting]]
-key = "primary_font_size"
-type = "int"
-label_key = "settings.primary_font_size.label"
-description_key = "settings.primary_font_size.description"
-default = 0
-min = 0
-max = 48
-
-[[setting]]
-key = "font_weight"
-type = "select"
-label_key = "settings.font_weight.label"
-description_key = "settings.font_weight.description"
-default = "normal"
-options = [
-  { value = "thin", label_key = "settings.font_weight.options.thin" },
-  { value = "light", label_key = "settings.font_weight.options.light" },
-  { value = "normal", label_key = "settings.font_weight.options.normal" },
-  { value = "medium", label_key = "settings.font_weight.options.medium" },
-  { value = "semibold", label_key = "settings.font_weight.options.semibold" },
-  { value = "bold", label_key = "settings.font_weight.options.bold" },
-  { value = "heavy", label_key = "settings.font_weight.options.heavy" },
-]
-
-[[setting]]
-key = "secondary_font_size"
-type = "int"
-label_key = "settings.secondary_font_size.label"
-description_key = "settings.secondary_font_size.description"
-default = 10
-min = 6
-max = 36
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "font_style"
-type = "select"
-label_key = "settings.font_style.label"
-description_key = "settings.font_style.description"
-default = "normal"
-advanced = true
-options = [
-  { value = "normal", label_key = "settings.font_style.options.normal" },
-  { value = "fixed", label_key = "settings.font_style.options.fixed" },
-  { value = "ink_centered", label_key = "settings.font_style.options.ink_centered" },
-]
-
-[[setting]]
-key = "line_gap"
-type = "int"
-label_key = "settings.line_gap.label"
-description_key = "settings.line_gap.description"
-default = 2
-min = 0
-max = 24
-visible_when = { key = "double_line", values = ["true"] }
-
-[[setting]]
-key = "padding_left"
-type = "int"
-label_key = "settings.padding_left.label"
-description_key = "settings.padding_left.description"
-default = 0
-min = 0
-max = 64
-advanced = true
-
-[[setting]]
-key = "padding_right"
-type = "int"
-label_key = "settings.padding_right.label"
-description_key = "settings.padding_right.description"
-default = 0
-min = 0
-max = 64
 advanced = true
 
 # Keyboard shortcut for opening the lyrics selector panel.
@@ -506,6 +242,282 @@ entry = "lyrics.luau"
   type = "bool"
   label_key = "settings.hide_when_no_lyrics.label"
   default = false
+
+  [[widget.setting]]
+  key = "text_alignment"
+  type = "select"
+  label_key = "settings.text_alignment.label"
+  description_key = "settings.text_alignment.description"
+  default = "left"
+  options = [
+    { value = "left", label_key = "settings.text_alignment.options.left" },
+    { value = "center", label_key = "settings.text_alignment.options.center" },
+    { value = "right", label_key = "settings.text_alignment.options.right" },
+  ]
+
+  [[widget.setting]]
+  key = "display_mode"
+  type = "select"
+  label_key = "settings.display_mode.label"
+  description_key = "settings.display_mode.description"
+  default = "toggle"
+  options = [
+    { value = "toggle", label_key = "settings.display_mode.options.toggle" },
+    { value = "lyrics", label_key = "settings.display_mode.options.lyrics" },
+    { value = "track", label_key = "settings.display_mode.options.track" },
+  ]
+
+  [[widget.setting]]
+  key = "double_line"
+  type = "bool"
+  label_key = "settings.double_line.label"
+  description_key = "settings.double_line.description"
+  default = true
+
+  [[widget.setting]]
+  key = "show_translation"
+  type = "bool"
+  label_key = "settings.show_translation.label"
+  description_key = "settings.show_translation.description"
+  default = true
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "show_romanization"
+  type = "bool"
+  label_key = "settings.show_romanization.label"
+  description_key = "settings.show_romanization.description"
+  default = false
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "secondary_line_mode"
+  type = "select"
+  label_key = "settings.secondary_line_mode.label"
+  description_key = "settings.secondary_line_mode.description"
+  default = "translation_first"
+  options = [
+    { value = "translation_first", label_key = "settings.secondary_line_mode.options.translation_first" },
+    { value = "romanization_first", label_key = "settings.secondary_line_mode.options.romanization_first" },
+    { value = "translation", label_key = "settings.secondary_line_mode.options.translation" },
+    { value = "romanization", label_key = "settings.secondary_line_mode.options.romanization" },
+  ]
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "double_line_auto_fit"
+  type = "bool"
+  label_key = "settings.double_line_auto_fit.label"
+  description_key = "settings.double_line_auto_fit.description"
+  default = true
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "double_line_height_budget"
+  type = "int"
+  label_key = "settings.double_line_height_budget.label"
+  description_key = "settings.double_line_height_budget.description"
+  default = 26
+  min = 18
+  max = 40
+  visible_when = { key = "double_line", values = ["true"] }
+  advanced = true
+
+  [[widget.setting]]
+  key = "karaoke_enabled"
+  type = "bool"
+  label_key = "settings.karaoke_enabled.label"
+  description_key = "settings.karaoke_enabled.description"
+  default = true
+
+  [[widget.setting]]
+  key = "gradient"
+  type = "bool"
+  label_key = "settings.gradient.label"
+  description_key = "settings.gradient.description"
+  default = true
+
+  [[widget.setting]]
+  key = "animation"
+  type = "select"
+  label_key = "settings.animation.label"
+  description_key = "settings.animation.description"
+  default = "karaoke"
+  options = [
+    { value = "karaoke", label_key = "settings.animation.options.karaoke" },
+    { value = "cascade", label_key = "settings.animation.options.cascade" },
+    { value = "wave", label_key = "settings.animation.options.wave" },
+    { value = "fade", label_key = "settings.animation.options.fade" },
+    { value = "typewriter", label_key = "settings.animation.options.typewriter" },
+    { value = "pulse", label_key = "settings.animation.options.pulse" },
+    { value = "blink", label_key = "settings.animation.options.blink" },
+    { value = "none", label_key = "settings.animation.options.none" },
+  ]
+
+  [[widget.setting]]
+  key = "scroll_mode"
+  type = "select"
+  label_key = "settings.scroll_mode.label"
+  description_key = "settings.scroll_mode.description"
+  default = "auto"
+  options = [
+    { value = "auto", label_key = "settings.scroll_mode.options.auto" },
+    { value = "marquee", label_key = "settings.scroll_mode.options.marquee" },
+    { value = "static", label_key = "settings.scroll_mode.options.static" },
+  ]
+
+  [[widget.setting]]
+  key = "marquee_speed"
+  type = "int"
+  label_key = "settings.marquee_speed.label"
+  description_key = "settings.marquee_speed.description"
+  default = 30
+  min = 10
+  max = 120
+  advanced = true
+
+  [[widget.setting]]
+  key = "max_lines"
+  type = "int"
+  label_key = "settings.max_lines.label"
+  description_key = "settings.max_lines.description"
+  default = 1
+  min = 1
+  max = 3
+  advanced = true
+
+  [[widget.setting]]
+  key = "max_chars"
+  type = "int"
+  label_key = "settings.max_chars.label"
+  description_key = "settings.max_chars.description"
+  default = 15
+  min = 8
+  max = 80
+  advanced = true
+
+  [[widget.setting]]
+  key = "char_width"
+  type = "int"
+  label_key = "settings.char_width.label"
+  description_key = "settings.char_width.description"
+  default = 9
+  min = 4
+  max = 24
+  advanced = true
+
+  [[widget.setting]]
+  key = "font_family"
+  type = "string"
+  label_key = "settings.font_family.label"
+  description_key = "settings.font_family.description"
+  default = ""
+
+  [[widget.setting]]
+  key = "primary_font_size"
+  type = "int"
+  label_key = "settings.primary_font_size.label"
+  description_key = "settings.primary_font_size.description"
+  default = 0
+  min = 0
+  max = 48
+
+  [[widget.setting]]
+  key = "font_weight"
+  type = "select"
+  label_key = "settings.font_weight.label"
+  description_key = "settings.font_weight.description"
+  default = "normal"
+  options = [
+    { value = "thin", label_key = "settings.font_weight.options.thin" },
+    { value = "light", label_key = "settings.font_weight.options.light" },
+    { value = "normal", label_key = "settings.font_weight.options.normal" },
+    { value = "medium", label_key = "settings.font_weight.options.medium" },
+    { value = "semibold", label_key = "settings.font_weight.options.semibold" },
+    { value = "bold", label_key = "settings.font_weight.options.bold" },
+    { value = "heavy", label_key = "settings.font_weight.options.heavy" },
+  ]
+
+  [[widget.setting]]
+  key = "font_style"
+  type = "select"
+  label_key = "settings.font_style.label"
+  description_key = "settings.font_style.description"
+  default = "normal"
+  options = [
+    { value = "normal", label_key = "settings.font_style.options.normal" },
+    { value = "fixed", label_key = "settings.font_style.options.fixed" },
+    { value = "ink_centered", label_key = "settings.font_style.options.ink_centered" },
+  ]
+  advanced = true
+
+  [[widget.setting]]
+  key = "secondary_font_size"
+  type = "int"
+  label_key = "settings.secondary_font_size.label"
+  description_key = "settings.secondary_font_size.description"
+  default = 10
+  min = 6
+  max = 36
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "line_gap"
+  type = "int"
+  label_key = "settings.line_gap.label"
+  description_key = "settings.line_gap.description"
+  default = 2
+  min = 0
+  max = 24
+  visible_when = { key = "double_line", values = ["true"] }
+
+  [[widget.setting]]
+  key = "padding_left"
+  type = "int"
+  label_key = "settings.padding_left.label"
+  description_key = "settings.padding_left.description"
+  default = 0
+  min = 0
+  max = 64
+  advanced = true
+
+  [[widget.setting]]
+  key = "padding_right"
+  type = "int"
+  label_key = "settings.padding_right.label"
+  description_key = "settings.padding_right.description"
+  default = 0
+  min = 0
+  max = 64
+  advanced = true
+
+  [[widget.setting]]
+  key = "cue_text"
+  type = "string"
+  label_key = "settings.cue_text.label"
+  description_key = "settings.cue_text.description"
+  default = "•••••"
+
+  [[widget.setting]]
+  key = "cue_font_mode"
+  type = "select"
+  label_key = "settings.cue_font_mode.label"
+  description_key = "settings.cue_font_mode.description"
+  default = "follow"
+  options = [
+    { value = "follow", label_key = "settings.cue_font_mode.options.follow" },
+    { value = "custom", label_key = "settings.cue_font_mode.options.custom" },
+  ]
+  advanced = true
+
+  [[widget.setting]]
+  key = "cue_font_family"
+  type = "string"
+  label_key = "settings.cue_font_family.label"
+  description_key = "settings.cue_font_family.description"
+  default = "sans-serif"
+  visible_when = { key = "cue_font_mode", values = ["custom"] }
+  advanced = true
 
   [[widget.setting]]
   key = "show_cover"

--- a/lyrics/translations/en.json
+++ b/lyrics/translations/en.json
@@ -195,7 +195,7 @@
       "label": "Marquee speed"
     },
     "max_chars": {
-      "description": "Visible width before a long lyric line scrolls (marquee).",
+      "description": "Fixed lyric width before a long line scrolls (marquee).",
       "label": "Max characters"
     },
     "max_lines": {
@@ -263,6 +263,15 @@
         "romanization_first": "Romanization, then translation",
         "translation": "Translation only",
         "translation_first": "Translation, then romanization"
+      }
+    },
+    "text_alignment": {
+      "description": "Align lyrics and track information within the fixed lyric width.",
+      "label": "Text alignment",
+      "options": {
+        "center": "Center",
+        "left": "Left",
+        "right": "Right"
       }
     },
     "show_artist": {

--- a/lyrics/translations/zh-Hans.json
+++ b/lyrics/translations/zh-Hans.json
@@ -195,7 +195,7 @@
       "label": "滚动速度"
     },
     "max_chars": {
-      "description": "长歌词开始滚动前显示的最大字符数。",
+      "description": "歌词的固定显示宽度；超出宽度的长歌词会滚动。",
       "label": "最大字符数"
     },
     "max_lines": {
@@ -263,6 +263,15 @@
         "romanization_first": "罗马音优先，其次翻译",
         "translation": "仅翻译",
         "translation_first": "翻译优先，其次罗马音"
+      }
+    },
+    "text_alignment": {
+      "description": "在固定歌词宽度内对齐歌词和歌曲信息。",
+      "label": "文字对齐",
+      "options": {
+        "center": "居中",
+        "left": "左对齐",
+        "right": "右对齐"
       }
     },
     "show_artist": {


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `h465855hgg/lyrics`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds left, center, and right lyric alignment within the configured lyric viewport. Display and layout preferences now belong to each lyrics widget instance, while the background service retains shared source, player, timing, polling, and credential settings.

`display_mode=track` on one widget no longer prevents the shared service from fetching lyrics for other widget instances.

Closes #554

## External dependencies

- `playerctl`: reads and controls MPRIS players.
- `python3`: runs lyric-source adapters and parsers.
- `cp`: preserves local MPRIS artwork in the plugin cache.
- `chmod`: secures temporary credential request files.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `v5.0.0-beta.9-4-g7fd9f7bfa960`
- **Plugin API level:** 3

Tested per-widget left, center, and right alignment with the lyrics widget on Niri. Validation completed:

- `noctalia plugins lint lyrics`
- `python3 -m unittest test_lyric_sources.py` (11 tests)
- `python3 -m py_compile lyric_sources.py krc_decode.py lrclib_lyric.py`
- `sh scripts/setup-deps.sh --check`
- TOML, JSON, and whitespace checks

## Screenshots / Videos

The plugin screenshots remain under `lyrics/screenshots/`; this update changes alignment behavior and settings placement without replacing the existing visual surface.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
