### PR TITLE
feat(git companion) : add gitea provider

### DIFF
--- a/git_companion/README.md
+++ b/git_companion/README.md
@@ -2,7 +2,8 @@
 
 Monitor your git repositories from the Noctalia bar. See your open pull requests
 and issues at a glance, and jump to any of them on the web without leaving your
-desktop. Works with **GitHub** (via `gh`) and **GitLab** (via `glab`).
+desktop. Works with **GitHub** (via `gh`), **GitLab** (via `glab`) and
+**Gitea** (via `tea`).
 
 ## Plugin
 
@@ -17,10 +18,14 @@ Install the CLI for the platform you want to monitor and sign in once:
 
 - `gh` — the [GitHub CLI](https://cli.github.com/), for `platform = github`. Run `gh auth login`.
 - `glab` — the [GitLab CLI](https://glab.readthedocs.io/), for `platform = gitlab`. Run `glab auth login`.
+- `tea` — the [Gitea CLI](https://gitea.com/gitea/tea), for `platform = gitea`. Run
+  `tea login add --url https://git.example.com`.
+- `git` — only for `platform = gitea`; see **Gitea working directory** below.
 - `xdg-open` — opens a PR/MR or issue in your default browser when you click it in the panel.
 
-You only need the CLI matching your chosen `platform`; both are listed so the
-requirement shows up regardless of which one you pick.
+You only need the CLI matching your chosen `platform`; all three are listed so the
+requirement shows up regardless of which one you pick. No token is ever stored by
+the plugin — each CLI keeps its own credentials.
 
 ## Usage
 
@@ -41,11 +46,12 @@ Then up to three tabs, each listing items by title and reference:
 
 - **Pull Requests / Merge Requests** — the ones you authored.
 - **Issues** — the ones assigned to you.
-- **Code Review** — open, unmerged PR/MRs waiting on your review.
+- **Code Review** — open, unmerged PR/MRs waiting on your review. **Not available
+  on Gitea**, where the tab is hidden; `tea` has no review-requested filter.
 
 On GitLab a check glyph marks a merge request whose `detailed_merge_status` is
-`mergeable`. Click an item to open it on the web (GitHub or GitLab) in your
-browser; the panel closes as it opens.
+`mergeable`. Click an item to open it on the web in your browser; the panel closes
+as it opens.
 
 Each tab can be hidden with its `show_*` setting, and a hidden tab is not
 fetched at all. Hide every tab and the panel says so instead of showing an empty
@@ -61,14 +67,15 @@ which **GitHub does not** — see Notes.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `platform` | `select` | `github` | `github` (uses `gh`) or `gitlab` (uses `glab`). |
-| `repo` | `string` | `""` | Scope to one repo: `owner/repo` (GitHub) or the project path (GitLab). Leave empty to use the group/owner. |
-| `group` | `string` | `""` | Filter by group (GitLab) or owner (GitHub). Leave empty to use `repo`. |
+| `platform` | `select` | `github` | `github` (uses `gh`), `gitlab` (uses `glab`) or `gitea` (uses `tea`). |
+| `gitea_login` | `string` | `""` | Gitea only: which `tea` login to use, as listed by `tea login list`. Empty uses tea's default login. |
+| `repo` | `string` | `""` | Scope to one repo: `owner/repo` (GitHub, Gitea) or the project path (GitLab). Leave empty to use the group/owner. |
+| `group` | `string` | `""` | Filter by group (GitLab) or owner (GitHub, Gitea). Leave empty to use `repo`. |
 | `refresh_interval` | `int` | `60` | Seconds between automatic refreshes (minimum 10). |
 | `bar_display_mode` | `select` | `both` | What the bar shows next to the glyph: `none`, `prs` (PRs/MRs only), `issues` (Issues only), or `both`. |
 | `show_prs` | `bool` | `true` | Show the PRs/MRs tab. |
 | `show_issues` | `bool` | `true` | Show the Issues tab. |
-| `show_reviews` | `bool` | `true` | Show the Code Review tab. |
+| `show_reviews` | `bool` | `true` | Show the Code Review tab. Ignored on Gitea, which cannot fill it. |
 | `count_reviews_with_prs` | `bool` | `false` | Add the review count to the PR/MR number in the bar. Hidden while `show_reviews` is off. |
 | `branch_badge_primary` | `string_list` | `["develop"]` | Branch patterns badged in the theme's primary accent. |
 | `branch_badge_secondary` | `string_list` | `["release/*"]` | Branch patterns badged in the secondary accent. |
@@ -88,8 +95,22 @@ GitHub — see Notes.
 
 On GitHub the widget lists pull requests **authored by you** and issues **assigned
 to you**. On GitLab it lists merge requests and issues **authored by you** — both
-GitLab lists are filtered by author, not by assignee. The Code Review tab is
-filtered by **requested reviewer** on both platforms, and includes drafts.
+GitLab lists are filtered by author, not by assignee. On Gitea both lists are
+**authored by you** too: its cross-repository search rejects an assignee filter
+unless a single `repo` is set. The Code Review tab is filtered by **requested
+reviewer** on GitHub and GitLab, and includes drafts; Gitea has no such filter.
+
+### Gitea working directory
+
+`tea` resolves its context by running `git rev-parse --show-toplevel` before it reads
+`--login` or `--repo`, so every one of its repo-scoped commands fails when the working
+directory is not a git repository — and a background service has no such directory. Any
+repository satisfies it, so on the first Gitea refresh the plugin runs `git init` once in
+an empty `tea-ctx` folder inside its own data directory and runs `tea` from there. Nothing
+is committed to it and it is never touched again.
+
+Other Gitea-compatible forges (Forgejo, Codeberg) expose the same v1 API and should work
+through `tea` as well, but they are not tested here.
 
 `show_reviews` is the master switch for the Code Review feature: turned off, the
 tab disappears, nothing is fetched for it, and `count_reviews_with_prs` has no
@@ -108,26 +129,37 @@ fetch completes.
 
 ## Notes
 
-- **Network:** each refresh calls the GitHub or GitLab API through the installed
-  CLI (`gh search prs/issues` or `glab mr/issue list`), scoped by your `repo` or
-  `group` setting. One call per visible tab, so hiding a tab removes its request.
-  The Code Review tab uses `glab mr list --reviewer=@me` or
-  `gh search prs --review-requested=@me`, which **both** platforms support —
-  unlike the branch badge below.
+- **Network:** each refresh calls the forge API through the installed CLI
+  (`gh search prs/issues`, `glab mr/issue list`, or `tea issues list --kind
+  pulls/issues`), scoped by your `repo` or `group` setting. One call per visible
+  tab, so hiding a tab removes its request. The Code Review tab uses
+  `glab mr list --reviewer=@me` or `gh search prs --review-requested=@me`; `tea`
+  offers no equivalent, so the tab is hidden on Gitea. Your avatar is then
+  downloaded from the forge; on Gitea it comes from the instance's public
+  `<instance>/<user>.png` route, so it needs no token.
 - **Branch badges are not available on GitHub.** The chip needs each item's
   target branch, which the provider has to report. `glab` returns it with every
   merge request. `gh search prs` has no base-branch field at all, and it is the
   only GitHub call that works across a whole owner, so pull requests fetched
-  from GitHub render without a chip. This is a per-provider capability rather
-  than a setting: the `branch_badge_*` lists stay configured and apply to any
-  provider that does report a target branch.
-- **Processes:** the service spawns `gh` or `glab` for fetches; the panel spawns
-  `xdg-open` (non-blocking) when you click an item.
+  from GitHub render without a chip. `tea` is in the same position: none of the
+  fields it can print for a search carries a base branch, so Gitea items have no
+  chip either. This is a per-provider capability rather than a setting: the
+  `branch_badge_*` lists stay configured and apply to any provider that does
+  report a target branch.
+- **Processes:** the service spawns `gh`, `glab` or `tea` for fetches, plus a
+  one-time `git init` on Gitea; the panel spawns `xdg-open` (non-blocking) when
+  you click an item.
 - **Filesystem:** the service downloads your profile picture to the plugin's own
   data directory, at `~/.local/state/noctalia/plugins/data/tphilippot/git_companion/avatar`
   (it follows `NOCTALIA_STATE_HOME` if you set it), so the panel can show it next
   to your username. It is re-downloaded only when the avatar URL changes, and the
-  file persists until you delete it. Nothing else is written: the PR/MR and issue
-  lists are in-memory only and are cleared when the plugin stops.
+  file persists until you delete it. On Gitea the same directory also holds the
+  empty `tea-ctx` repository described above. Nothing else is written: the PR/MR
+  and issue lists are in-memory only and are cleared when the plugin stops.
 - **GitLab scope:** GitLab requires a `repo` or `group` scope in settings; the
-  service shows an error notification if neither is set.
+  service shows an error notification if neither is set. GitHub and Gitea both
+  search across all your repositories when no scope is set.
+- **Failed fetches:** when a CLI call fails, the panel keeps showing the items it
+  last fetched and reports the failure in a strip above them, quoting the CLI's
+  own message — so a mistyped `repo` reads as `Error: not found` rather than a
+  silently empty tab.

--- a/git_companion/panel.luau
+++ b/git_companion/panel.luau
@@ -1,7 +1,7 @@
 --!nonstrict
 -- Git Companion panel — a mini-docker-style dashboard for your PRs and issues.
 -- Tabs switch between pull requests and issues; clicking an item opens it on
--- the web (GitHub/GitLab) via xdg-open. Layout mirrors mini-docker's panel:
+-- the web (GitHub/GitLab/Gitea) via xdg-open. Layout mirrors mini-docker's panel:
 -- tab buttons with selected/ghost variants, an outline button-card list, and
 -- a centered empty state with a large glyph.
 
@@ -17,6 +17,7 @@ local snapshot = {
   username = noctalia.state.get("username") or "",
   bio = noctalia.state.get("bio") or "",
   avatarPath = noctalia.state.get("avatar_path") or "",
+  errorDetail = noctalia.state.get("error_detail") or "",
 }
 local currentTab = "prs" -- a TABS id
 local hoveredKey = nil
@@ -45,9 +46,15 @@ local TABS = {
 }
 
 local function visibleTabs()
+  -- tea has no review-requested filter, so Gitea can never fill that tab and
+  -- it is dropped rather than shown permanently empty (see service.luau).
+  local platform = noctalia.getConfig("platform")
   local shown = {}
   for _, tab in ipairs(TABS) do
-    if noctalia.getConfig(tab.setting) ~= false then table.insert(shown, tab) end
+    local supported = not (platform == "gitea" and tab.id == "reviews")
+    if supported and noctalia.getConfig(tab.setting) ~= false then
+      table.insert(shown, tab)
+    end
   end
   return shown
 end
@@ -121,16 +128,35 @@ local function statusBox(glyph, message)
   })
 end
 
+local PLATFORM_BIN = {
+  github = "gh",
+  gitlab = "glab",
+  gitea = "tea",
+}
+local PLATFORM_GLYPH = {
+  github = "brand-github",
+  gitlab = "brand-gitlab",
+  gitea = "brand-git", -- Tabler ships no Gitea brand glyph
+}
+
+local function platformGlyph()
+  return PLATFORM_GLYPH[noctalia.getConfig("platform")] or "brand-git"
+end
+
 local function statusInfo()
-  local platform = noctalia.getConfig("platform")
-  local bin = platform == "gitlab" and "glab" or "gh"
+  local bin = PLATFORM_BIN[noctalia.getConfig("platform")] or "gh"
   local status = snapshot.status
   if status == "bin_missing" then
-    return platform == "gitlab" and "brand-gitlab" or "brand-github",
-           tr("bin_missing", { bin = bin })
+    return platformGlyph(), tr("bin_missing", { bin = bin })
   end
   if status == "gitlab_scope_missing" then
     return "alert-triangle", tr("gitlab_scope_missing")
+  end
+  if status == "gitea_ctx_failed" then
+    return "alert-triangle", tr("gitea_ctx_failed")
+  end
+  if status == "gitea_login_missing" then
+    return "alert-triangle", tr("gitea_login_missing")
   end
   return "alert-triangle", tr("no_items")
 end
@@ -261,6 +287,20 @@ local TAB_ACTIONS = {
   reviews = "onTabReviews",
 }
 
+-- A failed fetch is reported next to the list rather than replacing it, so the
+-- items already on screen stay readable while the CLI's own message
+-- ("Error: not found" for a mistyped repo) explains what went wrong.
+local function errorBanner()
+  return ui.row({ gap = 6, align = "center", padding = 8, radius = 8, fill = "surface_variant" }, {
+    ui.glyph({ name = "alert-triangle", size = 16, color = "error" }),
+    ui.label({
+      text = tr("fetch_failed", { bin = PLATFORM_BIN[noctalia.getConfig("platform")] or "gh" })
+        .. " " .. snapshot.errorDetail,
+      fontSize = 11, color = "on_surface_variant", maxLines = 2, flexGrow = 1,
+    }),
+  })
+end
+
 local function tabButton(label, tab, callback)
   return ui.button({
     text = label,
@@ -301,13 +341,14 @@ render = function()
       table.insert(strip, tabButton(tabLabel(tab), tab.id, TAB_ACTIONS[tab.id]))
     end
     table.insert(body, ui.row({ gap = 4, align = "center" }, strip))
+    if snapshot.errorDetail ~= "" then table.insert(body, errorBanner()) end
     table.insert(body, ui.scroll({ flexGrow = 1, gap = 8, align = "stretch", justify = "start" }, itemList()))
   end
 
   panel.render(ui.column({ flexGrow = 1, gap = 10, align = "stretch" }, {
     -- Header
     ui.row({ align = "center", gap = 8 }, {
-      ui.glyph({ name = platform == "gitlab" and "brand-gitlab" or "brand-github", size = 24, color = "primary" }),
+      ui.glyph({ name = platformGlyph(), size = 24, color = "primary" }),
       ui.label({ text = tr("title"), fontSize = 18, fontWeight = "bold", flexGrow = 1 }),
       ui.button({ glyph = "refresh", variant = "ghost", onClick = "onRefreshClicked" }),
       ui.button({ glyph = "close", onClick = "onCloseClicked" }),
@@ -338,6 +379,7 @@ noctalia.state.watch("status", function(value) snapshot.status = value or "ok"; 
 noctalia.state.watch("username", function(value) snapshot.username = value or ""; render() end)
 noctalia.state.watch("bio", function(value) snapshot.bio = value or ""; render() end)
 noctalia.state.watch("avatar_path", function(value) snapshot.avatarPath = value or ""; render() end)
+noctalia.state.watch("error_detail", function(value) snapshot.errorDetail = value or ""; render() end)
 
 -- Periodically re-render to pick up setting changes (like platform)
 noctalia.setUpdateInterval(5000)

--- a/git_companion/plugin.toml
+++ b/git_companion/plugin.toml
@@ -1,13 +1,13 @@
 id = "tphilippot/git_companion"
 name = "Git Companion"
-version = "1.1.0"
+version = "1.2.0"
 plugin_api = 23
 author = "thomas-philippot"
 license = "MIT"
 icon = "brand-git"
 description = "Monitor your git repositories from the Noctalia bar. See your current PRs/MRs and issues at a glance."
 tags = ["development", "bar", "panel", "service", "productivity"]
-dependencies = ["gh", "glab", "xdg-open"]
+dependencies = ["gh", "glab", "tea", "git", "xdg-open"]
 
 # ── Plugin-level settings ────────────────────────────────────
 
@@ -19,8 +19,17 @@ description_key = "settings.platform.description"
 default = "github"
 options = [
   { value = "github", label_key = "settings.platform.options.github" },
-  { value = "gitlab", label_key = "settings.platform.options.gitlab" }
+  { value = "gitlab", label_key = "settings.platform.options.gitlab" },
+  { value = "gitea", label_key = "settings.platform.options.gitea" }
 ]
+
+[[setting]]
+key = "gitea_login"
+type = "string"
+label_key = "settings.gitea_login.label"
+description_key = "settings.gitea_login.description"
+default = ""
+visible_when = { key = "platform", values = ["gitea"] }
 
 [[setting]]
 key = "repo"

--- a/git_companion/service.luau
+++ b/git_companion/service.luau
@@ -1,16 +1,24 @@
 -- Git Companion Service
--- Headless entry: fetches data from gh/glab and stores it in noctalia.state.
+-- Headless entry: fetches data from gh/glab/tea and stores it in noctalia.state.
 
 local platform = noctalia.getConfig("platform") or "github"
 local repo = noctalia.getConfig("repo") or ""
 local group = noctalia.getConfig("group") or ""
+local giteaLogin = noctalia.getConfig("gitea_login") or ""
 local refreshInterval = noctalia.getConfig("refresh_interval") or 60
 
-local bin = platform == "gitlab" and "glab" or "gh"
+local PLATFORM_BIN = {
+  github = "gh",
+  gitlab = "glab",
+  gitea = "tea",
+}
 local PLATFORM_GROUP = {
   gitlab = "--group",
   github = "--owner",
+  gitea = "--owner",
 }
+
+local bin = PLATFORM_BIN[platform] or PLATFORM_BIN.github
 
 local function tr(key, args) return noctalia.tr("service." .. key, args) end
 
@@ -28,8 +36,78 @@ local function scopeArgs()
   return {}
 end
 
+-- ── Gitea context ────────────────────────────────────────────
+-- tea resolves its context with `git rev-parse --show-toplevel` before it even
+-- looks at --login/--repo, so every repo-scoped command fails when the cwd is
+-- not a git repository - and a service runs from an arbitrary cwd. Any
+-- repository satisfies it, so the plugin keeps an empty one of its own and runs
+-- tea from there. Created once; the path is cached for the rest of the session.
+
+local teaContext = nil
+local teaUser = ""
+
+local function ensureTeaContext(cb)
+  if teaContext then return cb(teaContext) end
+
+  local dataDir = noctalia.pluginDataDir()
+  if not dataDir then return cb(nil) end
+
+  local dir = dataDir .. "/tea-ctx"
+  if noctalia.fileExists(dir .. "/.git") then
+    teaContext = dir
+    return cb(dir)
+  end
+
+  if not noctalia.mkdirAll(dir) then
+    noctalia.log("[Git Companion] Could not create " .. dir)
+    return cb(nil)
+  end
+
+  noctalia.runAsync("git -C " .. shellQuote(dir) .. " init --quiet", function(res)
+    if res.exitCode ~= 0 then
+      noctalia.log("[Git Companion] git init failed: " .. (res.stderr or ""))
+      return cb(nil)
+    end
+    teaContext = dir
+    cb(dir)
+  end)
+end
+
+-- Run a tea invocation from the context repository.
+local function teaCommand(parts)
+  return "cd " .. shellQuote(teaContext) .. " && " .. table.concat(parts, " ")
+end
+
 local function buildCommand(kind)
   local parts = {}
+  if platform == "gitea" then
+    -- `tea pulls list` demands a repo scope, so pull requests go through
+    -- `tea issues list --kind pulls`, which tea documents as the way to apply
+    -- the search filters to PRs. Gitea's global search rejects --assignee, so
+    -- both lists are filtered by author. tea has no review-requested filter at
+    -- all, so "review" never reaches this branch (see fetchEnabledLists).
+    table.insert(parts, bin)
+    table.insert(parts, "issues")
+    table.insert(parts, "list")
+    if giteaLogin ~= "" then
+      table.insert(parts, "--login")
+      table.insert(parts, shellQuote(giteaLogin))
+    end
+    table.insert(parts, "--kind")
+    table.insert(parts, kind == "issue" and "issues" or "pulls")
+    table.insert(parts, "--state")
+    table.insert(parts, "open")
+    table.insert(parts, "--author")
+    table.insert(parts, shellQuote(teaUser))
+    table.insert(parts, "--fields")
+    table.insert(parts, "index,title,url,state,owner,repo")
+    table.insert(parts, "--output")
+    table.insert(parts, "json")
+    table.insert(parts, "--limit")
+    table.insert(parts, "15")
+    for _, v in ipairs(scopeArgs()) do table.insert(parts, v) end
+    return teaCommand(parts)
+  end
   if platform == "gitlab" then
     local sub = kind == "issue" and "issue" or "mr"
     -- glab lists only open merge requests by default, so "unmerged" is free.
@@ -75,6 +153,14 @@ local function normalizeItem(raw, kind)
       targetBranch = raw.target_branch or "",
     }
   end
+  if platform == "gitea" then
+    return {
+      title = raw.title or "",
+      url = raw.url or "",
+      ref = (raw.owner or "") .. "/" .. (raw.repo or "") .. "#" .. (raw.index or ""),
+      targetBranch = "",
+    }
+  end
   -- GitHub
   local repoName = (raw.repository and (raw.repository.nameWithOwner or raw.repository.name)) or ""
   return {
@@ -104,12 +190,41 @@ local function clearList(kind)
   noctalia.state.set(kind .. "s_count", 0)
 end
 
+-- Reduce a CLI's stderr to the one line worth putting in front of the user.
+-- The interesting line is rarely the first: tea prefixes a "NOTE: no gitea
+-- login detected..." before the actual "Error: not found". So an explicit
+-- Error line wins, otherwise the last line that is not a note or a warning.
+local function errorLine(text)
+  local fallback = ""
+  for line in tostring(text or ""):gmatch("[^\r\n]+") do
+    local trimmed = noctalia.string.trim(line)
+    if trimmed ~= "" then
+      local lower = trimmed:lower()
+      if lower:match("^error") then
+        fallback = trimmed
+        break
+      end
+      if not (lower:match("^note[:%s]") or lower:match("^warn")) then
+        fallback = trimmed
+      end
+    end
+  end
+  if #fallback > 120 then return fallback:sub(1, 117) .. "..." end
+  return fallback
+end
+
 local function fetchList(kind)
   local cmd = buildCommand(kind)
   noctalia.log("[Git Companion] Running: " .. cmd)
   noctalia.runAsync(cmd, function(res)
+    -- The failure is reported next to the list rather than over it: the panel
+    -- keeps showing what it last fetched. Carrying the CLI's own first line
+    -- through is what makes it actionable - a mistyped repo reads as
+    -- "Error: not found" instead of a silently empty tab.
     if res.exitCode ~= 0 then
-      noctalia.log("[Git Companion] " .. kind .. " fetch failed: " .. (res.stderr or ""))
+      local stderr = res.stderr or ""
+      noctalia.log("[Git Companion] " .. kind .. " fetch failed: " .. stderr)
+      noctalia.state.set("error_detail", errorLine(stderr))
       return
     end
     local list = processList(kind, res.stdout)
@@ -121,6 +236,17 @@ end
 
 local lastAvatarUrl = ""
 
+local function setAvatar(avatarUrl)
+  if avatarUrl == "" or avatarUrl == lastAvatarUrl then return end
+  lastAvatarUrl = avatarUrl
+  local dir = noctalia.pluginDataDir()
+  if not dir then return end
+  local dest = dir .. "/avatar"
+  noctalia.download(avatarUrl, dest, function(ok)
+    if ok then noctalia.state.set("avatar_path", dest) end
+  end)
+end
+
 local function fetchUser()
   noctalia.runAsync(bin .. " api user", function(res)
     if res.exitCode ~= 0 then
@@ -129,44 +255,64 @@ local function fetchUser()
     end
     local decoded = noctalia.json.decode(res.stdout or "")
     if type(decoded) ~= "table" then return end
-    local username = decoded.username or decoded.login or ""
-    local bio = decoded.bio or ""
-    local avatarUrl = decoded.avatar_url or ""
-    noctalia.state.set("username", username)
-    noctalia.state.set("bio", bio)
-    if avatarUrl ~= "" and avatarUrl ~= lastAvatarUrl then
-      lastAvatarUrl = avatarUrl
-      local dir = noctalia.pluginDataDir()
-      if not dir then return end
-      local dest = dir .. "/avatar"
-      noctalia.download(avatarUrl, dest, function(ok)
-        if ok then noctalia.state.set("avatar_path", dest) end
-      end)
-    end
+    noctalia.state.set("username", decoded.username or decoded.login or "")
+    noctalia.state.set("bio", decoded.bio or "")
+    setAvatar(decoded.avatar_url or "")
   end)
 end
 
-local function refresh()
-  noctalia.log("[Git Companion] Refresh triggered.")
-  if not noctalia.commandExists(bin) then
-    noctalia.state.set("status", "bin_missing")
-    noctalia.notifyError(tr("title"), tr("bin_missing", { bin = bin }))
-    noctalia.log("[Git Companion] Error: " .. bin .. " not found.")
-    return
+-- Pick the login tea should use: the configured one, else tea's own default,
+-- else the only sensible fallback - the first one it knows about.
+local function pickTeaLogin(logins)
+  if giteaLogin ~= "" then
+    for _, entry in ipairs(logins) do
+      if entry.name == giteaLogin then return entry end
+    end
+    return nil
   end
-
-  if platform == "gitlab" and repo == "" and group == "" then
-    noctalia.state.set("status", "gitlab_scope_missing")
-    noctalia.notifyError(tr("title"), tr("gitlab_scope_missing"))
-    noctalia.log("[Git Companion] Error: GitLab scope missing.")
-    return
+  for _, entry in ipairs(logins) do
+    if tostring(entry.default) == "true" then return entry end
   end
+  return logins[1]
+end
 
+-- tea has no `api user` equivalent, but `tea login list` already holds the
+-- instance URL and the account name, and Gitea serves avatars publicly at
+-- <instance>/<user>.png - so no token ever leaves tea's own config.
+local function fetchTeaLogin(cb)
+  noctalia.runAsync(teaCommand({bin, "login", "list", "--output", "json"}), function(res)
+    if res.exitCode ~= 0 then
+      noctalia.log("[Git Companion] tea login list failed: " .. (res.stderr or ""))
+      return cb(false)
+    end
+    local decoded = noctalia.json.decode(res.stdout or "")
+    if type(decoded) ~= "table" then return cb(false) end
+
+    local entry = pickTeaLogin(decoded)
+    if not entry or not entry.user or entry.user == "" then return cb(false) end
+
+    teaUser = entry.user
+    noctalia.state.set("username", teaUser)
+    noctalia.state.set("bio", "")
+    if entry.url and entry.url ~= "" then
+      setAvatar((entry.url:gsub("/+$", "")) .. "/" .. teaUser .. ".png")
+    end
+    cb(true)
+  end)
+end
+
+-- tea exposes no review-requested filter, so Gitea cannot fill the Code Review
+-- tab. The panel hides that tab on Gitea and the state is emptied to match.
+local function supportsKind(kind)
+  return not (platform == "gitea" and kind == "review")
+end
+
+local function fetchEnabledLists()
   -- All preconditions met: the panel can render the lists. Individual fetch
   -- failures are logged per-list (see fetchList) and leave the previous list
   -- in place, so they don't flip this back.
   noctalia.state.set("status", "ok")
-  fetchUser()
+  noctalia.state.set("error_detail", "")
 
   -- Settings are read here rather than at module scope so toggling a tab takes
   -- effect on the next tick. show_reviews is the master switch for the Code
@@ -176,12 +322,46 @@ local function refresh()
     { kind = "issue", setting = "show_issues" },
     { kind = "review", setting = "show_reviews" },
   }) do
-    if noctalia.getConfig(entry.setting) ~= false then
+    if supportsKind(entry.kind) and noctalia.getConfig(entry.setting) ~= false then
       fetchList(entry.kind)
     else
       clearList(entry.kind)
     end
   end
+end
+
+local function fail(status, args)
+  noctalia.state.set("status", status)
+  noctalia.notifyError(tr("title"), tr(status, args))
+  noctalia.log("[Git Companion] Error: " .. status)
+end
+
+local function refresh()
+  noctalia.log("[Git Companion] Refresh triggered.")
+  if not noctalia.commandExists(bin) then
+    return fail("bin_missing", { bin = bin })
+  end
+
+  -- Gitea needs two async steps first: a git context for tea to run in, and the
+  -- account name that --author filters on. Gitea's global search works without
+  -- a repo or owner scope, so it has no equivalent of the GitLab check below.
+  if platform == "gitea" then
+    ensureTeaContext(function(dir)
+      if not dir then return fail("gitea_ctx_failed") end
+      fetchTeaLogin(function(ok)
+        if not ok then return fail("gitea_login_missing") end
+        fetchEnabledLists()
+      end)
+    end)
+    return
+  end
+
+  if platform == "gitlab" and repo == "" and group == "" then
+    return fail("gitlab_scope_missing")
+  end
+
+  fetchUser()
+  fetchEnabledLists()
 end
 
 -- Initial fetch

--- a/git_companion/translations/en.json
+++ b/git_companion/translations/en.json
@@ -1,6 +1,9 @@
 {
   "panel": {
     "bin_missing": "{bin} is not installed. Install it to use this plugin.",
+    "fetch_failed": "{bin} could not fetch your items:",
+    "gitea_ctx_failed": "Could not prepare tea's working directory. Is git installed?",
+    "gitea_login_missing": "No matching tea login. Run `tea login add` to sign in to your Gitea instance.",
     "gitlab_scope_missing": "Set a Repository or Group in settings to view your items.",
     "last_update": "Last update",
     "last_update_placeholder": "...",
@@ -16,6 +19,8 @@
   },
   "service": {
     "bin_missing": "{bin} is not installed.",
+    "gitea_ctx_failed": "Could not prepare tea's working directory.",
+    "gitea_login_missing": "No matching tea login. Run `tea login add`.",
     "gitlab_scope_missing": "GitLab requires a repo or group scope in settings.",
     "title": "Git Companion"
   },
@@ -49,14 +54,19 @@
       "description": "Add reviews to the PR/MR count in the bar. The tooltip always lists both.",
       "label": "Count Code Reviews with PRs/MRs"
     },
+    "gitea_login": {
+      "description": "Name of the tea login to use, as shown by `tea login list`. Leave empty for tea's default login.",
+      "label": "Gitea Login"
+    },
     "group": {
-      "description": "Filter by group (GitLab) or owner (GitHub). Leave empty to use repo.",
+      "description": "Filter by group (GitLab) or owner (GitHub, Gitea). Leave empty to use repo.",
       "label": "Group / Owner"
     },
     "platform": {
-      "description": "Choose between GitHub or GitLab.",
+      "description": "Choose between GitHub, GitLab or Gitea.",
       "label": "Platform",
       "options": {
+        "gitea": "Gitea",
         "github": "GitHub",
         "gitlab": "GitLab"
       }
@@ -66,7 +76,7 @@
       "label": "Refresh Interval (seconds)"
     },
     "repo": {
-      "description": "e.g. owner/repo (GitHub) or project path (GitLab). Leave empty to use group/owner.",
+      "description": "e.g. owner/repo (GitHub, Gitea) or project path (GitLab). Leave empty to use group/owner.",
       "label": "Repository"
     },
     "show_issues": {
@@ -78,7 +88,7 @@
       "label": "Show PRs/MRs tab"
     },
     "show_reviews": {
-      "description": "Show the tab listing open pull/merge requests awaiting your review.",
+      "description": "Show the tab listing open pull/merge requests awaiting your review. Not available on Gitea.",
       "label": "Show Code Review tab"
     }
   },

--- a/git_companion/widget.luau
+++ b/git_companion/widget.luau
@@ -10,6 +10,8 @@ local function getPlatformIcon()
     return "brand-gitlab"
   elseif platform == "github" then
     return "brand-github"
+  elseif platform == "gitea" then
+    return "brand-git" -- Tabler ships no Gitea brand glyph
   end
   return "brand-git" -- Fallback
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `tphilippot/git_companion`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

Add gitea provider

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

[tea](https://about.gitea.com/products/tea/) and git 

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

Tested with a local gitea instance on hyprland

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 23<!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
