### PR TITLE
feat(github-prs): add configurable GitHub hostname

### DIFF
--- a/github-prs/README.md
+++ b/github-prs/README.md
@@ -43,6 +43,7 @@ noctalia msg panel-toggle raycursive/github-prs:panel
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `rules` | `string_list` | `author:@me` | GitHub search fragments; one `gh api graphql` request runs per non-empty rule. |
+| `hostname` | `string` | `github.com` | GitHub hostname passed to `gh api`; set this to your GitHub Enterprise hostname when applicable. |
 | `excluded_repositories` | `string_list` | empty | Case-insensitive repository-name or `owner/name` glob patterns removed after fetching. |
 | `refresh_interval` | `int` | `180` seconds | Background refresh interval, limited to 30–3600 seconds. |
 | `glyph` | `glyph` | `git-pull-request` | Glyph used by this bar-widget instance. |
@@ -62,7 +63,7 @@ noctalia msg plugin raycursive/github-prs:fetch all dump
 
 ## Notes
 
-- For every configured rule, the service spawns `gh api graphql`, which sends the resulting search query to GitHub using the GitHub CLI's current authentication. The plugin does not read or store a GitHub token itself.
+- For every configured rule, the service spawns `gh api --hostname <hostname> graphql`, which sends the resulting search query to GitHub using the GitHub CLI's current authentication. The plugin does not read or store a GitHub token itself.
 - Selecting a pull request spawns `xdg-open` with the GitHub URL. The plugin does not write files.
 - Each rule returns at most 50 rows. The panel reports additional matches as truncated instead of silently presenting the list as complete.
 - A partial rule failure is shown alongside successful results. If every rule fails, the last successful in-memory result remains visible until the plugin reloads or a later fetch succeeds.

--- a/github-prs/fetch.luau
+++ b/github-prs/fetch.luau
@@ -21,6 +21,7 @@
 
 local GH_TIMEOUT_MS = 30000
 local DEFAULT_INTERVAL_S = 180
+local DEFAULT_HOSTNAME = "github.com"
 local MIN_INTERVAL_S = 30
 local RESULTS_PER_RULE = 50
 
@@ -57,6 +58,15 @@ local function readRules()
     end
   end
   return rules
+end
+
+local function readHostname()
+  local hostname = noctalia.getConfig("hostname")
+  if type(hostname) ~= "string" then
+    return DEFAULT_HOSTNAME
+  end
+  hostname = noctalia.string.trim(hostname)
+  return hostname ~= "" and hostname or DEFAULT_HOSTNAME
 end
 
 local function readExcludedRepositories()
@@ -144,8 +154,10 @@ local function buildSearchQuery(rule)
   return q .. " " .. rule
 end
 
-local function buildCommand(rule)
-  return "gh api graphql -f query="
+local function buildCommand(rule, hostname)
+  return "gh api --hostname "
+    .. quoteShellArgument(hostname)
+    .. " graphql -f query="
     .. quoteShellArgument(GRAPHQL_QUERY)
     .. " -f q="
     .. quoteShellArgument(buildSearchQuery(rule))
@@ -245,6 +257,7 @@ local function startFetch()
   end
 
   local rules = readRules()
+  local hostname = readHostname()
   local excludedRepositories = readExcludedRepositories()
   if #rules == 0 then
     publish({}, "ok", "", 0, 0, true)
@@ -278,7 +291,7 @@ local function startFetch()
   end
 
   for _, rule in ipairs(rules) do
-    local started = noctalia.runAsync(buildCommand(rule), function(result)
+    local started = noctalia.runAsync(buildCommand(rule, hostname), function(result)
       if thisGeneration ~= fetchGeneration then
         return -- config changed mid-flight; a newer fetch owns the state
       end

--- a/github-prs/plugin.toml
+++ b/github-prs/plugin.toml
@@ -5,7 +5,7 @@
 
 id = "raycursive/github-prs"
 name = "GitHub Pull Requests"
-version = "0.3.0"
+version = "0.3.1"
 plugin_api = 9
 author = "raycursive"
 license = "MIT"
@@ -22,6 +22,13 @@ type = "string_list"
 label_key = "settings.rules.label"
 description_key = "settings.rules.description"
 default = ["author:@me"]
+
+[[setting]]
+key = "hostname"
+type = "string"
+label_key = "settings.hostname.label"
+description_key = "settings.hostname.description"
+default = "github.com"
 
 [[setting]]
 key = "excluded_repositories"

--- a/github-prs/translations/en.json
+++ b/github-prs/translations/en.json
@@ -30,6 +30,10 @@
     "glyph": {
       "label": "Bar glyph"
     },
+    "hostname": {
+      "description": "GitHub hostname passed to the GitHub CLI. Use github.com for GitHub.com or your GitHub Enterprise hostname.",
+      "label": "GitHub hostname"
+    },
     "hide_when_zero": {
       "description": "Hide the bar widget when there are no open pull requests.",
       "label": "Hide when empty"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `raycursive/github-prs`
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a configurable GitHub hostname setting to GitHub Pull Requests. The fetch
service passes the configured hostname to `gh api`, allowing the plugin to query
GitHub Enterprise as well as GitHub.com. The setting defaults to `github.com`,
so existing installations keep their current behavior.

## External dependencies

`gh` performs the configured-host API request. `xdg-open` opens selected pull
requests. Both are already declared in `plugin.toml`.

## Testing

- [x] Tested on Niri
- **Noctalia version tested against:** installed local version
- **Plugin API level:** 9

Validated with:

```sh
python3 .github/workflows/scripts/validate-plugins.py
noctalia plugins lint github-prs
```

Also tested the setting against `github.azc.ext.hp.com`: the service fetched
three matching open pull requests. Removing the setting used the `github.com`
default and fetched the public-account results successfully.

## Screenshots / Videos

No visual-surface changes; this adds a plugin Settings control.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
