### PR TITLE
fix(thunderbird-companion): add shebang to native host (v0.1.1)

### DIFF
--- a/thunderbird-companion/native-host/host.py
+++ b/thunderbird-companion/native-host/host.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Native-messaging bridge between Thunderbird and Noctalia.
 
 Thunderbird owns stdin/stdout using the native-messaging framing protocol.

--- a/thunderbird-companion/plugin.toml
+++ b/thunderbird-companion/plugin.toml
@@ -1,6 +1,6 @@
 id = "mdj2812/thunderbird-companion"
 name = "Thunderbird Companion"
-version = "0.1.0"
+version = "0.1.1"
 plugin_api = 9
 author = "mdj2812"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `mdj2812/thunderbird-companion`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes #561: adds `#!/usr/bin/env python3` to the bundled native-messaging host so Linux can exec the installed `host.py` when Thunderbird starts the bridge. Without a shebang, direct exec fails with `ENOEXEC` and the panel stays offline indefinitely.

Bumps plugin version to `0.1.1`. Users who already ran **Set up bridge** on v0.1.0 must run it again so the fixed host is copied into `~/.local/share/noctalia-thunderbird-companion/`. No Thunderbird extension reinstall is required.

## External dependencies

Unchanged from v0.1.0:

- `thunderbird` — mailbox and MailExtension APIs.
- `python3` — builds the bundled extension, runs the native-messaging host, and installs the bridge.
- `xdg-open` — opens the generated extension package directory on request.

## Testing

Awaiting confirmation from the reporter in #561 before marking ready for review.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor:
- **Noctalia version tested against:** (pending reporter)
- **Plugin API level:** 9

**Reporter test plan** (Arch Linux, native Thunderbird, same environment as #561):

1. Install from this PR branch (`git fetch origin pull/575/head:pr-thunderbird-shebang && git checkout pr-thunderbird-shebang`), then `noctalia msg plugins source add thunderbird-test path "$(pwd)"` and refresh, or symlink `thunderbird-companion/` into `~/.local/share/noctalia/plugins/`.
2. Confirm plugin version **0.1.1**.
3. Open the panel and run **Set up bridge** again.
4. Verify shebang: `head -1 ~/.local/share/noctalia-thunderbird-companion/host.py` → `#!/usr/bin/env python3`
5. Verify exec: `~/.local/share/noctalia-thunderbird-companion/host.py` waits on stdin (no ENOEXEC / shell parse errors).
6. With Thunderbird running and the extension installed, confirm the panel shows connected and unread mail.

## Screenshots / Videos

None yet — pending reporter validation.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.


Made with [Cursor](https://cursor.com)