### PR TITLE
yt-music: release 0.2.5

### DIFF
--- a/yt-music/CHANGELOG.md
+++ b/yt-music/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2.5] - 2026-09-04
+
+### Fixed
+- **Rapid skipping**: songs skipped over are no longer fetched or played
+- **Playback after skipping**: fixed a race where the new player instance could lose its control socket, leaving duration at 0:00 and transport controls dead.
+- **Netcat flavors**: mpv control now works with both OpenBSD netcat and ncat (Fedora/RHEL default).
+
+### Added
+- **Dependency healthcheck**: the login page shows a card checking yt-dlp, mpv, jq, netcat and curl : versions, staleness, and unix-socket support, with a refresh button.
+- **Boot diagnostics**: debug.log now records platform, plugin/host versions, auth state, and detected browsers on every start.
+
 ## [0.2.4] - 2026-09-03
 
 ### Added

--- a/yt-music/README.md
+++ b/yt-music/README.md
@@ -20,7 +20,9 @@ Install these tools on your `PATH`:
 - `mpv-mpris` — MPRIS control of mpv *(optional)*
 - `jq` — JSON parsing in YouTube API requests
 - `curl` — YouTube API and thumbnail requests
-- `nc` — mpv socket IPC
+- `nc` — mpv socket IPC (OpenBSD netcat or ncat; traditional/busybox nc lack unix-socket support and won't work)
+
+The plugin's login page shows a health-check card for all of the above if anything is missing, stale, or unsupported.
 
 ## Usage
 

--- a/yt-music/api/resolve.luau
+++ b/yt-music/api/resolve.luau
@@ -51,6 +51,7 @@ local EXPO = {}
 
 local stream_cache = {}
 local resolving_in_flight = {}
+local attempt_resolve: (string, number) -> () -- forward: resolve_stream parks the list, attempt spawns
 local STREAM_DISK_TTL = 4 * 3600
 
 function EXPO.get_audio_cache_path(video_id: string): string?
@@ -156,10 +157,19 @@ function EXPO.resolve_stream(video_id: string, cb: ((string?) -> ())?)
     end
 
     resolving_in_flight[video_id] = { cb }
+    attempt_resolve(video_id, 0)
+end
 
+-- Spawn the yt-dlp fetch for a video_id whose callback list is already parked
+-- in resolving_in_flight. Attempt 0 is the first try; on host spawn refusal
+-- (burst saturation from rapid skips) one delayed retry follows, then fail.
+attempt_resolve = function(video_id, attempt)
+    local safe_id = video_id:gsub("[^%w%-_]", "_")
     log("resolving stream URL for id=" .. video_id)
     local script = RESOLVE_SCRIPT:gsub("VIDEO", safe_id)
-    network.runAsync(script, function(res)
+    local started_ms = noctalia.nowMs()
+    local launched = network.runAsync(script, function(res)
+        local elapsed_ms = noctalia.nowMs() - started_ms
         local out = type(res) == "table" and res.stdout or ""
         local raw_url = out:match("URL=([^\n\r]+)")
         local url = sanitize_str(raw_url)
@@ -167,18 +177,53 @@ function EXPO.resolve_stream(video_id: string, cb: ((string?) -> ())?)
         resolving_in_flight[video_id] = nil
 
         if url ~= "" then
-            log("stream resolved successfully (" .. #url .. " bytes) for id=" .. video_id)
+            log("stream resolved successfully (" .. #url .. " bytes, " .. elapsed_ms .. "ms) for id=" .. video_id)
             stream_cache[video_id] = { url = url, timestamp = os.time() }
             for _, callback in ipairs(callbacks) do
                 if callback then callback(url) end
             end
         else
-            log("stream resolution failed for id=" .. video_id)
+            local reason = "failed"
+            if out:find("NETGATE=OFFLINE", 1, true) then
+                reason = "offline, deferred"
+            elseif type(res) == "table" and res.timedOut then
+                reason = "timed out"
+            elseif type(res) == "table" and (res.exitCode == 143 or res.exitCode == 137) then
+                -- SIGTERM/SIGKILL is our own supersede kill reaping a stale
+                -- fetch during rapid skips — expected, not an error.
+                reason = "superseded (stale fetch reaped)"
+            end
+            log("stream resolution " .. reason .. " (" .. elapsed_ms .. "ms) for id=" .. video_id)
             for _, callback in ipairs(callbacks) do
                 if callback then callback(nil) end
             end
         end
     end, 30000)
+    if not launched and network.isOnline() then
+        -- Host refused the spawn: rapid skips fill every slot with stale
+        -- yt-dlp fetches, so the final song's resolve is the one refused and
+        -- its entry would wedge (UI loading forever + id poisoned). Retry once
+        -- after the burst drains; if that also fails, fail fast with nil so
+        -- the owner falls back to stopped instead of hanging. Offline needs
+        -- no handling: the net gate already scheduled its synthetic failure.
+        if attempt < 1 then
+            log("stream resolve launch refused for id=" .. video_id .. ", retrying")
+            local scheduled = noctalia.runAsync("sleep 1.5", function()
+                if resolving_in_flight[video_id] then
+                    attempt_resolve(video_id, attempt + 1)
+                end
+            end)
+            if scheduled then
+                return
+            end
+        end
+        log("stream resolve launch refused for id=" .. video_id)
+        local pending = resolving_in_flight[video_id] or {}
+        resolving_in_flight[video_id] = nil
+        for _, callback in ipairs(pending) do
+            if callback then callback(nil) end
+        end
+    end
 end
 
 function EXPO.prefetch_track(item: types.Track)

--- a/yt-music/modules/auth.luau
+++ b/yt-music/modules/auth.luau
@@ -27,6 +27,7 @@ function Auth.open_login(browser)
     state.browser = target
     state.browser_label = label
     state.status_text = "Opened " .. label .. ". Sign in, then click " .. label .. " again to extract."
+    log("open_login: browser=" .. target)
     store.publish()
     Bash.run_script("cookies.sh", "open_browser", function() end, 5000, target)
     if noctalia.notify then
@@ -116,6 +117,7 @@ function Auth.load_cached_cookies()
             local kept = tonumber(out:match("KEPT=([^\n]+)") or "0") or 0
             local cookies = out:match("OUT=([^\n]+)") or ""
             if kept > 0 then
+                log("cookies: ready (" .. kept .. ")")
                 state.status = "ready"
                 state.cookies_path = cookies
                 state.cookie_count = kept
@@ -149,18 +151,49 @@ function Auth.load_cached_cookies()
                     end)
                 end
             end
+        else
+            log("cookies: none — signed out")
         end
     end, 8000)
+end
+
+-- Dependency health check, run at boot before the browser list is shown.
+-- Result lands in state.health as name -> {status, detail}; the auth views
+-- render a warning card for anything not ok. Additive only: never blocks.
+function Auth.check_health()
+    state.checking_health = true
+    store.publish()
+    Bash.run_script("health.sh", "health_check", function(res)
+        local out = (type(res) == "table" and res.stdout) or ""
+        local health = {}
+        local parts = {}
+        for name, status, detail in out:gmatch("HEALTH=([^:]+):([^:]+):([^\n]*)") do
+            health[name] = { status = status, detail = detail }
+            table.insert(parts, name .. "=" .. status .. ":" .. detail)
+        end
+        -- Full check-by-check record (versions, netcat variant, stale
+        -- verdicts) lands in debug.log for remote diagnosis.
+        log("health check:")
+        for _, line in ipairs(parts) do
+            log("  " .. line)
+        end
+        state.health = health
+        state.checking_health = false
+        store.publish()
+    end, 15000)
 end
 
 function Auth.detect_browsers()
     Bash.run_script("cookies.sh", "detect_browsers", function(res)
         local out = (type(res) == "table" and res.stdout) or ""
         local available = {}
-        for found in out:gmatch("FOUND=([^\n]+)") do
-            available[found] = true
+        local found = {}
+        for id in out:gmatch("FOUND=([^\n]+)") do
+            available[id] = true
+            table.insert(found, id)
         end
         state.available = available
+        log("browsers: " .. (#found > 0 and table.concat(found, ",") or "none detected"))
         store.publish()
     end, 8000)
 end

--- a/yt-music/modules/mpv.luau
+++ b/yt-music/modules/mpv.luau
@@ -1,6 +1,8 @@
 local Mpv = {}
 local Bash = require("../utils/bash.luau")
 local scratch = require("../utils/scratch.luau")
+local logger = require("../utils/log.luau")
+local log = logger.module("ytm", "mpv")
 
 -- url/title go through per-call scratch slots (rotating pool, overwritten on
 -- reuse) so a fast track switch can never clobber the previous launch inputs.
@@ -11,8 +13,11 @@ function Mpv.play(url, title, volume, on_ready)
     noctalia.writeFile(title_file, title or "")
     Bash.run_script("mpv.sh", "mpv_play", function(res)
         local out = (type(res) == "table" and res.stdout) or ""
+        local ready = out:find("READY=1", 1, true) ~= nil
+        local ms = out:match("MS=(%d+)")
+        log("mpv_play ready=" .. tostring(ready) .. (ms and (" in " .. ms .. "ms") or ""))
         if type(on_ready) == "function" then
-            on_ready(out:find("READY=1") ~= nil)
+            on_ready(ready)
         end
     end, 10000, tostring(volume or 100), url_file, title_file)
 end

--- a/yt-music/modules/player.luau
+++ b/yt-music/modules/player.luau
@@ -23,6 +23,32 @@ local original_queue = nil
 local play_generation = 0
 local start_stream
 
+-- Coalesced manual skips: rapid next/prev presses accumulate into
+-- pending_steps and fire once the burst settles, so intermediate songs never
+-- audibly start — only the final landing resolves and plays.
+local pending_steps = 0
+local skip_nonce = 0
+local firing_debounce = false
+local queue_skip -- forward: Player.next/prev coalesce through this, defined below
+
+-- Last click wins, structurally: when a new intent supersedes a still-loading
+-- one, the older yt-dlp stream-resolves are already useless (the generation
+-- guard would drop their results) but still hold spawn slots the final song
+-- needs. Kill them before spawning the new fetch. The pattern matches ONLY
+-- stream resolves (-f bestaudio/best -g); audio downloads use -f bestaudio -o
+-- and are untouched. The -[g] bracket form keeps pkill from matching its own
+-- command line.
+local function kill_stale_resolves(done)
+	local scheduled = noctalia.runAsync("pkill -f 'bestaudio/best -[g]' 2>/dev/null; true", function()
+		if done then
+			done()
+		end
+	end, 2000)
+	if not scheduled and done then
+		done()
+	end
+end
+
 local function player_set(item, stream_url)
 	state.player.title = item.title or "Unknown track"
 	state.player.artist = item.artist or ""
@@ -78,6 +104,27 @@ local function player_set(item, stream_url)
 			start_stream()
 		end
 	end)
+	-- Speculative work happens only for settled playback: the song that
+	-- actually starts earns its next-track prefetch and queue thumbnails.
+	-- Skipped-over intents never get here, so rapid skipping spawns nothing
+	-- but one kill + one resolve per click.
+	if api and api.prefetch_queue then
+		api.prefetch_queue(state.player.queue, state.player.index)
+	elseif api and api.prefetch_track then
+		local q = state.player.queue
+		local idx = state.player.index
+		if q[idx + 1] then
+			api.prefetch_track(q[idx + 1])
+		end
+		if q[idx + 2] then
+			api.prefetch_track(q[idx + 2])
+		end
+	end
+	if api and api.ensure_thumbnails then
+		noctalia.runAsync("true", function()
+			api.ensure_thumbnails(state.player.queue, publish, "queue")
+		end)
+	end
 	if api and api.save_session then
 		noctalia.runAsync("true", function()
 			api.save_session(state.player)
@@ -117,10 +164,21 @@ function Player.play_index(index, queue)
 	if #queue == 0 then
 		return
 	end
+	if not firing_debounce then
+		-- Any direct play voids queued-up manual skips: they were aimed at
+		-- whatever was current before this intent (clicks, play-now, resume,
+		-- natural advance).
+		skip_nonce = skip_nonce + 1
+		pending_steps = 0
+	end
 	if queue ~= state.player.queue then
 		original_queue = nil
 	end
 
+	-- A new intent while the previous one is still loading supersedes it: the
+	-- older fetches are dead weight and the skipped songs earn no prefetch or
+	-- thumbnails — only the song we land on gets work done.
+	local superseding = (state.player.status == "loading")
 	-- Any new play intent invalidates every in-flight resolve before it.
 	play_generation = play_generation + 1
 	local gen = play_generation
@@ -157,7 +215,12 @@ function Player.play_index(index, queue)
 	state.player.queue = queue
 	state.player.index = index
 	local item = queue[index]
-	mpv.send((noctalia.json.encode({ command = { "set_property", "pause", true } })))
+	if not superseding then
+		-- Silence the outgoing track. Skipped when superseding: the previous
+		-- intent already sent exactly one of these, and piled-up delayed
+		-- copies are what used to pause the final song after it started.
+		mpv.send((noctalia.json.encode({ command = { "set_property", "pause", true } })))
+	end
 	state.player.id = item.id or ""
 	state.player.title = item.title or "Loading track..."
 	state.player.artist = item.artist or ""
@@ -176,11 +239,6 @@ function Player.play_index(index, queue)
 		noctalia.notify("Offline mode", "Skipped " .. skipped_offline .. " undownloaded track(s)")
 	end
 
-	if api and api.ensure_thumbnails then
-		noctalia.runAsync("true", function()
-			api.ensure_thumbnails(state.player.queue, publish, "queue")
-		end)
-	end
 	log(
 		"play_index: "
 			.. index
@@ -193,18 +251,7 @@ function Player.play_index(index, queue)
 			.. "'"
 	)
 
-	if api and api.prefetch_queue then
-		api.prefetch_queue(queue, index)
-	elseif api and api.prefetch_track then
-		if queue[index + 1] then
-			api.prefetch_track(queue[index + 1])
-		end
-		if queue[index + 2] then
-			api.prefetch_track(queue[index + 2])
-		end
-	end
-
-	api.resolve_stream(item.id, function(url)
+	local function on_resolved(url)
 		if gen ~= play_generation then
 			log(
 				"play_index: dropped stale stream response (gen "
@@ -226,7 +273,17 @@ function Player.play_index(index, queue)
 		end
 		log("play_index: stream resolved (" .. #url .. " chars), dispatching to mpv")
 		player_set(item, url)
-	end)
+	end
+
+	if superseding then
+		-- Newest intent's fetch spawns only after the stale ones are dead, so
+		-- a saturated pool can never refuse the song we actually land on.
+		kill_stale_resolves(function()
+			api.resolve_stream(item.id, on_resolved)
+		end)
+	else
+		api.resolve_stream(item.id, on_resolved)
+	end
 end
 
 function Player.play(item)
@@ -371,18 +428,62 @@ function Player.next(is_natural_end)
 
 	-- With shuffle on the queue is physically reordered by toggle_shuffle,
 	-- so a plain sequential advance IS the shuffled order.
+	queue_skip(1)
+end
 
-	local next_idx = state.player.index + 1
-	if next_idx > #state.player.queue then
-		if state.player.repeat_mode == "all" then
-			next_idx = 1
-		else
-			state.player.status = "stopped"
-			publish()
-			return
+-- Walk the accumulated manual steps in one go and resolve+play only the
+-- landing: no intermediate player_set, so skipped-over songs (even cached
+-- ones) never become audible.
+local function advance_steps()
+	local steps = pending_steps
+	pending_steps = 0
+	if steps == 0 then
+		return
+	end
+	local n = #state.player.queue
+	if n == 0 then
+		return
+	end
+	local idx = state.player.index
+	local dir = steps > 0 and 1 or -1
+	for _ = 1, math.abs(steps) do
+		idx = idx + dir
+		if idx > n then
+			if state.player.repeat_mode == "all" then
+				idx = 1
+			else
+				-- Past the end without repeat-all: stop, like a single
+				-- next at the tail would.
+				state.player.status = "stopped"
+				publish()
+				return
+			end
+		elseif idx < 1 then
+			idx = n
 		end
 	end
-	Player.play_index(next_idx)
+	firing_debounce = true
+	Player.play_index(idx)
+	firing_debounce = false
+end
+
+-- Each press within the window replaces the previous timer; the burst fires
+-- once quiet. Net-zero bursts (next then prev) stay put.
+queue_skip = function(dir)
+	pending_steps = pending_steps + dir
+	skip_nonce = skip_nonce + 1
+	local my = skip_nonce
+	local scheduled = noctalia.runAsync("sleep 0.25", function()
+		if my ~= skip_nonce then
+			return
+		end
+		advance_steps()
+	end, 2000)
+	if not scheduled then
+		-- No slot even for the timer: run the backlog now rather than
+		-- dropping the press.
+		advance_steps()
+	end
 end
 
 function Player.prev()
@@ -394,11 +495,7 @@ function Player.prev()
 		state.player.position = 0
 		publish()
 	else
-		local prev_idx = state.player.index - 1
-		if prev_idx < 1 then
-			prev_idx = #state.player.queue
-		end
-		Player.play_index(prev_idx)
+		queue_skip(-1)
 	end
 end
 

--- a/yt-music/plugin.toml
+++ b/yt-music/plugin.toml
@@ -1,6 +1,6 @@
 id = "aabidk20/yt-music"
 name = "YouTube Music"
-version = "0.2.4"
+version = "0.2.5"
 plugin_api = 23
 icon = "brand-youtube-filled"
 author = "Aabid"

--- a/yt-music/scripts/health.sh
+++ b/yt-music/scripts/health.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Invoked via:  bash scripts/health.sh <fn> <args...>
+# Dependency health check, run once at boot before the browser list is shown.
+# Prints HEALTH=<name>:<status>:<detail> lines; status is ok, warn or missing.
+
+# $1=name $2=status $3=detail
+report() {
+  echo "HEALTH=$1:$2:$3"
+}
+
+check_ytdlp() {
+  command -v yt-dlp >/dev/null 2>&1 || { report "ytdlp" "missing" "not on PATH"; return; }
+  local ver
+  ver=$(yt-dlp --version 2>/dev/null | head -1)
+  # Flag builds older than ~6 months: rotted extractors are the usual cause
+  # of mysterious resolve failures. Unparseable versions pass silently.
+  local day
+  day=$(date -d "$(echo "$ver" | tr '.' '-')" +%s 2>/dev/null)
+  if [ -n "$day" ] && [ $(( ($(date +%s) - day) / 86400 )) -gt 180 ]; then
+    report "ytdlp" "warn" "$ver (stale)"
+  else
+    report "ytdlp" "ok" "$ver"
+  fi
+}
+
+check_mpv() {
+  command -v mpv >/dev/null 2>&1 || { report "mpv" "missing" "not on PATH"; return; }
+  report "mpv" "ok" "$(mpv --version 2>/dev/null | head -1)"
+}
+
+check_nc() {
+  command -v nc >/dev/null 2>&1 || { report "nc" "missing" "not on PATH"; return; }
+  # ncat names itself in its help line; any other nc that accepts -U can
+  # only be openbsd's. Both give mpv IPC; traditional/busybox don't.
+  local variant="openbsd-netcat"
+  case "$(nc -h 2>&1 | head -1)" in *[Nn]cat*) variant="ncat" ;; esac
+  local err
+  err=$(printf '' | nc -U -w1 /tmp/yt-music-ipc-probe 2>&1)
+  case "$err" in
+    *nvalid*|*sage*|*llegal*) report "nc" "warn" "no unix sockets — install openbsd-netcat or ncat" ;;
+    *) report "nc" "ok" "$variant" ;;
+  esac
+}
+
+check_curl() {
+  command -v curl >/dev/null 2>&1 || { report "curl" "missing" "not on PATH"; return; }
+  local ver vnum
+  ver=$(curl --version 2>/dev/null | head -1 | awk '{print $2}')
+  vnum=$(echo "$ver" | awk -F. '{ if ($1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/) print ($1 * 1000) + $2 }')
+  # Thumbnails fetch with --parallel-immediate, which needs curl 7.68+.
+  if [ -n "$vnum" ] && [ "$vnum" -ge 7068 ]; then
+    report "curl" "ok" "curl $ver"
+  else
+    report "curl" "warn" "${ver:-unknown version} (too old for parallel fetching)"
+  fi
+}
+
+check_jq() {
+  command -v jq >/dev/null 2>&1 || { report "jq" "missing" "not on PATH"; return; }
+  report "jq" "ok" "$(jq --version 2>/dev/null)"
+}
+
+health_check() {
+  check_ytdlp
+  check_mpv
+  check_nc
+  check_curl
+  check_jq
+}
+
+fn="${1:?fn required}"; shift
+type -t "$fn" >/dev/null 2>&1 || { echo "unknown fn: $fn" >&2; exit 1; }
+"$fn" "$@"

--- a/yt-music/scripts/mpv.sh
+++ b/yt-music/scripts/mpv.sh
@@ -8,34 +8,83 @@ GENFILE="$DIR/mpv.gen"
 
 mkdir -p "$DIR"
 
+# nc flavor, probed not assumed: OpenBSD nc needs -N to exit after stdin
+# EOF (mpv never closes the connection, so sends would hang till timeout
+# without it); ncat shuts down by default and rejects -N. Traditional and
+# busybox nc lack -U entirely (covered by the health check, not here).
+# All branches fail fast, so this costs nothing per invocation.
+NC_N=0
+if command -v nc >/dev/null 2>&1; then
+  _ncerr=$(printf '' | nc -N -w1 "$DIR/nc-probe-never" 2>&1)
+  case "$_ncerr" in *nvalid*|*sage*|*llegal*) ;; *) NC_N=1 ;; esac
+fi
+
+# stdin -> socket with prompt EOF shutdown on either flavor.
+nc_send() {   # $1=sock $2=timeout
+  if [ "$NC_N" = 1 ]; then
+    nc -U -N -w"$2" "$1"
+  else
+    nc -U -w"$2" "$1"
+  fi
+}
+# Succeeds iff a socket connection works.
+nc_check() {   # $1=sock $2=timeout
+  printf '' | nc_send "$1" "$2" >/dev/null 2>&1
+}
+
 mpv_play() {   # $1=volume $2=url_file $3=title_file
   local vol="${1:-100}"
   URL=$(cat "$2")
   TITLE=$(cat "$3" 2>/dev/null)
+  START_MS=$(date +%s%N)
+  # Serialize overlapping plays (rapid skips): without this, a newer
+  # invocation can launch while the older instance is still holding the
+  # socket path, leaving the audible mpv without IPC : audio plays, but no
+  # duration/ticks/eof ever arrive and transport goes dead. Opportunistic:
+  # skipped where flock is unavailable. Released on process exit, even
+  # under SIGKILL.
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$DIR/mpv.lock"
+    flock 9 || exit 1
+  fi
   if [ -f "$PIDFILE" ]; then
     PREV=$(cat "$PIDFILE" 2>/dev/null)
     [ -n "$PREV" ] && kill "$PREV" >/dev/null 2>&1
     rm -f "$PIDFILE"
   fi
   pkill -f "input-ipc-server=$SOCK" >/dev/null 2>&1
-  sleep 0.3
+  # Wait until the old instance actually exits and releases the socket path;
+  # a fixed sleep loses under load. The [.] keeps pgrep from matching its
+  # own command line (which contains the pattern text).
+  for i in $(seq 1 20); do
+    pgrep -f "input-ipc-server=.*mpv[.]sock" >/dev/null 2>&1 || break
+    sleep 0.1
+  done
+  pkill -9 -f "input-ipc-server=$SOCK" >/dev/null 2>&1
+  sleep 0.1
   rm -f "$SOCK"
+  # 9>&-: mpv must not inherit the lock fd, or the lock would outlive this
+  # script (held open by the playing mpv) and deadlock the next play.
   nohup mpv "$URL" --no-video --vo=null --vd=null --audio-display=no --no-osc --no-osd-bar \
     --demuxer-max-bytes=20M --demuxer-readahead-secs=60 --really-quiet --no-terminal \
     --keep-open=yes \
     --force-media-title="$TITLE" \
     --input-ipc-server="$SOCK" --ao=pulse,pipewire,alsa,auto \
-    >/dev/null 2>&1 &
+    >/dev/null 2>&1 9>&- &
   echo $! > "$PIDFILE"
   echo $(( $(cat "$GENFILE" 2>/dev/null || echo 0) + 1 )) > "$GENFILE"
   for i in 1 2 3 4 5 6 7 8 9 10; do
-    [ -S "$SOCK" ] && printf '' | nc -U -N -w1 "$SOCK" >/dev/null 2>&1 && break
+    [ -S "$SOCK" ] && nc_check "$SOCK" 1 && break
     sleep 0.2
   done
   [ -S "$SOCK" ] && { 
-    echo "READY=1"
-    printf '{"command":["set_property","volume",%s]}\n' "$vol" | nc -U -N -w1 "$SOCK" >/dev/null 2>&1
+    echo "READY=1 MS=$(( ($(date +%s%N) - START_MS) / 1000000 ))"
+    printf '{"command":["set_property","volume",%s]}\n' "$vol" | nc_send "$SOCK" 1 >/dev/null 2>&1
   }
+  if command -v flock >/dev/null 2>&1; then
+    flock -u 9 2>/dev/null
+    exec 9>&- 2>/dev/null
+  fi
 }
 
 mpv_send() {   # $1=payload json
@@ -43,11 +92,15 @@ mpv_send() {   # $1=payload json
   [ -S "$SOCK" ] || exit 0
   TMP=$(mktemp)
   printf '%s\n' "$payload" > "$TMP"
-  nc -U -N -w2 "$SOCK" < "$TMP" >/dev/null 2>&1
+  nc_send "$SOCK" 2 < "$TMP" >/dev/null 2>&1
   rm -f "$TMP"
 }
 
 mpv_kill() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$DIR/mpv.lock"
+    flock 9 || exit 1
+  fi
   if [ -f "$PIDFILE" ]; then
     PREV=$(cat "$PIDFILE" 2>/dev/null)
     [ -n "$PREV" ] && kill -9 "$PREV" >/dev/null 2>&1

--- a/yt-music/service.luau
+++ b/yt-music/service.luau
@@ -11,6 +11,34 @@ local logger = require("./utils/log.luau")
 local network = require("./utils/network.luau")
 local log = logger.module("ytm", "service")
 
+-- Boot environment snapshot: one log line giving the full support picture
+-- (host build, plugin version, distro, session) without interrogating the
+-- user. Host build comes from `noctalia --version`.
+local function read_line(path, pattern)
+	local raw = noctalia.readFile(path)
+	if type(raw) ~= "string" then
+		return "?"
+	end
+	return (raw:match(pattern) or "?"):gsub('"', "")
+end
+
+local function log_boot_env()
+	local plugin_ver = read_line((noctalia.pluginDir() or "") .. "/plugin.toml", 'version%s*=%s*"([^"]+)"')
+	local os_name = read_line("/etc/os-release", 'PRETTY_NAME="([^"]+)"')
+	if os_name == "?" then
+		-- Bazzite/Universal Blue: /etc/os-release may miss; real file lives in /usr
+		os_name = read_line("/usr/lib/os-release", 'PRETTY_NAME="([^"]+)"')
+	end
+	local desktop = noctalia.getenv("XDG_CURRENT_DESKTOP") or "?"
+	local session = noctalia.getenv("XDG_SESSION_TYPE") or "?"
+	noctalia.runAsync("noctalia --version 2>/dev/null | head -1", function(res)
+		local out = (type(res) == "table" and res.stdout) or ""
+		local host = out:match("noctalia%s+(v?[%d%.]+)") or "?"
+		log("env: noctalia=" .. host .. " plugin=" .. plugin_ver .. " os=\"" .. os_name
+			.. "\" desktop=" .. desktop .. " session=" .. session)
+	end)
+end
+
 -- Domain logic lives in dedicated backend modules under modules/.
 -- Service keeps the wiring: logging, and request dispatch.
 local auth = require("./modules/auth.luau")
@@ -75,6 +103,9 @@ local ACTIONS = {
 	end,
 	refresh_quick_picks = function(r)
 		home.refresh_quick_picks()
+	end,
+	refresh_health = function(r)
+		auth.check_health()
 	end,
 	download_track = function(r)
 		local vid = (r.item and r.item.id) or r.id or r.video_id
@@ -245,9 +276,11 @@ end
 noctalia.setUpdateInterval(1000)
 
 log("boot: service started, api=" .. tostring(type(api)) .. " library=" .. tostring(type(api and api.library)))
+log_boot_env()
 mpv.kill()
 library.load_offline_meta()
 auth.detect_browsers()
+auth.check_health()
 auth.load_cached_cookies()
 if api and api.load_cached_library then
 	local cached_lib = api.load_cached_library()

--- a/yt-music/translations/en.json
+++ b/yt-music/translations/en.json
@@ -1,8 +1,8 @@
 {
   "settings": {
     "debug_logging": {
-      "description": "Write verbose logs to the plugin log file to help troubleshoot issues.",
-      "label": "Debug logging"
+      "label": "Debug logging",
+      "description": "Write verbose logs to the plugin log file to help troubleshoot issues."
     }
   }
 }

--- a/yt-music/utils/schema.luau
+++ b/yt-music/utils/schema.luau
@@ -8,6 +8,8 @@ local function new()
 		cookies_path = "",
 		cookie_count = 0,
 		available = {},
+	health = {},
+	checking_health = false,
 		extracting = false,
 		last_error = "",
 		player = {

--- a/yt-music/views/components/auth.luau
+++ b/yt-music/views/components/auth.luau
@@ -6,6 +6,98 @@ local rerender = require("../rerender.luau")
 
 local BROWSERS = require("../../utils/browsers.luau")
 
+-- Always-on dependency card above the browser grid: every check with its
+-- status in both success and failure cases. Returns nil only before the
+-- first check has run.
+local DEP_ORDER = { "ytdlp", "mpv", "jq", "nc", "curl" }
+
+local DEP_LABEL = {
+    ytdlp = "yt-dlp",
+    mpv = "mpv",
+    jq = "jq",
+    nc = "netcat",
+    curl = "curl",
+}
+
+local function short_ver(name, detail)
+    detail = tostring(detail or "")
+    if name == "mpv" or name == "curl" then
+        local a, b = detail:match("^(%S+)%s+(%S+)")
+        if a then
+            return a .. " " .. b
+        end
+        return ""
+    end
+    return detail
+end
+
+local DEP_IMPACT = {
+    ytdlp = "not found — search, playback and downloads won't work",
+    mpv = "not found — no audio playback",
+    jq = "not found — search, library and playlists won't work",
+    nc = "not found — duration, controls and auto-advance won't work",
+    curl = "not found — thumbnails won't load",
+}
+
+local function build_health_card()
+    local h = state.data.health
+    if type(h) ~= "table" or next(h) == nil then
+        return nil
+    end
+    local rows = {}
+    for _, name in ipairs(DEP_ORDER) do
+        local dep = h[name]
+        if dep then
+            local label = DEP_LABEL[name] or name
+            local status = dep.status or "missing"
+            local glyph, text, color
+            if status == "missing" then
+                glyph, color = "x", "error"
+                text = label .. ": " .. (DEP_IMPACT[name] or "not found")
+            elseif status == "warn" then
+                glyph, color = "alert-triangle", "error"
+                text = label .. ": " .. tostring(dep.detail or "")
+            else
+                local ver = short_ver(name, dep.detail)
+                glyph, color = "check", "primary"
+                text = label .. (ver ~= "" and (": " .. ver) or "")
+            end
+            table.insert(rows, ui.row({ key = "health-row-" .. name, gap = 8, align = "center" }, {
+                ui.glyph({ name = glyph, size = 18, color = color }),
+                ui.label({ text = text, fontSize = theme.fontTitle, color = color })
+            }))
+        end
+    end
+    if #rows == 0 then
+        return nil
+    end
+    local checking = state.data.checking_health == true
+    table.insert(rows, 1, ui.row({ key = "health-header", align = "center", justify = "space_between" }, {
+        ui.label({
+            text = "HEALTHCHECK",
+            fontSize = theme.fontHeading,
+            fontWeight = "bold",
+            color = "on_surface_variant"
+        }),
+        ui.button({
+            key = "btn-health-refresh",
+            glyph = checking and "loader" or "refresh",
+            variant = "ghost",
+            controlSize = "sm",
+            tooltip = checking and "Checking dependencies..." or "Re-check dependencies",
+            onClick = checking and nil or function() request("refresh_health") end
+        })
+    }))
+    return ui.column({
+        key = "health-card",
+        gap = 6,
+        padding = 14,
+        borderWidth = 0,
+        fill = "surface_variant/0.5",
+        width = 880
+    }, rows)
+end
+
 local function build_browser_cells()
     local cells = {}
     for _, b in ipairs(BROWSERS) do
@@ -86,15 +178,7 @@ local function build_signin_prompt()
     for _, row in ipairs(common.chunk_rows(build_browser_cells(), 3, "browser-grid", 12)) do
         table.insert(browser_rows, row)
     end
-
-    return ui.column({
-        key = "signin-prompt",
-        align = "center",
-        justify = "center",
-        gap = 16,
-        padding = 40,
-        flexGrow = 1
-    }, {
+    local prompt_children = {
         ui.glyph({ name = "music", size = 48, color = "primary" }),
         ui.label({ text = "YouTube Music", fontSize = theme.fontHero, fontWeight = "bold", color = "on_surface" }),
         ui.row({ height = 4, borderWidth = 0 }),
@@ -110,7 +194,20 @@ local function build_signin_prompt()
             color = state.data.status == "error" and "error" or "primary"
         }),
         ui.column({ gap = 12, width = "fill" }, browser_rows)
-    })
+    }
+    local health_card = build_health_card()
+    if health_card then
+        table.insert(prompt_children, 3, health_card)
+    end
+
+    return ui.column({
+        key = "signin-prompt",
+        align = "center",
+        justify = "center",
+        gap = 16,
+        padding = 40,
+        flexGrow = 1
+    }, prompt_children)
 end
 
 local function build_cookies_page()
@@ -170,8 +267,12 @@ local function build_cookies_page()
     table.insert(page, ui.row({ key = "spacer-above-browser-grid", height = 4, borderWidth = 0 }))
 
     local cells = build_browser_cells()
-
-    for _, row in ipairs(common.chunk_rows(cells, 3, "browser-grid", 12)) do
+    local grid_rows = common.chunk_rows(cells, 3, "browser-grid", 12)
+    local health_card = build_health_card()
+    if health_card then
+        table.insert(grid_rows, 1, health_card)
+    end
+    for _, row in ipairs(grid_rows) do
         table.insert(page, row)
     end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `aabidk20/yt-music`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

YouTube Music client for Noctalia v5 featuring home feed recommendation radios, album/artist/song search, queue management, and offline audio downloads.

**Full commit diff**: https://github.com/aabidk20/noctalia-plugins/compare/v0.2.4...v0.2.5-rc

**Changes in 0.2.5**:
- **Rapid skipping fix**: songs skipped over are no longer fetched or played; stale resolves are killed.
- **MPV IPC race fix**: fixed a race where rapid plays could lose the control socket, leaving duration at 0:00 and transport controls dead.
- **Netcat flavor fix**: mpv control now works with both OpenBSD netcat and ncat (Fedora/RHEL default).
- **Dependency healthcheck**: login page shows a card checking yt-dlp, mpv, jq, netcat, and curl versions, staleness, and unix-socket support, with a refresh button.
- **Boot diagnostics**: debug.log now records platform, plugin/host versions, auth state, and detected browsers on every start.

## External dependencies

- `yt-dlp`: Stream URL resolving and audio download.
- `mpv` & `mpv-mpris`: Audio playback engine and MPRIS media controls integration.
- `jq`: Fast JSON parsing of InnerTube API payloads.
- `curl`: Network request dispatching and parallel image thumbnail fetching.
- `nc`: mpv socket IPC (OpenBSD netcat or ncat; traditional/busybox nc lack unix-socket support and won't work).

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0 beta 8
- **Plugin API level:** 23

## Screenshots / Videos

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
