### PR TITLE
fix(k8s-status): don't flag Completed/Succeeded Job pods as problems

### DIFF
--- a/k8s-status/plugin.toml
+++ b/k8s-status/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/k8s-status"
 name = "K8s Status"
-version = "1.1.5"
+version = "1.1.6"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"

--- a/k8s-status/service.luau
+++ b/k8s-status/service.luau
@@ -267,7 +267,8 @@ local function parsePodsWide(stdout)
       local node = fields[idx + 1] or ""
       local have, want = parseReady(ready)
       local restartsNum = tonumber((restarts:match("^(%d+)"))) or 0
-      local problem = isProblemPhase(status) or (want > 0 and have < want) or restartsNum > 5
+      local finished = status == "Succeeded" or status == "Completed"
+      local problem = isProblemPhase(status) or (not finished and want > 0 and have < want) or restartsNum > 5
       table.insert(pods, {
         id = ns .. "/" .. name,
         namespace = ns,


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/k8s-status`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes the pod problem detection so finished pods (`Completed` / `Succeeded` from Jobs/CronJobs) are no longer counted as problems in the bar widget, panel and `/kube problems` launcher. Fixes #596 (replaces the closed #597, whose branch was force-pushed after the template bot closed it, making it unreopenable).

## External dependencies

Unchanged: `kubectl` and `less` (already declared in `plugin.toml`). No new dependencies.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** current
- **Plugin API level:** 10

Loaded the modified `service.luau` locally and verified against a cluster with completed CronJob pods: problem count no longer includes them; `CrashLoopBackOff`/`Failed` pods still flagged; `/kube problems` output matches the panel.

## Screenshots / Videos

Not a visual change (bug fix in problem detection logic).

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

(Version bumped `1.1.5` → `1.1.6`.)

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.