### PR TITLE
Arch-Updater: Some bug fixes -> V 2.0.3

### DIFF
--- a/arch-updater/CHANGELOG.md
+++ b/arch-updater/CHANGELOG.md
@@ -5,7 +5,10 @@ icon (the history icon next to Check) shows this same file.
 
 ## 2.0.3 - 2026-09-03
 
-- Fixed: the "Custom update command" setting was ignored in terminal update mode (the default), so a custom script only ran when update mode was set to background. Since 2.0.0 the override was wired into the background path only. It now takes effect in both modes, as it did before 2.0.0.
+- Fixed: a background update killed or crashed without writing its exit marker left the panel stuck on "Updating…", even across logins. The engine now spots a run whose log has stopped growing, clears it, and offers the usual retry. Terminal runs, which may legitimately sit idle at a prompt, are unaffected.
+- Fixed: the changelog could not be opened while an update was running. It now opens mid-update, and the back button returns to the live log.
+- Fixed: long changelog entries were clipped at three lines. They now wrap in full.
+- Fixed: the "Custom update command" setting was ignored in terminal update mode (the default); since 2.0.0 it only applied to background updates. It now takes effect in both modes, as it did before 2.0.0.
 
 ## 2.0.2 - 2026-08-28
 

--- a/arch-updater/CHANGELOG.md
+++ b/arch-updater/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Arch Updater are documented here. The panel's changelog
 icon (the history icon next to Check) shows this same file.
 
+## 2.0.3 - 2026-09-03
+
+- Fixed: the "Custom update command" setting was ignored in terminal update mode (the default), so a custom script only ran when update mode was set to background. Since 2.0.0 the override was wired into the background path only. It now takes effect in both modes, as it did before 2.0.0.
+
 ## 2.0.2 - 2026-08-28
 
 - Fixed: Update in terminal mode always failed on the Flatpak step, auto-declining its confirmation prompt with "n" (exit 1) even when nothing was typed. flatpak's prompt refuses to be interactive once its stdout isn't a real terminal, which is the case here since the whole run is piped into `tee` for the log; pacman/AUR prompts aren't affected by this. The Flatpak step now runs non-interactively (`-y --noninteractive`) in terminal mode too, same as background mode already did; pacman/AUR review stays fully interactive.

--- a/arch-updater/README.md
+++ b/arch-updater/README.md
@@ -190,7 +190,7 @@ setting.
 | `hide_polkit_hint` | `bool` | `false` | Hide the panel line offering to install the polkit keep-authorization rule. |
 | `log_lines` | `int` | `14` | How many of the latest update-log lines the panel shows during a run (6–30). |
 | `terminal` | `string` | *(empty)* | Terminal command for terminal-mode updates, the retry fallback and the log viewer. Empty uses Noctalia's detection. |
-| `update_cmd` | `string` | *(empty)* | Full override for the background update command. Empty builds it from the settings above, running pacman through `pkexec`. |
+| `update_cmd` | `string` | *(empty)* | Full override for the update command, in both terminal and background mode. Empty builds it from the settings above. |
 | `glyph` | `glyph` | `package` | The glyph shown for the widget on the bar. |
 | `show_count` | `bool` | `true` | Show the pending-update count next to the bar glyph. |
 | `hide_on_empty` | `bool` | `false` | Hide the widget entirely when there is nothing to show. |

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -835,7 +835,7 @@ local function changelogRows()
         for li, bullet in ipairs(release.lines) do
             table.insert(rows, ui.row({ key = "changelog-" .. ri .. "-" .. li, paddingH = 10, gap = 6 }, {
                 ui.label({ text = "•", fontSize = 11, color = "on_surface_variant" }),
-                ui.label({ text = bullet, fontSize = 11, color = "on_surface_variant", flexGrow = 1, maxLines = 3 }),
+                ui.label({ text = bullet, fontSize = 11, color = "on_surface_variant", flexGrow = 1 }),
             }))
         end
     end

--- a/arch-updater/panel.luau
+++ b/arch-updater/panel.luau
@@ -979,15 +979,15 @@ end
 local function body()
     local children = {}
 
-    -- The middle of the panel: the live log while updating (and after a
-    -- failure), the changelog, an opened history run, or the package list.
-    -- The live log always wins over the changelog: a run in progress is more
-    -- urgent than release notes.
-    if phaseOf() == "running" or (runFailed() and #logLines() > 0) then
-        table.insert(children, logSection())
-    elseif changelogOpen then
+    -- The middle of the panel: the changelog, the live log while updating
+    -- (and after a failure), an opened history run, or the package list.
+    -- The changelog is checked first so it can be opened during a run: the
+    -- back button returns to the live log, which is otherwise still shown.
+    if changelogOpen then
         table.insert(children, ui.scroll({ key = "changelog-view", flexGrow = 1, gap = 4 }, changelogRows()))
         return children
+    elseif phaseOf() == "running" or (runFailed() and #logLines() > 0) then
+        table.insert(children, logSection())
     else
         local runRows = openedRunAt ~= nil and runViewRows() or nil
         if runRows ~= nil then

--- a/arch-updater/plugin.toml
+++ b/arch-updater/plugin.toml
@@ -1,6 +1,6 @@
 id = "yuuto/arch-updater"
 name = "Arch Updater"
-version = "2.0.2"
+version = "2.0.3"
 plugin_api = 9
 author = "yuuto"
 license = "MIT"

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -1061,7 +1061,13 @@ end
 -- as the retry after a failed background run: no --noconfirm, prompts and
 -- the PKGBUILD review work as usual. Output is tee'd into the same log so the
 -- engine still sees the "::EXIT" marker and re-checks when the run ends.
+-- The update_cmd override wins here too, same as in background mode.
 local function buildTerminalCommand()
+    local override = trim(cfg("update_cmd"))
+    if override ~= "" then
+        return override
+    end
+
     local ignored = ignoreList()
     local ignoreFlag = #ignored > 0 and (" --ignore " .. table.concat(ignored, ",")) or ""
 

--- a/arch-updater/service.luau
+++ b/arch-updater/service.luau
@@ -1124,13 +1124,21 @@ local function runMetaPath()
     return dir ~= nil and (dir .. "/" .. RUN_META_FILE) or nil
 end
 
--- Written by the terminal run's own shell (echo $$) as its first action, so
--- pollRunLog can tell a closed terminal window from one legitimately sitting
--- at a PKGBUILD prompt: the log alone cannot, since closing the window kills
--- the pipeline before it ever gets to write an ::EXIT marker.
+-- Written by the run's own shell (echo $$) as its first action, so pollRunLog
+-- can tell a run that died without an ::EXIT marker (a closed terminal window,
+-- a killed or crashed background run) from one legitimately sitting at a
+-- PKGBUILD prompt or a slow package: the log alone cannot.
 local function runPidPath()
     local dir = noctalia.pluginDataDir()
     return dir ~= nil and (dir .. "/" .. RUN_PID_FILE) or nil
+end
+
+-- Shell prefix that drops the runner's PID into the pidfile before anything
+-- else. Shared by all three run launchers (background update, terminal
+-- update, rollback).
+local function pidWritePrefix()
+    local pidPath = runPidPath()
+    return pidPath ~= nil and ("echo $$ > " .. shellQuote(pidPath) .. "; ") or ""
 end
 
 local function saveRunMeta()
@@ -1221,7 +1229,7 @@ local function runUpdate()
     -- the user's locale (their window, their language), at the cost of the
     -- progress count there.
     local quoted = shellQuote(path)
-    local script = "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+    local script = pidWritePrefix() .. "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
         .. "; { export LC_ALL=C; " .. buildBackgroundCommand() .. " ; } >> " .. quoted .. " 2>&1"
         .. "; printf '::EXIT %s\\n' \"$?\" >> " .. quoted
 
@@ -1245,12 +1253,10 @@ local function runUpdateTerminal()
         return
     end
     local quoted = shellQuote(path)
-    -- echo $$ first thing: pollRunLog's pidfile check is how a closed
-    -- terminal window gets noticed at all, since closing it SIGHUPs the
-    -- pipeline before the trailing ::EXIT printf ever runs.
-    local pidPath = runPidPath()
-    local pidWrite = pidPath ~= nil and ("echo $$ > " .. shellQuote(pidPath) .. "; ") or ""
-    local wrapped = pidWrite .. "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+    -- echo $$ first thing (pidWritePrefix): pollRunLog's pidfile check is how
+    -- a closed terminal window gets noticed at all, since closing it SIGHUPs
+    -- the pipeline before the trailing ::EXIT printf ever runs.
+    local wrapped = pidWritePrefix() .. "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
         .. "; { " .. buildTerminalCommand() .. "; printf '::EXIT %s\\n' \"$?\" ; } 2>&1 | tee -a " .. quoted
         .. "; echo; echo " .. shellQuote(tr("run.press_key")) .. "; read -n 1"
     if not launchTerminal(wrapped) then
@@ -1376,19 +1382,18 @@ local function pollRunLog()
     local quoted = shellQuote(path)
     local cmd = "tail -n " .. tostring(keep + 8) .. " " .. quoted .. " 2>/dev/null"
         .. "; printf '::COUNT %s\\n' \"$(grep -cE '^(upgrading|installing|reinstalling|downgrading) |^(Updating|Installing) (app|runtime)/' " .. quoted .. " 2>/dev/null)\""
-    -- A terminal run's pidfile: prints nothing while it hasn't appeared yet
-    -- (still launching), "::ALIVE 1" while the process it names is running,
-    -- "::ALIVE 0" once that process is gone - the only way to notice the
-    -- window was closed, since that kills the pipeline before ::EXIT.
-    if runMode == "terminal" then
-        local pidPath = runPidPath()
-        if pidPath ~= nil then
-            local pidQuoted = shellQuote(pidPath)
-            cmd = cmd
-                .. "; p=$(cat " .. pidQuoted .. " 2>/dev/null)"
-                .. "; if [ -n \"$p\" ] && kill -0 \"$p\" 2>/dev/null; then printf '::ALIVE 1\\n'"
-                .. "; elif [ -n \"$p\" ]; then printf '::ALIVE 0\\n'; fi"
-        end
+    -- The run's pidfile: prints nothing while it hasn't appeared yet (still
+    -- launching), "::ALIVE 1" while the process it names is running,
+    -- "::ALIVE 0" once that process is gone - the only way to notice a run
+    -- that ended without an ::EXIT marker (a closed terminal window, a killed
+    -- or crashed background run), since that kills the pipeline before ::EXIT.
+    local pidPath = runPidPath()
+    if pidPath ~= nil then
+        local pidQuoted = shellQuote(pidPath)
+        cmd = cmd
+            .. "; p=$(cat " .. pidQuoted .. " 2>/dev/null)"
+            .. "; if [ -n \"$p\" ] && kill -0 \"$p\" 2>/dev/null; then printf '::ALIVE 1\\n'"
+            .. "; elif [ -n \"$p\" ]; then printf '::ALIVE 0\\n'; fi"
     end
     local started = noctalia.runAsync(cmd, function(result)
         if phase ~= "running" then
@@ -1396,22 +1401,22 @@ local function pollRunLog()
         end
         local text = result.stdout or ""
         if text == lastTailText then
-            -- Staleness only means "stuck" for non-interactive runs. In a
-            -- terminal the user may sit on a PKGBUILD diff or a prompt for
-            -- any amount of time; killing the tracking there would also
-            -- offer a retry that clobbers the log under the live process.
-            if runMode ~= "terminal" then
+            if not pidConfirmedAlive and os.time() - runStartedAt > RUN_PID_GRACE_S then
+                -- Grace window elapsed with no log growth and the pidfile has
+                -- never once shown a live process: the run never actually
+                -- started. A run already confirmed alive skips this - a
+                -- terminal run may sit idle at a prompt for as long as the
+                -- user needs.
+                finishRun(runMode == "terminal" and TERMINAL_CLOSED_CODE or -1)
+            elseif runMode ~= "terminal" then
+                -- A background run gone this quiet is stuck, not slow. (A
+                -- terminal run may sit on a PKGBUILD diff or a prompt for any
+                -- amount of time; failing it here would also offer a retry
+                -- that clobbers the log under the live process.)
                 runStaleS += RUN_POLL_SECONDS
                 if runStaleS >= RUN_STALE_LIMIT_S then
                     finishRun(-1)
                 end
-            elseif not pidConfirmedAlive and os.time() - runStartedAt > RUN_PID_GRACE_S then
-                -- Nothing has changed (no tail growth, no pidfile) since the
-                -- grace window opened and the pidfile has never once shown a
-                -- live process: the terminal never actually started. A run
-                -- already confirmed alive skips this - it may legitimately
-                -- sit idle at a prompt for as long as the user needs.
-                finishRun(TERMINAL_CLOSED_CODE)
             end
             return
         end
@@ -1449,10 +1454,11 @@ local function pollRunLog()
 
         if exitCode ~= nil then
             finishRun(exitCode)
-        elseif runMode == "terminal" and aliveMarker == "0" then
-            -- The pidfile's process is gone and no ::EXIT ever showed up:
-            -- the terminal window was closed mid-run.
-            finishRun(TERMINAL_CLOSED_CODE)
+        elseif aliveMarker == "0" then
+            -- The pidfile's process is gone and no ::EXIT ever showed up: a
+            -- terminal window closed mid-run, or a background run that was
+            -- killed or crashed.
+            finishRun(runMode == "terminal" and TERMINAL_CLOSED_CODE or -1)
         else
             publish()
         end
@@ -1473,6 +1479,7 @@ local function resumeRunIfActive()
     end
     local quoted = shellQuote(path)
     local cmd = "head -n 1 " .. quoted .. " 2>/dev/null; tail -n 3 " .. quoted .. " 2>/dev/null"
+        .. "; printf '::MTIME %s\\n' \"$(stat -c %Y " .. quoted .. " 2>/dev/null)\""
     local started = noctalia.runAsync(cmd, function(result)
         resumeProbed = true
         if phase ~= "idle" then
@@ -1490,6 +1497,16 @@ local function resumeRunIfActive()
             return
         end
         loadRunMeta()
+        local mtime = tonumber(text:match("::MTIME (%d+)"))
+        if runMode ~= "terminal" and mtime ~= nil and os.time() - mtime > RUN_STALE_LIMIT_S then
+            -- A background run whose log stopped growing this long ago is
+            -- dead, not slow: clear it instead of re-attaching. Re-attaching
+            -- would only show "running" until the stale timer expires - and
+            -- that timer restarts on every login, so frequent relogins would
+            -- never clear a wedged run.
+            clearRunMeta()
+            return
+        end
         beginRun(runKind, runTotal > 0 and runTotal or nil, runMode)
     end, FAST_TIMEOUT_MS)
     if not started then
@@ -1558,7 +1575,7 @@ pkexec pacman -U --noconfirm --noprogressbar --color never $files]]
     local quoted = shellQuote(path)
     -- export LC_ALL=C for the same reason as the update runner: the progress
     -- count greps for pacman's English "downgrading ..." lines.
-    local script = "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
+    local script = pidWritePrefix() .. "printf '::START %s\\n' \"$(date +%s)\" > " .. quoted
         .. "; { export LC_ALL=C\n" .. body .. "\n} >> " .. quoted .. " 2>&1"
         .. "; printf '::EXIT %s\\n' \"$?\" >> " .. quoted
     if not noctalia.runAsync(script) then

--- a/arch-updater/translations/de.json
+++ b/arch-updater/translations/de.json
@@ -163,7 +163,7 @@
       "label": "Terminal"
     },
     "update_cmd": {
-      "description": "Vollständige Überschreibung des im Terminal ausgeführten Befehls beim Aktualisieren. Leer (Standard) baut ihn aus AUR-Helfer, Ignorierliste, Flatpak und „Automatisch mit Ja bestätigen“ oben zusammen.",
+      "description": "Vollständige Überschreibung des Update-Befehls, im Terminal- und im Hintergrundmodus. Leer (Standard) baut ihn aus AUR-Helfer, Ignorierliste und Flatpak-Einstellungen oben zusammen.",
       "label": "Eigener Update-Befehl"
     },
     "update_mode": {

--- a/arch-updater/translations/en.json
+++ b/arch-updater/translations/en.json
@@ -184,7 +184,7 @@
       "label": "Terminal"
     },
     "update_cmd": {
-      "description": "Full override for the background update command. Empty (default) builds it from the AUR helper, ignore list and Flatpak settings above, running pacman through pkexec.",
+      "description": "Full override for the update command, in both terminal and background mode. Empty (default) builds it from the AUR helper, ignore list and Flatpak settings above.",
       "label": "Custom update command"
     },
     "update_mode": {


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot closes pull requests whose description loses required template structure.
     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `yuuto/arch-updater`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Fixes a stuck "Updating…" state. If a background update was killed or crashed without writing its ::EXIT marker, the panel stayed stuck on "Updating…" forever.

Lets the changelog open during a running update. Previously the live log always won and the changelog couldn't be opened mid-update. Now it opens during a run, and the back button returns to the live log.

Wraps long changelog entries. Entries were clipped at 3 lines (maxLines = 3); they now wrap in full.

Honors the custom update command in terminal mode. Since 2.0.0 the "Custom update command" setting only applied to background updates. buildTerminalCommand() now respects the update_cmd override too, restoring pre-2.0.0 behavior in both modes.

Refactor along the way: the pidfile-writing shell prefix is extracted into a shared pidWritePrefix() used by all three launchers (background update, terminal update, rollback), and pollRunLog's pidfile/alive-marker check is no longer terminal-only.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
No new dependencies

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.1-1-g709ebef14978
- **Plugin API level:**9 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] I created `thumbnail.webp` with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html).
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

closes #594 