### PR TITLE
Sing-box status

### DIFF
--- a/sing-box-status/plugin.toml
+++ b/sing-box-status/plugin.toml
@@ -1,0 +1,14 @@
+id = "dpvpro/sing-box-status"
+name = "Sing-Box Status"
+version = "1.1.0"
+plugin_api = 3
+author = "dpvpro"
+license = "MIT"
+icon = "link"
+description = "Shows status running sing-box."
+min_noctalia = "5.0.0"
+tags = ["sing-box", "proxy", "network"]
+
+[[widget]]
+id = "status"
+entry = "sing-box.luau"

--- a/sing-box-status/sing-box.luau
+++ b/sing-box-status/sing-box.luau
@@ -1,0 +1,28 @@
+local running = false
+
+local function render()
+    if running then
+        barWidget.setGlyph("link-plus")
+        barWidget.setGlyphColor("tertiary")
+        barWidget.setTooltip("Sing-box is running")
+    else
+        barWidget.setGlyph("link")
+        barWidget.setGlyphColor("on_surface")
+        barWidget.setTooltip("Sing-box is not running")
+    end
+end
+
+noctalia.setUpdateInterval(1000)
+
+local function check()
+    noctalia.runAsync("pgrep sing-box >/dev/null 2>&1", function(result)
+        running = result.exitCode == 0
+        render()
+    end)
+end
+
+function update()
+    check()
+end
+
+check()


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `dpvpro/sing-box-status`
<!-- Check exactly one plugin type. -->
- [x] New plugin
- [ ] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Shows status running sing-box.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: MangoWM
- **Noctalia version tested against:** 5.0.0.10
- **Plugin API level:** 3

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [ ] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [ ] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [ ] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
