### PR TITLE
chore(audio-switcher): mark plugin as deprecated

### DIFF
--- a/audio-switcher/plugin.toml
+++ b/audio-switcher/plugin.toml
@@ -1,9 +1,10 @@
 id = "blackbartblues/audio-switcher"
 name = "Audio Switcher"
-version = "0.6.0"
+version = "0.6.1"
 plugin_api = 15
 author = "blackbartblues"
 license = "MIT"
+deprecated = true
 icon = "switch-horizontal"
 description = "Switch audio inputs and outputs, hand off Bluetooth devices, and control them from compositor keybinds."
 tags = ["audio", "bar", "hardware", "launcher", "panel", "service", "system", "utility"]


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `blackbartblues/audio-switcher`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Marks Audio Switcher as deprecated because its author is stepping away from maintaining Noctalia plugins for now. Bumps the patch version from 0.6.0 to 0.6.1.

## External dependencies

No changes. Existing dependencies are `pactl`, `bluetoothctl`, and `sleep`.

## Testing

Manifest-only metadata change; validated all 138 plugin manifests with `.github/workflows/scripts/validate-plugins.py`.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** N/A (manifest-only change)
- **Plugin API level:** 15

## Screenshots / Videos

N/A (manifest-only change).

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
