### PR TITLE
feat: add support for dual GPUs

### DIFF
--- a/systempulse/README.md
+++ b/systempulse/README.md
@@ -1,10 +1,11 @@
 # SystemPulse
 
-A bar widget that displays live CPU and RAM usage, with a detailed panel showing CPU, RAM, Disk, Network, and GPU monitoring. Clicking the widget toggles the panel.
+A bar widget that displays live CPU and RAM usage, with a detailed panel showing CPU, RAM, Disk, Network, and GPU monitoring. Clicking the widget toggles the panel.This plugin is meant to use via IPC only. That's why I did not work on the widget that much.
 
 ## Requirements
 
 Requires `Nvtop` for detailed GPU telemetry (utilization, temperature, clock speeds, fan, power, VRAM, encoder/decoder). Without it, GPU monitoring falls back to basic values from `systemStats()`.
+
 ## Plugin
 
 | Field | Value |
@@ -23,8 +24,9 @@ Add the `sysmon` widget from the Add-widget picker. Clicking the widget opens th
 | `show_cpu` | `bool` | `true` | Display CPU usage percentage in the bar. |
 | `show_ram` | `bool` | `true` | Display RAM usage percentage in the bar. |
 | `show_gpu` | `bool` | `false` | Display GPU usage percentage in the bar. |
-| `show_disk` | `bool` | `false` | Display disk usage percentage in the bar. |
-| `show_network` | `bool` | `false` | Display network usage in the bar. |
+| `show_disk` | `bool` | `false` | Display Disk usage percentage in the bar. |
+| `show_network` | `bool` | `false` | Display Network usage in the bar. |
+| `panel_background_opacity` | `double` | `1.0` | Panel background translucency (0 transparent → 1 opaque); content stays opaque. Uses `fill = "surface/<alpha>"` so graphs, labels and cards remain fully opaque. Edited under Settings → Plugins (gear icon). |
 
 ## IPC
 

--- a/systempulse/monitors/gpu1.luau
+++ b/systempulse/monitors/gpu1.luau
@@ -1,6 +1,7 @@
 --!nonstrict
--- GPU 0 monitor detail view using nvtop for direct GPU data. On dual-GPU
--- systems this is the integrated GPU; single-GPU systems use this file as-is.
+-- Second GPU monitor detail view (GPU 1, the dedicated GPU) using nvtop.
+-- Only shown when nvtop reports more than one GPU; the single-GPU case is
+-- handled by gpu.luau.
 
 local MAX_SAMPLES = 60
 
@@ -18,12 +19,35 @@ local vramTotalBytes = nil
 local encodePercent = nil
 local decodePercent = nil
 local hasNvtop = false
+local hasSecondGpu = false
 local refresh = nil
 local M = {}
+
+-- -- TEMP TEST: fake second GPU (remove after testing)
+-- hasNvtop = true
+-- local FAKE_GPU = {
+--   device_name = "AMD Radeon RX 7900 XTX (FAKE)",
+--   gpu_util = "42%",
+--   temp = "55C",
+--   fan_speed = "0%",
+--   power_draw = "12W",
+--   gpu_clock = "2200MHz",
+--   mem_clock = "1800MHz",
+--   mem_used = "2147483648",
+--   mem_total = "34359738368",
+--   encode = "3%",
+--   decode = "7%",
+-- }
 
 function M.attach(fn)
   refresh = fn
   hasNvtop = noctalia.commandExists("nvtop")
+end
+
+-- True once nvtop reported a second GPU; the panel uses this to decide
+-- whether to show the "GPU 1" sidebar card.
+function M.hasSecondGpu()
+  return hasSecondGpu
 end
 
 function M.getPreview()
@@ -57,8 +81,6 @@ local function parseBytes(s)
   return tonumber(s)
 end
 
-local pendingNvtop = nil
-
 -- Orders GPUs so the integrated GPU comes first (GPU 0 = iGPU, GPU 1 = dGPU).
 -- iGPU signals are checked first because some iGPUs are branded "Arc Graphics".
 local function gpuOrderScore(name)
@@ -78,20 +100,22 @@ local function sortGpusIntegratedFirst(data)
   end)
 end
 
+local pendingNvtop = nil
+
 local function onNvtopResult(result)
   if result == nil or result.exitCode ~= 0 then return end
   local stdout = result.stdout
   if stdout == nil or stdout == "" then return end
   local ok, data = pcall(noctalia.json.decode, stdout)
-  if not ok or type(data) ~= "table" or data[1] == nil then return end
+  if not ok or type(data) ~= "table" or data[2] == nil then return end
   sortGpusIntegratedFirst(data)
-  pendingNvtop = data[1]
+  pendingNvtop = data[2]
 end
 
 function M.tick()
-  if hasNvtop then
-    noctalia.runAsync("nvtop -s", onNvtopResult, 5000)
-  end
+  if not hasNvtop then return end
+  -- TEMP TEST: inject fake data instead of calling nvtop (remove after testing)
+  -- pendingNvtop = FAKE_GPU
 
   if pendingNvtop ~= nil then
     local gpu = pendingNvtop
@@ -107,15 +131,12 @@ function M.tick()
     vramTotalBytes = parseBytes(gpu.mem_total)
     encodePercent = parsePercent(gpu.encode)
     decodePercent = parsePercent(gpu.decode)
-  else
-    local s = noctalia.systemStats()
-    if s ~= nil and s.gpu ~= nil then
-      usagePercent = s.gpu.usagePercent or usagePercent
-      tempC = s.gpu.tempC or tempC
-      vramUsedBytes = s.gpu.vramUsedBytes or vramUsedBytes
-      vramTotalBytes = s.gpu.vramTotalBytes or vramTotalBytes
-    end
+    hasSecondGpu = true
   end
+
+  -- No history before the second GPU is confirmed, so graphs only contain
+  -- real samples.
+  if not hasSecondGpu then return end
 
   table.insert(history, usagePercent / 100)
   local vramPct = (vramUsedBytes ~= nil and vramTotalBytes ~= nil and vramTotalBytes > 0) and (vramUsedBytes / vramTotalBytes) or 0

--- a/systempulse/panel.luau
+++ b/systempulse/panel.luau
@@ -8,6 +8,7 @@ local ram = require("./monitors/ram.luau")
 local disk = require("./monitors/disk.luau")
 local network = require("./monitors/network.luau")
 local gpu = require("./monitors/gpu.luau")
+local gpu1 = require("./monitors/gpu1.luau")
 local system = require("./monitors/system.luau")
 
 local monitors = {
@@ -16,6 +17,7 @@ local monitors = {
   disk = disk,
   network = network,
   gpu = gpu,
+  gpu1 = gpu1,
   system = system,
 }
 
@@ -31,6 +33,7 @@ local deviceColors = {
   disk = "secondary",
   network = "error",
   gpu = "secondary",
+  gpu1 = "secondary",
   system = "on_surface_variant",
 }
 
@@ -153,17 +156,31 @@ local function buildSidebar()
     table.insert(appItems, appItem(proc))
   end
 
-  -- Fixed-width column: device cards first, then the app list underneath.
-  return ui.column({ width = 180, gap = 6, fill = "surface_variant/0.4", radius = 10, padding = 6 }, {
-    -- ui.label({ text = "Devices", fontSize = 14, fontWeight = "bold" }),
+  -- Dual-GPU systems get separate GPU 0 / GPU 1 cards; single-GPU systems
+  -- keep the plain GPU card (backed by gpu.luau either way).
+  local dualGpu = gpu1.hasSecondGpu and gpu1.hasSecondGpu() or false
+  local gpuItems = {
+    sidebarItem("gpu", dualGpu and "GPU 0" or "GPU", gpu.getSubtitle and gpu.getSubtitle() or "", gpuVal, gpu),
+  }
+  if dualGpu then
+    local gpu1Val = gpu1.getValue and gpu1.getValue() or "—"
+    table.insert(gpuItems, sidebarItem("gpu1", "GPU 1", gpu1.getSubtitle and gpu1.getSubtitle() or "", gpu1Val, gpu1))
+  end
+
+  local items = {
     sidebarItem("cpu", "CPU", cpu.getSubtitle and cpu.getSubtitle() or "", cpuVal, cpu),
     sidebarItem("ram", "Memory", ram.getSubtitle and ram.getSubtitle() or "", ramVal, ram),
     sidebarItem("disk", "Disk", disk.getSubtitle and disk.getSubtitle() or "", diskVal, disk),
     sidebarItem("network", "Network", network.getSubtitle and network.getSubtitle() or "", netVal, network),
-    sidebarItem("gpu", "GPU", gpu.getSubtitle and gpu.getSubtitle() or "", gpuVal, gpu),
-    sidebarItem("system", "System", "System Info", "", system),
-    ui.column({ gap = 4 }, appItems),
-  })
+  }
+  for _, item in ipairs(gpuItems) do
+    table.insert(items, item)
+  end
+  table.insert(items, sidebarItem("system", "System", "System Info", "", system))
+  table.insert(items, ui.column({ gap = 4 }, appItems))
+
+  -- Fixed-width column: device cards first, then the app list underneath.
+  return ui.column({ width = 180, gap = 6, fill = "surface_variant/0.4", radius = 10, padding = 5 }, items)
 end
 
 -- Main content area: sidebar on the left, the active device's detail view

--- a/systempulse/plugin.toml
+++ b/systempulse/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "arrifat346afs/systempulse"
 name = "SystemPulse"
-version = "1.1.0"
+version = "1.1.2"
 plugin_api = 22
 author = "arrifat346afs "
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `arrifat346afs/systempulse`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

## External dependencies
Nvtop
<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos
<img width="1417" height="964" alt="image" src="https://github.com/user-attachments/assets/5c325f81-2979-463c-9e1b-5e41fb1abeb7" />

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
