### PR TITLE
Update nightwatch75/file-search to 0.2.0 — disk usage chart, row context menu, argv exec

### DIFF
--- a/file-search/README.md
+++ b/file-search/README.md
@@ -1,11 +1,13 @@
 # File Search
 
 A [noctalia](https://github.com/noctalia-dev/noctalia) v5 bar plugin: fuzzy
-search files and folders as you type, with [fzf](https://github.com/junegunn/fzf)
-as the matching subsystem. Click the bar glyph to open a search panel; picking
-a result opens it with the system MIME association (`xdg-open`) — directories
-open in your file manager. One button widens the search to the USB disks you
-have plugged in, or narrows it to those alone.
+search files and folders as you type, matched with
+[fzf](https://github.com/junegunn/fzf). Click the bar glyph to open a search
+panel; picking a result opens it with the system MIME association
+(`xdg-open`) — directories open in the file manager. A `/fs` launcher entry
+gives the same search with native keyboard navigation. The panel can widen
+the search to mounted USB/removable disks, and show a disk-usage donut for
+the search folder.
 
 ## Plugin
 
@@ -25,47 +27,61 @@ your compositor:
 noctalia msg panel-toggle nightwatch75/file-search:panel
 ```
 
-| Action       | Effect                                          |
-|--------------|-------------------------------------------------|
-| Left click   | Open/close the search panel                     |
-| Right click  | Open the search folder in the file manager      |
+| Action      | Effect                                     |
+|-------------|---------------------------------------------|
+| Left click  | Open/close the search panel                |
+| Right click | Open the search folder in the file manager |
 
-Middle click is not used: every bar widget carries a built-in binding for it
-that opens the widget's own settings, and a bound gesture never reaches the
-plugin. Use the panel's ⚙ button, or the command below, for the settings.
+Middle click is not handled: every bar widget carries a built-in binding for
+it that opens the widget's own settings, so a bound gesture never reaches the
+plugin. Use the panel's settings button, or the command below.
 
-In the panel:
+### The panel
 
-| Key     | Action                              |
-|---------|-------------------------------------|
-| `Enter` | Open the top match                  |
-| `Esc`   | Close the panel (noctalia default)  |
+| Key     | Action                             |
+|---------|--------------------------------------|
+| `Enter` | Open the top match                 |
+| `Esc`   | Close the panel (noctalia default) |
+
+Header buttons, left to right:
+
+| Glyph | Button | Effect |
+|---|---|---|
+| 🗠/🗺 | Ranking | Switches how matches are scored (see *Search syntax*) |
+| ◕ | Usage chart | Shows/hides the disk-usage donut |
+| 🗀 | Scope | Cycles what the search covers (see *Searching external disks*) |
+| ↻ | Refresh | Rebuilds the index (and, on the folder scope, re-measures disk usage) |
+| ⚙ | Settings | Opens this plugin's page in *Settings → Plugins* (same as `noctalia msg settings-open-plugin nightwatch75/file-search`) |
+| ✕ | Close | Closes the panel |
+
+Every choice made from these buttons (ranking, scope, usage chart shown or
+not) survives a restart. The plugin version sits next to the panel title; the
+footer shows how many results are listed, how many entries are indexed, and
+how long the last index build took.
 
 On a result row:
 
-| Action      | Effect                                                   |
-|-------------|----------------------------------------------------------|
-| Left click  | Open it with the system MIME association                 |
-| Right click | Copy its path, *or* reveal it in the file manager        |
+| Action      | Effect                                    |
+|-------------|--------------------------------------------|
+| Left click  | Open it with the system MIME association  |
+| Right click | Open the row menu                         |
 
-The 🗐/🗁 button in the panel header picks which of the two, and remembers it.
-*Reveal* opens the containing folder with the item selected. Both leave the
-panel up, so several rows can be picked off in a row. (Middle click is not an
-option: a panel row only ever receives left and right clicks.)
+| Row menu entry        | Effect                                            |
+|------------------------|----------------------------------------------------|
+| Open                   | Same as a left click                              |
+| Show in file manager   | Open the containing folder with the item selected |
+| Copy full path         | Put the absolute path on the clipboard            |
+| Copy name              | Put just the file or folder name on the clipboard |
 
-A path too long for one row is shortened in the middle rather than at the end,
-so the file name — the part the query matched — always stays readable:
+Everything but *Open* leaves the panel up, so several rows can be picked off
+in a row. A path too long for one row is shortened in the middle, keeping the
+file name (the part the query matched) readable:
 `.local/share/flatpak/repo/tmp/cache/…dolphin.idx.sig`.
-
-The plugin version sits next to the panel title. The footer counts what is
-listed and what is indexed, and on the right how long the walk behind that
-index took — per scope, kept across restarts, and still visible while a new
-walk runs, which is when knowing the last one's cost is most useful.
 
 ### Search syntax
 
-The query goes to `fzf` as-is, so its extended-search operators work here. The
-panel keeps a one-line reminder of them above the status bar.
+The query goes to `fzf` as-is, so its extended-search operators work here.
+The panel keeps a one-line reminder of them above the results.
 
 | Query | Matches |
 |---|---|
@@ -77,92 +93,92 @@ panel keeps a one-line reminder of them above the status bar.
 | `.toml$ \| .json$` | either one (spaces around the `\|` are required) |
 
 A lowercase query is case-insensitive; one uppercase letter anywhere makes it
-case-sensitive. There is no regex: fzf does not have one.
+case-sensitive. There is no regex — fzf does not have one.
 
-The 🗠/🗺 button in the header switches how matches are scored, and remembers it:
+The ranking button switches how matches are scored:
 
-| Glyph | Ranking |
+| Ranking | Effect |
 |---|---|
-| 🗺 | **path-aware** *(default)* — a match starting a file or folder name wins, so `config` finds `.ssh/config` and not the deepest `…/Steam Controller Configs/` |
-| 🗠 | generic — fzf's own scoring, which mostly rewards the shortest path |
+| **Path-aware** *(default)* | A match starting a file or folder name wins, so `config` finds `.ssh/config`, not `…/Steam Controller Configs/` |
+| Generic | fzf's own scoring, which mostly rewards the shortest path |
 
-Path-aware costs about a third more CPU per keystroke and needs fzf 0.36 or
-newer; on an older build the button stays on generic and says so.
+Path-aware needs fzf 0.36 or newer; on an older build the button stays on
+generic and its tooltip says why.
 
 ### Searching external disks
 
-The 🗀 button in the panel header cycles what the search covers:
-
-| Glyph | Scope | Covers |
-|-------|-------|--------|
-| 🗀 | Search folder only *(default)* | The `search_folder` setting, as before |
-| 🗀🗀 | Search folder + external disks | Both, in one index |
-| ⚿ | External disks only | Only the mounted removable volumes |
+| Scope | Covers |
+|---|---|
+| Search folder only *(default)* | The `search_folder` setting |
+| Search folder + external disks | Both, in one index |
+| External disks only | Only the mounted removable volumes |
 
 An *external disk* is a mounted volume that came from a USB port or reports
-itself removable: sticks and drives (bus-powered SSDs and LUKS-encrypted ones
-included), SD cards, optical media. Internal drives never count, not even a
-second SATA/NVMe under `/mnt` — put that in `search_folder` instead. The plugin
-mounts nothing; it only sees what your desktop has already mounted.
+itself removable: sticks, bus-powered SSDs, LUKS-encrypted drives, SD cards,
+optical media. Internal drives never count — put those in `search_folder`
+instead. The plugin mounts nothing; it only sees what your desktop already
+mounted. When disks are in scope, the scope button's tooltip also shows free
+space across them.
 
-The choice survives restarts and is shared with the `/fs` launcher, which offers
-the same switch. Each scope keeps its own index, so switching to the disks and
-back does not re-walk your home folder.
+The scope choice is shared with the `/fs` launcher, and each scope keeps its
+own index — switching to the disks and back never re-walks the search
+folder.
 
-**External disks are only ever indexed on command**, because walking a
-multi-terabyte drive takes minutes. Switching scope, opening the panel, changing
-a setting or plugging a disk in never start a walk: the index stays in use and
-the footer says *out of date*. The ↻ button (or *Rebuild search index* in the
-launcher) is what rebuilds it, and a scope never indexed says so and waits. The
-search folder alone keeps re-indexing itself, as before — it takes seconds.
+**External disks are only ever indexed on command.** Opening the panel,
+switching scope, changing a setting or plugging a disk in never starts a
+walk on a disk scope — the index stays as-is and the footer says *out of
+date*. Press refresh (or *Rebuild search index* in the launcher) to walk it.
+The search folder alone keeps re-indexing itself automatically, since that
+takes seconds rather than minutes.
 
-The panel header also carries a ⚙ button that opens this plugin's page in
-*Settings → Plugins*, and a ↻ button that rebuilds the index. The same settings
-page opens from the command line, so it can be bound in your compositor too:
+### Disk usage chart
 
-```sh
-noctalia msg settings-open-plugin nightwatch75/file-search
+A donut under the results shows what fills the search folder: its biggest
+direct children, the rest folded into *other*, and loose files that belong
+to no subfolder. Each legend row gives the size and share of the total. It
+is only offered on the *search folder* scope, since measuring a disk means
+walking it — exactly what this plugin refuses to do unasked.
+
+Click a folder in the legend to search inside it: results narrow to that
+folder, a strip above them names it, and clicking the strip's ✕ (or the same
+row again) lifts the restriction. It combines with whatever you type — pick
+`winboat`, type `img`, get `winboat/data.img`.
+
+Sizes come from `du -x -d1`, measured once and cached for a day, so restarts
+and reopens cost nothing (`du` over a home directory takes a few seconds).
+The refresh button re-measures immediately. Other filesystems are never
+walked — a mount point under the search folder is skipped and named in the
+legend as *not counted: … (other filesystem)*. The `usage_exclude_dirs`
+setting keeps `du` out of specific, slow-but-same-filesystem folders instead.
+
+### Launcher
+
+```
+/fs <text>
 ```
 
-In the noctalia launcher (keyboard-first flow, native navigation):
+| Key       | Action                                   |
+|-----------|--------------------------------------------|
+| ↑ / ↓     | Move through the results                  |
+| `Enter`   | Open the selected result (MIME/`xdg-open`) |
 
-| Key         | Action                                    |
-|-------------|-------------------------------------------|
-| `/fs <text>`| Fuzzy search files and folders            |
-| `↑` / `↓`   | Move through the results                  |
-| `Enter`     | Open the selected result (MIME/xdg-open)  |
-
-With an empty `/fs` query the list also offers *Rebuild search index* and the
-scope switch; the index is shared with the panel. *Rebuild search index* walks
-the tree there and then, keeping the launcher open, and is offered next to the
+An empty `/fs` query also offers *Rebuild search index* and the scope
+switch; the index is shared with the panel. *Rebuild search index* walks the
+tree right away, keeping the launcher open, and is offered next to the
 results whenever the index is out of date.
 
 ## Features
 
 - Live results while you type: the search folder is walked once with `find`
-  into a cache, then every keystroke is fuzzy-matched through
-  `fzf --filter`, so typing stays responsive even on large trees
-- Configurable bar glyph, search folder (defaults to `~`), excluded folder
-  names (`.git, node_modules, .cache, .venv` by default, matched anywhere in
-  the tree), hidden entries on/off, max results
-- One button to search the mounted USB/removable disks as well, or only those:
-  one index per scope, and disks walked only when you ask
-- `Enter` opens the top match; every result row opens on click via the
-  system MIME association — files in their default app, folders in the file
-  manager
-- Launcher provider for a keyboard-first flow: type `/fs <text>` in the
-  noctalia launcher and navigate the results with the native arrow keys +
-  `Enter` (plugin panels cannot receive arrow keys in the current Luau API,
-  so the launcher is the keyboard way to browse results)
+  into a cache, then every keystroke is fuzzy-matched with `fzf --filter`
+- Configurable search folder (defaults to `~`), excluded folder names, hidden
+  entries on/off, max results, and bar glyph
 - Folder results are marked with a trailing `/` and a folder glyph
-- Right click copies a result's path, or reveals it in the file manager with the
-  item selected (`org.freedesktop.FileManager1.ShowItems` — Thunar, Nautilus,
-  Dolphin, Nemo, Caja and PCManFM-Qt all implement it)
-- The search-folder index rebuilds itself when the relevant settings change, and
-  on demand via the panel's refresh button; any index covering an external disk
-  rebuilds on demand only
+- Reveal in file manager uses `org.freedesktop.FileManager1.ShowItems`
+  (Thunar, Nautilus, Dolphin, Nemo, Caja, PCManFM-Qt); falls back to opening
+  the containing folder if no file manager implements it
 - Panel placement (attached/floating), position and open-near-click are the
-  standard per-panel settings noctalia exposes in Settings → Plugins
+  standard per-panel settings noctalia exposes in *Settings → Plugins*
 
 ## Settings
 
@@ -171,25 +187,30 @@ results whenever the index is out of date.
 | `search_folder` | `folder` | *(empty)* | Root folder the search indexes. Empty = your home folder. |
 | `exclude_dirs` | `string` | `.git, node_modules, .cache, .venv` | Folder names skipped while indexing, separated by `,` or `;`, matched anywhere in the tree. |
 | `show_hidden` | `bool` | `false` | Index files and folders whose name starts with a dot. |
+| `usage_exclude_dirs` | `string` | *(empty)* | Folders left out of the disk usage chart, separated by `,` or `;`. A bare name matches anywhere below the search folder; a path (absolute, or starting with `~`) matches that one folder. Folders on another filesystem are already skipped. |
 | `max_results` | `int` | `50` | How many matches the panel lists at most (10–200). |
 | `glyph` (widget) | `glyph` | `search` | Icon shown on the bar. |
 
 ## Requirements
 
-- noctalia v5.0.0-beta.6 or newer — the first tagged release that accepts
-  `plugin_api = 15` (`noctalia.openSettings()`, the panel's ⚙ button)
+- noctalia with `plugin_api = 28` (v5.0.0-beta.9 or newer; on beta.8 the
+  plugin store keeps serving 0.0.29) — for the row context menu, relative
+  Luau imports (the three entries share `shared.luau`) and direct argv
+  process execution, so `du`, `xdg-open` and the reveal call take their
+  arguments with no shell parsing them
 - [`fzf`](https://github.com/junegunn/fzf) — the fuzzy matcher. 0.36 or newer
-  for the path-aware ranking; older builds work, with fzf's default ranking
+  for path-aware ranking; older builds work with fzf's default ranking
 - `find` (GNU findutils) — walks the roots into the index
 - `xdg-open` (xdg-utils) — opens results with the MIME association
-- `mktemp`, `mv`, `wc`, `head`, `rm`, `date` — GNU coreutils, standard on any
-  Linux desktop (`date` times the index walk for the footer)
-- `lsblk` (util-linux) — lists the mounted USB/removable volumes; only run when
+- `mktemp`, `mv`, `wc`, `head`, `rm`, `date`, `du` — GNU coreutils, standard
+  on any Linux desktop. Missing `du`, the usage chart says so; everything
+  else still works
+- `lsblk` (util-linux) — lists mounted USB/removable volumes, only run when
   the scope includes them. Missing, it falls back to `/proc/mounts` and the
   udisks2 layout (`/run/media/<user>/…`, `/media/…`)
-- `gdbus` (glib2) — reveals a result in the file manager
-  (`FileManager1.ShowItems`); only run on that right click. Missing, or with no
-  file manager implementing it, the click opens the containing folder instead
+- `gdbus` (glib2) — reveals a result in the file manager. Missing, or with no
+  file manager implementing `FileManager1`, *Show in file manager* opens the
+  containing folder instead
 
 ## Install
 
@@ -209,49 +230,31 @@ noctalia msg plugins enable nightwatch75/file-search
 
 - The index lives in the plugin's private data directory
   (`noctalia.pluginDataDir()`, by default
-  `~/.local/state/noctalia/plugins/data/nightwatch75/file-search/` — honors
-  `NOCTALIA_STATE_HOME`/`XDG_STATE_HOME`): `list-<scope>` is a plain list of
-  paths, `meta-<scope>` records the scope, roots and exclusions that built it,
-  `count-<scope>` its line count and the walk's duration in milliseconds, and
-  `scope`, `row-action` and `ranking` the one word each
-  header toggle cycles. A fingerprint that no longer matches — a settings
-  change, a scope change, a disk plugged in or removed — rebuilds the
-  search-folder index automatically and marks a disk index out of date.
+  `~/.local/state/noctalia/plugins/data/nightwatch75/file-search/`):
+  `list-<scope>` is the plain list of paths, `meta-<scope>` the fingerprint
+  it was built with, `count-<scope>` its entry count and build time, and
+  `scope`/`ranking`/`usage-chart` the one-word header choices. The disk usage
+  measurement is cached in `usage.json`, rendered as one of two alternating
+  SVG files. A fingerprint mismatch (a settings change, a scope change, a
+  disk plugged in or removed) rebuilds the search-folder index automatically
+  and marks a disk index out of date.
 - Several disks share one index, not one each: a rebuild walks every mounted
-  volume in a single pass. Records are relative to the root when there is only
-  one (the common case, and what keeps the rows short) and absolute when there
-  are several — and they are always read the way the index was *written*, so
-  unplugging one of two disks leaves the rest of the results openable.
-- Volume metadata is pruned at every root, since a disk used on Windows or macOS
-  otherwise contributes tens of thousands of records that are not your files:
-  `lost+found`, `$RECYCLE.BIN`, `RECYCLER`, `System Volume Information`,
-  `.Trash-*`, `.Spotlight-V100`, `.fseventsd`, `.Trashes`, `.TemporaryItems`,
-  `.DocumentRevisions-V100`, `Backups.backupdb`, `*.sparsebundle`,
-  `*.backupbundle`, `._*`, `.DS_Store`, `.AppleDouble`, `.AppleDB`,
-  `.AppleDesktop`, `Network Trash Folder`, `Temporary Items`,
-  `TheVolumeSettingsFolder`.
-- `find` is bound by metadata latency, so a spinning USB drive with a million
-  files runs for minutes — hence on-demand only. A walk covering disks gets 30
-  minutes against 3 for the search folder, and the panel stays usable
-  throughout, scope button included: a second walk is never queued.
-- Cheap by design elsewhere too: the mount scan is cached 30 seconds and never
-  concurrent, and the line count comes from a `count-<scope>` sidecar instead of
-  re-reading a >100 MB index.
-- Detection reads the transport and removable flags of the parent disk, not of
-  the mounted partition — a USB partition reports neither. NVMe and SATA drives
-  advertising hot-plug are deliberately not treated as removable.
-- Both files are written to `mktemp`-created private files and renamed into
-  place, so a rebuild never writes through a symlink planted at the cache
-  path.
-- Names containing a newline are excluded from the index (they would break
-  the one-record-per-line format), and every record is validated against the
-  roots it claims to come from before being opened.
-- Excluded entries match by folder/file *name* (`find -name`), not by path;
-  entries containing `/` are skipped and logged.
-- With hidden entries off, anything starting with a dot is pruned — both
-  hidden folders (not descended into) and hidden files.
-- Unreadable subtrees are silently skipped (permission errors don't fail the
-  index).
+  volume in a single pass, unplugging one still leaves the rest openable.
+- Volume metadata from other operating systems is pruned at every root
+  (`lost+found`, `$RECYCLE.BIN`, `System Volume Information`, `.Trash-*`,
+  macOS Spotlight/Time Machine/AppleDouble leftovers, and similar), since it
+  is never a user file and can otherwise add tens of thousands of records.
+- `find` is bound by metadata latency, so a spinning USB drive with a
+  million files can run for minutes — hence indexed on command only. A walk
+  covering disks gets 30 minutes against 3 for the search folder; the panel
+  stays usable throughout.
+- Both the index and its fingerprint are written to temp files and renamed
+  into place, so a rebuild never writes through a symlink at the cache path.
+- Names containing a newline are excluded from the index, and every record
+  is validated against the roots it claims to come from before being opened.
+- Excluded entries match by folder/file name (`find -name`), not by path;
+  entries containing `/` are skipped and logged. Unreadable subtrees are
+  silently skipped.
 
 ## License
 

--- a/file-search/file-search.luau
+++ b/file-search/file-search.luau
@@ -16,29 +16,16 @@
 
 local PANEL_ID = "nightwatch75/file-search:panel"
 
+-- Only for searchRoot() and openPath(): the widget shows the folder in its
+-- tooltip and opens it on a right click, and both have to mean exactly what
+-- they mean in the panel (plugin_api >= 22 for the relative import).
+local shared = require("./shared.luau")
+
 local open = false
-
-local function shellQuote(value)
-    return "'" .. value:gsub("'", "'\\''") .. "'"
-end
-
-local function searchRoot()
-    local dir = noctalia.getConfig("search_folder")
-    if dir == nil or dir == "" then
-        dir = noctalia.getenv("HOME") or "/tmp"
-    else
-        dir = noctalia.expandPath(dir)
-    end
-    dir = dir:gsub("/+$", "")
-    if dir == "" then
-        dir = "/"
-    end
-    return dir
-end
 
 local function render()
     barWidget.setGlyph(noctalia.getConfig("glyph"))
-    local root = searchRoot()
+    local root = shared.searchRoot()
     if open then
         barWidget.setGlyphColor("primary")
         barWidget.setTooltip(noctalia.tr("tooltip_open", { path = root }))
@@ -63,7 +50,7 @@ function onClick()
 end
 
 function onRightClick()
-    noctalia.runAsync("xdg-open " .. shellQuote(searchRoot()) .. " >/dev/null 2>&1")
+    shared.openPath(shared.searchRoot())
 end
 
 noctalia.setUpdateInterval(1000)

--- a/file-search/launcher.luau
+++ b/file-search/launcher.luau
@@ -13,378 +13,24 @@
 -- a row that cycles it here too, and each scope keeps its own index, so
 -- switching back and forth never re-walks a tree twice.
 --
--- Every helper below the tr() line down to computeRoots() is a copy of the
--- panel's: entries are separate scripts with no module system, so the two must
--- be kept in step by hand — in particular indexKey(), which is the fingerprint
--- that lets one entry reuse an index the other built.
+-- The index itself, the fingerprint that identifies it and every helper around
+-- both live in shared.luau, required below (plugin_api >= 22) and shared with
+-- panel.luau: whichever entry built the index, the other recognizes it.
 
 local MAX_RESULTS = 9
-local INDEX_FORMAT = "2"
--- Seconds a mount scan stays good for. Long enough that a burst of keystrokes
--- costs one lsblk at most, short enough that a disk plugged in mid-session
--- shows up without a manual refresh.
-local MOUNT_TTL = 30
 
-local VOLUME_NOISE = {
-    "lost+found",
-    "$RECYCLE.BIN", "RECYCLER", "System Volume Information",
-    ".Trash-*",
-    ".Spotlight-V100", ".fseventsd", ".Trashes", ".TemporaryItems",
-    ".DocumentRevisions-V100", ".PKInstallSandboxManager",
-    "Backups.backupdb", "*.sparsebundle", "*.backupbundle",
-    "._*", ".DS_Store", ".AppleDouble", ".AppleDB", ".AppleDesktop",
-    "Network Trash Folder", "Temporary Items", "TheVolumeSettingsFolder",
-}
-
-local SCOPE_GLYPHS = { folder = "folder", all = "folders", external = "usb" }
-local NEXT_SCOPE = { folder = "all", all = "external", external = "folder" }
-local DEFAULT_SCOPE = "folder"
-
-local BUILD_TIMEOUT_LOCAL = 180000
-local BUILD_TIMEOUT_DISKS = 1800000
+local shared = require("./shared.luau")
 
 local searching = false
 local indexing = false
-local probing = false
 local forceBuild = false -- set by the rebuild row, consumed by the next onQuery
 local pendingQuery = nil -- latest query typed while a search/index/probe ran
-local scope = DEFAULT_SCOPE
-local mounts = {}
-local mountsAt = 0       -- unix seconds of the last mount scan (0 = never)
-local roots = {}
-local indexRoots = {}    -- what the index ON DISK was built with (indexRootsOf)
-local absoluteRecords = false
 local staleIndex = false -- searching an index that no longer matches the disks
-local ranking = "path"   -- scoring scheme, as persisted by the panel's toggle
-local schemeSupported = false -- whether this fzf understands --scheme at all
 
 local runQuery
 
-local function tr(key, args)
-    return noctalia.tr(key, args)
-end
-
-local function trim(value)
-    return (value:gsub("^%s+", ""):gsub("%s+$", ""))
-end
-
-local function shellQuote(value)
-    return "'" .. value:gsub("'", "'\\''") .. "'"
-end
-
-local function startsWith(value, prefix)
-    return value:sub(1, #prefix) == prefix
-end
-
-local function now()
-    return tonumber(noctalia.formatTime("%s")) or 0
-end
-
--- Same version gate as the panel: fzf learned --scheme in 0.36 and an older one
--- would exit on an unknown option, leaving the launcher with an empty list.
-local function probeFzfScheme()
-    noctalia.runAsync("fzf --version 2>/dev/null", function(result)
-        local major, minor = (result.stdout or ""):match("(%d+)%.(%d+)")
-        major, minor = tonumber(major), tonumber(minor)
-        schemeSupported = major ~= nil and minor ~= nil and (major > 0 or minor >= 36)
-    end, 5000)
-end
-
-local function rankingFlag()
-    return (ranking == "path" and schemeSupported) and " --scheme=path" or ""
-end
-
--- The panel owns the toggle; the launcher just follows what it wrote, re-read
--- per query like the scope so the two never rank the same index differently.
-local function readRanking(dir)
-    local raw = noctalia.readFile(dir .. "/ranking")
-    if type(raw) == "string" then
-        local value = trim(raw)
-        if value == "path" or value == "default" then
-            return value
-        end
-    end
-    return "path"
-end
-
--- Mirrors the panel: the search folder may be re-walked whenever its
--- fingerprint goes stale, an external disk never is. A 5 TB mechanical drive
--- takes minutes per walk, and a keystroke is not a mandate to spend them — the
--- rebuild row below is.
-local function autoIndexAllowed()
-    return scope == "folder"
-end
-
--- Private per-plugin storage (XDG state); the host creates the directory on
--- every call. nil (with a log line) when no state directory resolves.
-local function dataDir()
-    local dir, err = noctalia.pluginDataDir()
-    if dir == nil then
-        noctalia.log("file-search: pluginDataDir failed: " .. tostring(err))
-        return nil
-    end
-    return dir
-end
-
--- Shell header shared by every cache command. One cache pair per scope; the
--- .meta sidecar holds the settings fingerprint the cache was built with, so the
--- panel and the launcher can both tell a stale index apart.
-local function cacheSh(dir)
-    return "CACHE_DIR=" .. shellQuote(dir)
-        .. '\nCACHE="$CACHE_DIR/list-' .. scope .. '"'
-        .. '\nMETA="$CACHE_DIR/meta-' .. scope .. '"'
-        .. '\nCOUNTF="$CACHE_DIR/count-' .. scope .. '"'
-end
-
-local function readScope(dir)
-    local raw = noctalia.readFile(dir .. "/scope")
-    if type(raw) == "string" then
-        local value = trim(raw)
-        if SCOPE_GLYPHS[value] ~= nil then
-            return value
-        end
-    end
-    return DEFAULT_SCOPE
-end
-
-local function writeScope(dir, value)
-    local ok, err = noctalia.writeFile(dir .. "/scope", value)
-    if not ok then
-        noctalia.log("file-search: could not persist the scope: " .. tostring(err))
-    end
-end
-
-local function searchRoot()
-    local dir = noctalia.getConfig("search_folder")
-    if dir == nil or dir == "" then
-        dir = noctalia.getenv("HOME") or "/tmp"
-    else
-        dir = noctalia.expandPath(dir)
-    end
-    dir = dir:gsub("/+$", "")
-    if dir == "" then
-        dir = "/"
-    end
-    return dir
-end
-
-
--- Same exclusion set as the panel: names from the setting plus hidden
--- entries unless enabled.
-local function excludeNames()
-    local raw = noctalia.getConfig("exclude_dirs")
-    if type(raw) ~= "string" then
-        raw = ""
-    end
-    local names = {}
-    for entry in raw:gmatch("[^,;]+") do
-        local name = trim(entry)
-        if name ~= "" and not name:find("/") then
-            table.insert(names, name)
-        end
-    end
-    if noctalia.getConfig("show_hidden") ~= true then
-        table.insert(names, ".*")
-    end
-    return names
-end
-
--- ── removable volume detection (mirrors panel.luau) ──────────────────────────
-
-local function usableMount(path)
-    if path == nil or path == "" or path:sub(1, 1) ~= "/" then
-        return false
-    end
-    if path == "/" or path:find("%c") ~= nil then
-        return false
-    end
-    return path ~= "/boot" and not startsWith(path, "/boot/")
-end
-
--- nil for an escaped control byte, so the caller drops that mount point
--- entirely (see panel.luau).
-local function unescapeHex(value)
-    local rejected = false
-    local out = value:gsub("\\x(%x%x)", function(hex)
-        local code = tonumber(hex, 16)
-        if code == nil or code < 32 or code == 127 then
-            rejected = true
-            return ""
-        end
-        return string.char(code)
-    end)
-    if rejected then
-        return nil
-    end
-    return out
-end
-
-local function pairValue(line, key)
-    return (" " .. line):match(" " .. key .. '="(.-)"')
-end
-
--- USB/removable mount points. The transport lives on the disk, not on the
--- mounted partition, so the PKNAME chain is walked upwards; see the long
--- comment in panel.luau.
-local function parseLsblk(out)
-    local rows, byName = {}, {}
-    for line in out:gmatch("[^\n]+") do
-        local name = pairValue(line, "NAME")
-        if name ~= nil and name ~= "" then
-            local row = {
-                parent = pairValue(line, "PKNAME") or "",
-                removable = pairValue(line, "RM") == "1",
-                transport = pairValue(line, "TRAN") or "",
-                mount = unescapeHex(pairValue(line, "MOUNTPOINT") or ""),
-            }
-            byName[name] = row
-            table.insert(rows, row)
-        end
-    end
-    local found = {}
-    for _, row in ipairs(rows) do
-        if usableMount(row.mount) then
-            local node, depth = row, 0
-            while node ~= nil and depth < 4 do
-                if node.transport == "usb" or node.removable then
-                    table.insert(found, row.mount)
-                    break
-                end
-                node = (node.parent ~= "") and byName[node.parent] or nil
-                depth += 1
-            end
-        end
-    end
-    return found
-end
-
--- Fallback for a system without util-linux: the udisks2 mount convention.
-local function fallbackMounts()
-    local text = noctalia.readFile("/proc/mounts")
-    if type(text) ~= "string" then
-        return {}
-    end
-    local found = {}
-    for line in text:gmatch("[^\n]+") do
-        local raw = line:match("^%S+%s+(%S+)%s")
-        if raw ~= nil then
-            local rejected = false
-            local path = raw:gsub("\\(%d%d%d)", function(octal)
-                local code = tonumber(octal, 8)
-                if code == nil or code < 32 or code == 127 then
-                    rejected = true
-                    return ""
-                end
-                return string.char(code)
-            end)
-            if rejected then
-                path = ""
-            end
-            local rest = path:match("^/run/media/[^/]+/(.+)$") or path:match("^/media/(.+)$")
-            if rest ~= nil and rest ~= "" and usableMount(path) then
-                table.insert(found, path)
-            end
-        end
-    end
-    return found
-end
-
-local function computeRoots()
-    local list = {}
-    if scope ~= "external" then
-        table.insert(list, searchRoot())
-    end
-    if scope ~= "folder" then
-        for _, mount in ipairs(mounts) do
-            table.insert(list, (mount:gsub("/+$", "")))
-        end
-    end
-    table.sort(list)
-    local kept = {}
-    for _, path in ipairs(list) do
-        local nested = false
-        for _, parent in ipairs(kept) do
-            if path == parent or startsWith(path, parent == "/" and "/" or parent .. "/") then
-                nested = true
-                break
-            end
-        end
-        if path ~= "" and not nested then
-            table.insert(kept, path)
-        end
-    end
-    return kept
-end
-
--- Must build the same string as the panel's indexKey(): the fingerprint in
--- the .meta sidecar is how the two entries recognize each other's index.
-local function indexKey()
-    return INDEX_FORMAT .. "\n" .. scope
-        .. "\n--\n" .. table.concat(roots, "\n")
-        .. "\n--\n" .. table.concat(excludeNames(), "\n")
-end
-
--- The cache on disk is current when its fingerprint matches the settings,
--- whether the panel or the launcher built it.
-local function cacheFresh(dir)
-    return noctalia.readFile(dir .. "/meta-" .. scope) == indexKey()
-end
-
--- The roots the index on disk was built with, read back out of its fingerprint
--- (see panel.luau): records must be read the way they were written, or unplug
--- one of two disks and every row stops resolving until the next rebuild.
-local function indexRootsOf(dir)
-    local meta = noctalia.readFile(dir .. "/meta-" .. scope)
-    if type(meta) ~= "string" then
-        return nil
-    end
-    local section = meta:match("\n%-%-\n(.-)\n%-%-\n")
-    if section == nil then
-        return nil
-    end
-    local list = {}
-    for line in section:gmatch("[^\n]+") do
-        table.insert(list, line)
-    end
-    return #list > 0 and list or nil
-end
-
--- One cache record, about to be turned into a path. The cache is a plain
--- user-editable file, so records are untrusted: reject anything that could
--- resolve outside the roots it claims to come from.
-local function absolutePath(record)
-    if record == "" or record:find("%c") ~= nil then
-        return nil
-    end
-    local path = record:gsub("/+$", "")
-    for part in path:gmatch("[^/]+") do
-        if part == ".." then
-            return nil
-        end
-    end
-    -- Against the roots of the index the record came from, not of a walk that
-    -- would happen now: a record can still never escape a root.
-    local from = #indexRoots > 0 and indexRoots or roots
-    if absoluteRecords then
-        for _, root in ipairs(from) do
-            if startsWith(path, root == "/" and "/" or root .. "/") then
-                return path
-            end
-        end
-        return nil
-    end
-    local root = from[1]
-    if root == nil or path == "" or path:sub(1, 1) == "/" then
-        return nil
-    end
-    if root == "/" then
-        return root .. path
-    end
-    return root .. "/" .. path
-end
-
 local function noopRow(titleKey)
-    return { id = "noop", title = tr(titleKey), glyph = "info-circle" }
+    return { id = "noop", title = shared.tr(titleKey), glyph = "info-circle" }
 end
 
 -- Row that cycles the scope, offered whenever the query is empty (and whenever
@@ -393,9 +39,9 @@ end
 local function scopeRow()
     return {
         id = "scope",
-        title = tr("launcher.scope_title", { current = tr("scope." .. scope) }),
-        subtitle = tr("launcher.scope_next", { next = tr("scope." .. NEXT_SCOPE[scope]) }),
-        glyph = SCOPE_GLYPHS[scope],
+        title = shared.tr("launcher.scope_title", { current = shared.tr("scope." .. shared.scope) }),
+        subtitle = shared.tr("launcher.scope_next", { next = shared.tr("scope." .. shared.NEXT_SCOPE[shared.scope]) }),
+        glyph = shared.SCOPE_GLYPHS[shared.scope],
     }
 end
 
@@ -405,8 +51,8 @@ end
 local function reindexRow()
     return {
         id = "reindex",
-        title = tr("launcher.reindex_title"),
-        subtitle = #roots > 0 and table.concat(roots, "  ·  ") or tr("scope." .. scope),
+        title = shared.tr("launcher.reindex_title"),
+        subtitle = #shared.roots > 0 and table.concat(shared.roots, "  ·  ") or shared.tr("scope." .. shared.scope),
         glyph = "refresh",
     }
 end
@@ -416,12 +62,12 @@ local function buildIndex(query)
         pendingQuery = query
         return
     end
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir == nil then
         launcher.setResults(query, { noopRow("err_index") })
         return
     end
-    if #roots == 0 then
+    if #shared.roots == 0 then
         -- Scope "external" with nothing plugged in: nothing to walk, and no
         -- cache to write either. Say so, and keep the row that switches back.
         launcher.setResults(query, { noopRow("no_external"), scopeRow() })
@@ -430,67 +76,24 @@ local function buildIndex(query)
     indexing = true
     pendingQuery = query
 
-    local key = indexKey()
+    local key = shared.indexKey()
     -- The format this walk writes follows the roots it is about to visit.
-    local builtRoots = roots
+    local builtRoots = shared.roots
     local absolute = #builtRoots > 1
-    local builtScope = scope
-    -- Names containing a newline would each forge extra one-per-fragment
-    -- records (a crafted name can smuggle '..' lines into the index), so
-    -- they are pruned unconditionally, before the volume noise and the user's
-    -- own exclusions.
-    local names = { "-name " .. shellQuote("*\n*") }
-    for _, pattern in ipairs(VOLUME_NOISE) do
-        table.insert(names, "-iname " .. shellQuote(pattern))
-    end
-    for _, name in ipairs(excludeNames()) do
-        table.insert(names, "-name " .. shellQuote(name))
-    end
-    local prune = "\\( " .. table.concat(names, " -o ") .. " \\) -prune -o "
-    local args = {}
-    for _, root in ipairs(roots) do
-        table.insert(args, shellQuote(root))
-    end
-    -- Relative records for a single root (short rows, and no common prefix for
-    -- fzf to match on), absolute when several roots share one index.
-    local printSpec = absolute
-        and "-type d -printf '%p/\\n' -o -printf '%p\\n'"
-        or "-type d -printf '%P/\\n' -o -printf '%P\\n'"
-    local walk = "find " .. table.concat(args, " ") .. " -mindepth 1 " .. prune
-        .. printSpec .. ' > "$TMP" 2>/dev/null'
-    -- find's own exit status is ignored, so permission errors inside the
-    -- tree don't fail the build. Cache and fingerprint are written to
-    -- mktemp-created private files and renamed into place: rename replaces
-    -- a planted symlink at the destination instead of following it. The
-    -- host guarantees $CACHE_DIR exists (created by pluginDataDir above).
-    local cmd = cacheSh(dir)
-        .. '\nrm -f "$CACHE_DIR/index.list" "$CACHE_DIR/index.meta"\n'
-        .. 'find "$CACHE_DIR" -maxdepth 1 \\( -name \'list-*.*\' -o -name \'meta-*.*\''
-        .. " -o -name 'count-*.*' \\) -mmin +90 -delete 2>/dev/null\n"
-        .. 'START=$(date +%s%3N)\n'
-        .. 'TMP=$(mktemp "$CACHE_DIR/list-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. walk .. "\n"
-        .. 'mv -f "$TMP" "$CACHE" || exit 1\n'
-        .. 'TMPM=$(mktemp "$CACHE_DIR/meta-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. "printf '%s' " .. shellQuote(key) .. ' > "$TMPM"\n'
-        .. 'mv -f "$TMPM" "$META" || exit 1\n'
-        -- Same count sidecar the panel's footer reads — count and elapsed
-        -- milliseconds — written while the file is hot so nobody has to re-read
-        -- 100 MB to show a number.
-        .. 'COUNT=$(wc -l < "$CACHE") || exit 1\n'
-        .. 'ELAPSED=$(( $(date +%s%3N) - START ))\n'
-        .. 'TMPN=$(mktemp "$CACHE_DIR/count-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. 'printf "%s %s" "$COUNT" "$ELAPSED" > "$TMPN"\n'
-        .. 'mv -f "$TMPN" "$COUNTF" || exit 1'
+    local builtScope = shared.scope
+    -- The same walk the panel runs, from the same builder: the index and the
+    -- count sidecar it leaves behind are readable by either entry. Its stdout
+    -- (count and elapsed milliseconds) is only of use to the panel's footer,
+    -- so it is ignored here.
+    local cmd = shared.buildCommand(dir, key, absolute)
 
     launcher.setResults(query, { noopRow("launcher.indexing") })
-    local timeout = (scope == "folder") and BUILD_TIMEOUT_LOCAL or BUILD_TIMEOUT_DISKS
     local ok = noctalia.runAsync(cmd, function(result)
         indexing = false
         local queued = pendingQuery
         pendingQuery = nil
         if result.exitCode == 0 and not result.timedOut then
-            if builtScope ~= scope then
+            if builtScope ~= shared.scope then
                 -- The scope row was activated while the walk ran: this index
                 -- is not the one the launcher is showing. Start the query over
                 -- so roots, records and freshness are derived for the scope
@@ -499,12 +102,12 @@ local function buildIndex(query)
             else
                 -- The file on disk is the one this walk just wrote: read it
                 -- the way it was written.
-                indexRoots = builtRoots
-                absoluteRecords = absolute
-                if indexKey() == key then
+                shared.indexRoots = builtRoots
+                shared.absoluteRecords = absolute
+                if shared.indexKey() == key then
                     staleIndex = false
                     runQuery(queued or query)
-                elseif autoIndexAllowed() then
+                elseif shared.autoIndexAllowed() then
                     -- Roots or exclusions moved during the walk; chasing that
                     -- is fine for the search folder.
                     buildIndex(queued or query)
@@ -518,7 +121,7 @@ local function buildIndex(query)
         else
             launcher.setResults(queued or query, { noopRow("err_index") })
         end
-    end, timeout)
+    end, shared.buildTimeout())
     if not ok then
         indexing = false
         launcher.setResults(query, { noopRow("err_spawn") })
@@ -534,27 +137,20 @@ runQuery = function(query)
         pendingQuery = query
         return
     end
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir == nil then
         launcher.setResults(query, { noopRow("err_index") })
         return
     end
-    local text = trim(query)
-    if #roots == 0 then
+    local text = shared.trim(query)
+    if #shared.roots == 0 then
         -- Scope "external" with nothing plugged in: say so, and keep the row
         -- that switches back within reach.
         launcher.setResults(query, { noopRow("no_external"), scopeRow() })
         return
     end
     searching = true
-    local cmd
-    if text == "" then
-        cmd = cacheSh(dir) .. '\nhead -n ' .. MAX_RESULTS .. ' "$CACHE" 2>/dev/null'
-    else
-        cmd = cacheSh(dir) .. "\nfzf" .. rankingFlag() .. " --filter=" .. shellQuote(text)
-            .. ' < "$CACHE" 2>/dev/null | head -n ' .. MAX_RESULTS
-    end
-    local ok = noctalia.runAsync(cmd, function(result)
+    local ok = noctalia.runAsync(shared.searchCommand(dir, text, MAX_RESULTS), function(result)
         searching = false
         local rows = {}
         if not result.timedOut then
@@ -595,45 +191,32 @@ end
 -- Refresh the mount list if the scope needs it and the last scan has aged out,
 -- then continue with whatever query is current by then. With the default scope
 -- no process is spawned at all.
+--
+-- The scan itself is shared.probeMounts; what stays here is the query echo the
+-- launcher runs on. A keystroke arriving while a scan is in flight parks its
+-- query instead of starting a second scan, and the continuation below picks up
+-- whichever query is the latest by the time lsblk answers.
 local function withMounts(query, done)
-    if scope == "folder" then
-        mounts = {}
-        done(query)
-        return
-    end
-    if mountsAt > 0 and (now() - mountsAt) < MOUNT_TTL then
-        done(query)
-        return
-    end
-    if probing then
+    if shared.probeBusy() then
         pendingQuery = query
         return
     end
-    probing = true
-    local function finish()
-        probing = false
-        mountsAt = now()
+    -- shared.probeMounts calls back synchronously when it has nothing to scan
+    -- (the search-folder scope, or a scan still inside MOUNT_TTL). Nothing can
+    -- have been parked in between, so `pendingQuery` is not this call's to
+    -- read: it may belong to a build or a search still in flight, and taking it
+    -- here would hand that older text back and lose the one just typed.
+    local immediate = true
+    shared.probeMounts(false, function()
+        if immediate then
+            done(query)
+            return
+        end
         local queued = pendingQuery
         pendingQuery = nil
         done(queued or query)
-    end
-    if not noctalia.commandExists("lsblk") then
-        mounts = fallbackMounts()
-        finish()
-        return
-    end
-    local ok = noctalia.runAsync("lsblk -P -o NAME,PKNAME,RM,TRAN,MOUNTPOINT 2>/dev/null", function(result)
-        if result.exitCode == 0 and not result.timedOut then
-            mounts = parseLsblk(result.stdout or "")
-        else
-            mounts = fallbackMounts()
-        end
-        finish()
-    end, 10000)
-    if not ok then
-        mounts = fallbackMounts()
-        finish()
-    end
+    end)
+    immediate = false
 end
 
 function onQuery(query)
@@ -641,21 +224,21 @@ function onQuery(query)
         launcher.setResults(query, { noopRow("err_no_fzf") })
         return
     end
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir == nil then
         launcher.setResults(query, { noopRow("err_index") })
         return
     end
     -- Re-read on every query: the panel may have cycled the scope or the
     -- ranking since the last keystroke, and both files are a single word.
-    scope = readScope(dir)
-    ranking = readRanking(dir)
+    shared.scope = shared.readScope(dir)
+    shared.ranking = shared.readRanking(dir)
     withMounts(query, function(current)
-        roots = computeRoots()
+        shared.roots = shared.computeRoots()
         -- How to read what is on disk right now; a walk below overwrites both.
-        indexRoots = indexRootsOf(dir) or roots
-        absoluteRecords = #indexRoots > 1
-        if cacheFresh(dir) then
+        shared.indexRoots = shared.indexRootsOf(dir) or shared.roots
+        shared.absoluteRecords = #shared.indexRoots > 1
+        if shared.cacheFresh(dir) then
             staleIndex = false
             runQuery(current)
             return
@@ -665,14 +248,14 @@ function onQuery(query)
         -- the search folder, or when the rebuild row asked for it. Records of
         -- a vanished root are not joined to a new one either way: they are
         -- validated against the current roots when activated.
-        if forceBuild or autoIndexAllowed() then
+        if forceBuild or shared.autoIndexAllowed() then
             forceBuild = false
             staleIndex = false
             buildIndex(current)
             return
         end
         staleIndex = true
-        if noctalia.fileExists(dir .. "/list-" .. scope) then
+        if noctalia.fileExists(dir .. "/list-" .. shared.scope) then
             runQuery(current)
         else
             launcher.setResults(current, { noopRow("launcher.index_missing"), reindexRow(), scopeRow() })
@@ -682,13 +265,13 @@ end
 
 function onActivate(id)
     if id == "scope" then
-        local dir = dataDir()
+        local dir = shared.dataDir()
         if dir == nil then
             return
         end
-        scope = NEXT_SCOPE[scope] or DEFAULT_SCOPE
-        writeScope(dir, scope)
-        mountsAt = 0 -- the new scope may need a mount list this one never took
+        shared.scope = shared.NEXT_SCOPE[shared.scope] or shared.DEFAULT_SCOPE
+        shared.writeScope(dir, shared.scope)
+        shared.mountsAt = 0 -- the new scope may need a mount list this one never took
         -- Rewriting the query keeps the launcher open (the host only closes on
         -- an activation that does not call setQuery) and re-enters onQuery with
         -- an empty text, so the list comes back with the new scope applied.
@@ -702,7 +285,7 @@ function onActivate(id)
         -- the current index first: if the walk fails or is aborted, the old one
         -- is still there to search.
         forceBuild = true
-        mountsAt = 0 -- rescan: a disk may have been plugged in since
+        shared.mountsAt = 0 -- rescan: a disk may have been plugged in since
         launcher.setQuery("")
         return
     end
@@ -710,13 +293,13 @@ function onActivate(id)
     if rel == nil then
         return
     end
-    local path = absolutePath(rel)
+    local path = shared.absolutePath(rel)
     if path == nil then
         noctalia.log("file-search: refusing unsafe index record: " .. rel)
-        noctalia.notify(tr("title"), tr("err_bad_record"))
+        noctalia.notify(shared.tr("title"), shared.tr("err_bad_record"))
         return
     end
-    noctalia.runAsync("xdg-open " .. shellQuote(path) .. " >/dev/null 2>&1")
+    shared.openPath(path)
 end
 
-probeFzfScheme()
+shared.probeFzfScheme()

--- a/file-search/panel.luau
+++ b/file-search/panel.luau
@@ -6,7 +6,9 @@
 -- after that every keystroke runs `fzf --filter=<query>` over the cache, so
 -- typing stays responsive even on large trees. Results update live; picking
 -- one opens it with the system MIME association (xdg-open) — directories
--- open in the file manager. Enter opens the top match.
+-- open in the file manager. Enter opens the top match. Right-clicking a row
+-- raises a native context menu (plugin_api >= 28) with open, reveal in the
+-- file manager, copy path and copy name.
 --
 -- The roots come from the search scope, cycled with the panel's disk button
 -- and persisted in the plugin data directory so the launcher entry follows the
@@ -35,75 +37,14 @@
 local PATH_MAX_CHARS = 56
 local ELLIPSIS = "…"
 
--- Bumped whenever the record format or the pruned-name list below changes: it
--- is part of the cache fingerprint, so an index built by an older version of
--- this plugin is rebuilt instead of being read with the wrong rules.
-local INDEX_FORMAT = "2"
+-- The search core: constants, the state describing what is being searched, and
+-- every helper that depends on it — shared with launcher.luau and the bar
+-- widget through require() (plugin_api >= 22). See shared.luau for why.
+local shared = require("./shared.luau")
 
--- Volume metadata that other operating systems leave on removable media, plus
--- the filesystem-level ones. None of it is a user file and some of it is huge
--- (a Time Machine sparsebundle or a Spotlight store is tens of thousands of
--- entries), so it is pruned at every root, not only on external disks — the
--- names are vendor-fixed and never collide with real content. Matched with
--- -iname because Windows has shipped both "$RECYCLE.BIN" and "$Recycle.Bin".
--- Most of the macOS ones start with a dot and are already covered when hidden
--- entries are off; they are listed so that turning hidden entries ON does not
--- flood the index.
-local VOLUME_NOISE = {
-    "lost+found",
-    -- Windows / NTFS
-    "$RECYCLE.BIN", "RECYCLER", "System Volume Information",
-    -- Linux XDG trash on removable media (.Trash-<uid>)
-    ".Trash-*",
-    -- macOS volume services
-    ".Spotlight-V100", ".fseventsd", ".Trashes", ".TemporaryItems",
-    ".DocumentRevisions-V100", ".PKInstallSandboxManager",
-    -- macOS Time Machine
-    "Backups.backupdb", "*.sparsebundle", "*.backupbundle",
-    -- AppleDouble sidecars and AFP/netatalk leftovers
-    "._*", ".DS_Store", ".AppleDouble", ".AppleDB", ".AppleDesktop",
-    "Network Trash Folder", "Temporary Items", "TheVolumeSettingsFolder",
-}
-
--- Search scope: which roots the index covers. Persisted as a one-word file in
--- the plugin data directory because a plugin cannot write its own settings —
--- there is no setConfig in the host API — and the launcher entry has to read
--- the same choice.
-local SCOPE_GLYPHS = { folder = "folder", all = "folders", external = "usb" }
-local NEXT_SCOPE = { folder = "all", all = "external", external = "folder" }
-local DEFAULT_SCOPE = "folder"
-
--- What a right click on a result does, switched by the second header button
--- and persisted next to the scope. Two actions, one gesture: a panel row can
--- only ever receive left and right — the declarative UI wires BTN_LEFT, plus
--- BTN_RIGHT once an onRightClick is attached, and nothing else. Middle click
--- exists for bar widgets only (onMiddleClick), never inside a panel, so the
--- second action lives on a toggle instead of a third button.
-local ROW_ACTION_GLYPHS = { copy = "copy", reveal = "folder-open" }
-local NEXT_ROW_ACTION = { copy = "reveal", reveal = "copy" }
-local DEFAULT_ROW_ACTION = "copy"
-
--- How fzf scores a match, switched by the third header button and persisted
--- like the others. "path" is fzf's --scheme=path: it treats / as a strong
--- boundary, so a match that starts a file or folder name beats the same letters
--- buried in a long directory. "default" is fzf's generic scoring, which mostly
--- rewards the shortest path. Path wins on most queries here — "config" finds
--- .ssh/config instead of a Steam directory five levels down — but not on all of
--- them, which is exactly why it is a toggle and not a constant.
-local RANKING_GLYPHS = { default = "arrows-sort", path = "sitemap" }
-local NEXT_RANKING = { default = "path", path = "default" }
-local DEFAULT_RANKING = "path"
-
--- A walk over a USB spinning disk is seek-bound and can run for tens of
--- minutes on a multi-terabyte drive, where the search folder alone is seconds;
--- the timeout follows the scope. Nothing at that price is ever started on its
--- own — see autoIndexAllowed.
-local BUILD_TIMEOUT_LOCAL = 180000
-local BUILD_TIMEOUT_DISKS = 1800000
-
--- Seconds a mount scan stays good for, so that mashing the scope button spawns
--- one lsblk instead of one per press.
-local MOUNT_TTL = 30
+-- The usage donut under the results. Panel-only, so it is not in shared.luau:
+-- the bar widget and the launcher have no chart to draw.
+local usage = require("./usage.luau")
 
 -- Read out of the plugin's own manifest (readFile resolves a relative path
 -- against the plugin directory), so the header cannot drift from the version
@@ -117,10 +58,6 @@ local pluginVersion = (function()
     return ("\n" .. text):match('\nversion%s*=%s*"([^"]+)"') or ""
 end)()
 
--- Whether the installed fzf understands --scheme, decided once per script load
--- (see probeFzfScheme). False until it answers, and on any fzf too old for it.
-local schemeSupported = false
-
 local query = ""
 local results = {}      -- index records: relative to the root, or absolute
 local total = nil       -- entries in the index, shown in the footer
@@ -131,423 +68,69 @@ local errMsg = nil
 local fzfMissing = false
 local inputRev = 0      -- bumped to reseed the query input on open
 local haveIndex = false -- the cache on disk matches the current settings
-local scope = DEFAULT_SCOPE
-local rowAction = DEFAULT_ROW_ACTION
-local ranking = DEFAULT_RANKING
-local mounts = {}       -- mount points of the detected removable volumes
-local mountsAt = 0      -- unix seconds of the last mount scan (0 = never)
-local probing = false
-local roots = {}        -- what an index built now would cover, ancestors first
-local indexRoots = {}   -- what the index ON DISK was built with (see indexRootsOf)
-local absoluteRecords = false -- records are absolute (set when #indexRoots > 1)
 local indexState = "fresh" -- "fresh" | "stale" (usable, out of date) | "missing"
 local reloading = false -- a refresh pass is in flight
 local reloadQueued = false
 local queuedForce = false
 local queuedBuild = false
 local totals = {}       -- scope → { count, size, mtime }: see readTotal
+local showUsage = true  -- the usage donut, toggled from the header
+-- Folder the results are restricted to, picked from the chart's legend, or nil.
+-- Kept apart from `query` rather than written into it as '^name/': the input
+-- stays the user's own text, and the restriction gets its own removable strip
+-- instead of being fzf syntax to recognise and edit out.
+local usageFilter = nil
 
 local render
 local runSearch
 local buildIndex
 local applyState
 
-local function tr(key, args)
-    return noctalia.tr(key, args)
-end
+-- Braille spinner shown in the status footer during a from-scratch index
+-- build (plugin_api >= 18: panel.setNeedsFrameTick + onFrameTick). Gated on
+-- `#results == 0` in updateSpinnerState below, not just `indexing`: a stale
+-- index keeps showing its OLD results while a fresh build runs behind it
+-- (indexState == "stale"), and re-running render() at spinner speed would
+-- re-walk that whole results list (resultRow + elidePathCached) many times a
+-- second — the exact CPU-budget trap 0.0.26 was released to fix. An empty
+-- results list makes that rebuild cost nothing, so ticking is only ever
+-- armed for the genuinely slow case this exists for: a disk scope indexed
+-- for the first time, with nothing yet to show.
+local SPINNER_FRAMES = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
+local SPINNER_STEP_MS = 90
+local spinnerIndex = 1
+local spinnerAccumMs = 0
+local spinnerTicking = false
 
-local function trim(value)
-    return (value:gsub("^%s+", ""):gsub("%s+$", ""))
-end
-
-local function shellQuote(value)
-    return "'" .. value:gsub("'", "'\\''") .. "'"
-end
-
-local function startsWith(value, prefix)
-    return value:sub(1, #prefix) == prefix
-end
-
-local function now()
-    return tonumber(noctalia.formatTime("%s")) or 0
-end
-
--- --scheme=path arrived in fzf 0.36; an older build exits with "unknown option"
--- and the panel would show an empty list forever. So the flag is only ever used
--- after the installed version says it is understood — one spawn per script
--- load, generic ranking until it answers.
-local function probeFzfScheme()
-    noctalia.runAsync("fzf --version 2>/dev/null", function(result)
-        local major, minor = (result.stdout or ""):match("(%d+)%.(%d+)")
-        major, minor = tonumber(major), tonumber(minor)
-        schemeSupported = major ~= nil and minor ~= nil and (major > 0 or minor >= 36)
-    end, 5000)
-end
-
--- The scoring flag for the next search: what the toggle asks for, if fzf can.
-local function rankingFlag()
-    return (ranking == "path" and schemeSupported) and " --scheme=path" or ""
-end
-
--- Whether the plugin may walk the tree by itself. It may for the search folder,
--- which is local and takes seconds; it may NOT once an external disk is in
--- scope. A 5 TB mechanical USB drive takes minutes per walk and would otherwise
--- be re-walked on every scope change, settings change, disk plug and panel
--- open — the refresh button (and the launcher's rebuild row) is the only way.
-local function autoIndexAllowed()
-    return scope == "folder"
-end
-
--- Private per-plugin storage (XDG state); the host creates the directory on
--- every call. nil (with a log line) when no state directory resolves.
-local function dataDir()
-    local dir, err = noctalia.pluginDataDir()
-    if dir == nil then
-        noctalia.log("file-search: pluginDataDir failed: " .. tostring(err))
-        return nil
+local function setSpinnerTicking(on)
+    if on == spinnerTicking then
+        return
     end
-    return dir
-end
-
--- Shell header shared by every cache command. One cache pair per scope, so
--- switching to the disks and back does not re-walk the search folder; the
--- .meta sidecar holds the settings fingerprint the cache was built with, so the
--- panel and the launcher can both tell a stale index apart. The scope is a
--- word from SCOPE_GLYPHS, never free text, so it is safe inside the path.
-local function cacheSh(dir)
-    return "CACHE_DIR=" .. shellQuote(dir)
-        .. '\nCACHE="$CACHE_DIR/list-' .. scope .. '"'
-        .. '\nMETA="$CACHE_DIR/meta-' .. scope .. '"'
-        .. '\nCOUNTF="$CACHE_DIR/count-' .. scope .. '"'
-end
-
-local function readScope(dir)
-    local raw = noctalia.readFile(dir .. "/scope")
-    if type(raw) == "string" then
-        local value = trim(raw)
-        if SCOPE_GLYPHS[value] ~= nil then
-            return value
-        end
+    spinnerTicking = on
+    panel.setNeedsFrameTick(on)
+    if not on then
+        spinnerAccumMs = 0
+        spinnerIndex = 1
     end
-    return DEFAULT_SCOPE
 end
 
-local function writeScope(dir, value)
-    local ok, err = noctalia.writeFile(dir .. "/scope", value)
+-- Whether the usage donut is shown, persisted next to the scope. A header
+-- button and a file rather than a bool setting: no API lets a plugin write its
+-- own settings (getSetting, added in 26, only reads), so a setting would only
+-- be changeable from the settings window, three clicks from the panel.
+local function readShowUsage(dir)
+    return shared.trim(noctalia.readFile(dir .. "/usage-chart") or "") ~= "0"
+end
+
+local function writeShowUsage(dir, value)
+    local ok, err = noctalia.writeFile(dir .. "/usage-chart", value and "1" or "0")
     if not ok then
-        noctalia.log("file-search: could not persist the scope: " .. tostring(err))
+        noctalia.log("file-search: could not persist the usage chart toggle: " .. tostring(err))
     end
-end
-
-local function readRowAction(dir)
-    local raw = noctalia.readFile(dir .. "/row-action")
-    if type(raw) == "string" then
-        local value = trim(raw)
-        if ROW_ACTION_GLYPHS[value] ~= nil then
-            return value
-        end
-    end
-    return DEFAULT_ROW_ACTION
-end
-
-local function writeRowAction(dir, value)
-    local ok, err = noctalia.writeFile(dir .. "/row-action", value)
-    if not ok then
-        noctalia.log("file-search: could not persist the row action: " .. tostring(err))
-    end
-end
-
-local function readRanking(dir)
-    local raw = noctalia.readFile(dir .. "/ranking")
-    if type(raw) == "string" then
-        local value = trim(raw)
-        if RANKING_GLYPHS[value] ~= nil then
-            return value
-        end
-    end
-    return DEFAULT_RANKING
-end
-
-local function writeRanking(dir, value)
-    local ok, err = noctalia.writeFile(dir .. "/ranking", value)
-    if not ok then
-        noctalia.log("file-search: could not persist the ranking: " .. tostring(err))
-    end
-end
-
-local function searchRoot()
-    local dir = noctalia.getConfig("search_folder")
-    if dir == nil or dir == "" then
-        dir = noctalia.getenv("HOME") or "/tmp"
-    else
-        dir = noctalia.expandPath(dir)
-    end
-    dir = dir:gsub("/+$", "")
-    if dir == "" then
-        dir = "/"
-    end
-    return dir
 end
 
 local function maxResults()
     return math.max(10, math.min(200, tonumber(noctalia.getConfig("max_results")) or 50))
-end
-
--- Excluded directory names from the setting, split on ',' or ';'. Matching
--- is by basename (find -name), so entries containing '/' are skipped and
--- logged. Hidden entries are folded in as an extra '.*' pattern.
-local function excludeNames()
-    local raw = noctalia.getConfig("exclude_dirs")
-    if type(raw) ~= "string" then
-        raw = ""
-    end
-    local names = {}
-    for entry in raw:gmatch("[^,;]+") do
-        local name = trim(entry)
-        if name:find("/") then
-            noctalia.log("file-search: ignoring exclude entry with '/': '" .. name .. "'")
-        elseif name ~= "" then
-            table.insert(names, name)
-        end
-    end
-    if noctalia.getConfig("show_hidden") ~= true then
-        table.insert(names, ".*")
-    end
-    return names
-end
-
--- ── removable volume detection ───────────────────────────────────────────────
-
--- A mount point worth indexing: absolute, not the system root, no control
--- character (it becomes a shell word and a cache record), and not the boot
--- partition, which is a mount of firmware files even when it sits on a stick.
-local function usableMount(path)
-    if path == nil or path == "" or path:sub(1, 1) ~= "/" then
-        return false
-    end
-    if path == "/" or path:find("%c") ~= nil then
-        return false
-    end
-    return path ~= "/boot" and not startsWith(path, "/boot/")
-end
-
--- lsblk --pairs quotes every value; depending on the util-linux version a
--- space or a quote inside one can come back as a \xNN escape. nil for an
--- escaped control byte: the whole mount point is then dropped by the caller,
--- rather than kept with a literal "\x0a" in it that no path would match.
-local function unescapeHex(value)
-    local rejected = false
-    local out = value:gsub("\\x(%x%x)", function(hex)
-        local code = tonumber(hex, 16)
-        if code == nil or code < 32 or code == 127 then
-            rejected = true
-            return ""
-        end
-        return string.char(code)
-    end)
-    if rejected then
-        return nil
-    end
-    return out
-end
-
-local function pairValue(line, key)
-    return (" " .. line):match(" " .. key .. '="(.-)"')
-end
-
--- Mount points of the volumes that came from a USB port or report themselves
--- removable (sticks, SD cards, optical media).
---
--- The interesting attribute lives on the DISK, not on the partition that is
--- actually mounted: a USB partition row reports TRAN="" and, for a bus-powered
--- SSD, RM="0" as well — only its parent disk says TRAN="usb". So the PKNAME
--- chain is walked upwards (one more level for an encrypted stick: crypt →
--- part → disk). HOTPLUG is deliberately not part of the test: some NVMe and
--- hot-swap SATA controllers report HOTPLUG="1" for internal drives.
-local function parseLsblk(out)
-    local rows, byName = {}, {}
-    for line in out:gmatch("[^\n]+") do
-        local name = pairValue(line, "NAME")
-        if name ~= nil and name ~= "" then
-            local row = {
-                parent = pairValue(line, "PKNAME") or "",
-                removable = pairValue(line, "RM") == "1",
-                transport = pairValue(line, "TRAN") or "",
-                mount = unescapeHex(pairValue(line, "MOUNTPOINT") or ""),
-            }
-            byName[name] = row
-            table.insert(rows, row)
-        end
-    end
-    local found = {}
-    for _, row in ipairs(rows) do
-        if usableMount(row.mount) then
-            local node, depth = row, 0
-            -- Capped: PKNAME comes from outside and a cycle would hang here.
-            while node ~= nil and depth < 4 do
-                if node.transport == "usb" or node.removable then
-                    table.insert(found, row.mount)
-                    break
-                end
-                node = (node.parent ~= "") and byName[node.parent] or nil
-                depth += 1
-            end
-        end
-    end
-    return found
-end
-
--- Fallback for a system without util-linux: the mount table still exposes the
--- udisks2 convention every mainstream desktop mounts removable media with
--- (/run/media/<user>/<label>), plus the older /media/<user>|<label> layout of
--- udisks1 and pmount. Paths in /proc/mounts spell space and tab as an octal
--- escape. Internal disks mounted by hand under /mnt are NOT picked up here —
--- same as with lsblk, where they are neither USB nor removable.
-local function fallbackMounts()
-    local text = noctalia.readFile("/proc/mounts")
-    if type(text) ~= "string" then
-        return {}
-    end
-    local found = {}
-    for line in text:gmatch("[^\n]+") do
-        local raw = line:match("^%S+%s+(%S+)%s")
-        if raw ~= nil then
-            local rejected = false
-            local path = raw:gsub("\\(%d%d%d)", function(octal)
-                local code = tonumber(octal, 8)
-                if code == nil or code < 32 or code == 127 then
-                    rejected = true
-                    return ""
-                end
-                return string.char(code)
-            end)
-            if rejected then
-                path = ""
-            end
-            local rest = path:match("^/run/media/[^/]+/(.+)$") or path:match("^/media/(.+)$")
-            if rest ~= nil and rest ~= "" and usableMount(path) then
-                table.insert(found, path)
-            end
-        end
-    end
-    return found
-end
-
--- Refresh `mounts`, then continue. Async because lsblk is a process: every
--- caller has to be written as a continuation. Skipped entirely — no spawn at
--- all — while the scope is the search folder, so the default costs nothing,
--- and a scan younger than MOUNT_TTL is reused unless `force` says otherwise
--- (the refresh button forces one, since noticing a disk is the point of it).
--- Callers must not call this concurrently: requestReload is the single caller
--- that serialises them.
-local function probeMounts(force, done)
-    if scope == "folder" then
-        mounts = {}
-        done()
-        return
-    end
-    if not force and mountsAt > 0 and (now() - mountsAt) < MOUNT_TTL then
-        done()
-        return
-    end
-    local function finish()
-        mountsAt = now()
-        probing = false
-        done()
-    end
-    if probing then
-        -- requestReload serialises callers, so this is defensive only: never
-        -- start a second scan, and keep the list we already have rather than
-        -- replacing it with a narrower one.
-        done()
-        return
-    end
-    if not noctalia.commandExists("lsblk") then
-        mounts = fallbackMounts()
-        finish()
-        return
-    end
-    probing = true
-    local ok = noctalia.runAsync("lsblk -P -o NAME,PKNAME,RM,TRAN,MOUNTPOINT 2>/dev/null", function(result)
-        if result.exitCode == 0 and not result.timedOut then
-            mounts = parseLsblk(result.stdout or "")
-        else
-            mounts = fallbackMounts()
-        end
-        finish()
-    end, 10000)
-    if not ok then
-        mounts = fallbackMounts()
-        finish()
-    end
-end
-
--- The roots the index covers, ancestors first and without overlaps: a volume
--- mounted inside the search folder (or inside another volume) would otherwise
--- be walked twice and produce duplicate rows. Sorting puts a parent before its
--- children, so one pass is enough to drop the nested ones.
-local function computeRoots()
-    local list = {}
-    if scope ~= "external" then
-        table.insert(list, searchRoot())
-    end
-    if scope ~= "folder" then
-        for _, mount in ipairs(mounts) do
-            table.insert(list, (mount:gsub("/+$", "")))
-        end
-    end
-    table.sort(list)
-    local kept = {}
-    for _, path in ipairs(list) do
-        local nested = false
-        for _, parent in ipairs(kept) do
-            if path == parent or startsWith(path, parent == "/" and "/" or parent .. "/") then
-                nested = true
-                break
-            end
-        end
-        if path ~= "" and not nested then
-            table.insert(kept, path)
-        end
-    end
-    return kept
-end
-
--- Everything that decides how the cache was built. Its two lists are joined
--- with a separator no root and no exclusion name can contain, so a name can
--- never be read back as a root.
-local function indexKey()
-    return INDEX_FORMAT .. "\n" .. scope
-        .. "\n--\n" .. table.concat(roots, "\n")
-        .. "\n--\n" .. table.concat(excludeNames(), "\n")
-end
-
--- The cache on disk is current when its fingerprint matches, whether the panel
--- or the launcher built it.
-local function cacheFresh(dir)
-    return noctalia.readFile(dir .. "/meta-" .. scope) == indexKey()
-end
-
--- The roots the index on disk was built with, read back out of its fingerprint,
--- or nil when there is no index. Records must be read the way they were
--- WRITTEN, not the way a fresh walk would write them now: unplug one of two
--- disks and the file still holds absolute records, so deciding the format from
--- the current mount list would make every row unopenable — including the rows
--- of the disk still attached — until the next rebuild.
-local function indexRootsOf(dir)
-    local meta = noctalia.readFile(dir .. "/meta-" .. scope)
-    if type(meta) ~= "string" then
-        return nil
-    end
-    local section = meta:match("\n%-%-\n(.-)\n%-%-\n")
-    if section == nil then
-        return nil
-    end
-    local list = {}
-    for line in section:gmatch("[^\n]+") do
-        table.insert(list, line)
-    end
-    return #list > 0 and list or nil
 end
 
 -- Code-point slices. Byte offsets would split a multi-byte character and
@@ -606,6 +189,37 @@ local function elidePath(rel)
     return headPart .. ELLIPSIS .. base
 end
 
+-- Cache keyed by the raw record: elidePath is pure, so the same rel never
+-- needs recomputing across the many render() calls that leave `results`
+-- untouched (toggling the usage chart, resizing, other settings changes all
+-- re-render the whole row list). On a flatpak-heavy $HOME almost every
+-- visible row is over PATH_MAX_CHARS (runtime trees nest well past 56
+-- chars), so the "common case skips this" comment above routinely fails and
+-- render() was recomputing the full utf8 walk for up to `max_results` rows
+-- on every one of those unrelated re-renders — that is what exceeded a
+-- panel callback's CPU budget and got the panel disabled. Cleared wholesale
+-- rather than LRU-evicted once it grows past a session's realistic working
+-- set — simplicity over a perfect policy, since a full miss just costs one
+-- elidePath call again.
+local elideCache = {}
+local elideCacheCount = 0
+local ELIDE_CACHE_MAX = 4000
+
+local function elidePathCached(rel)
+    local cached = elideCache[rel]
+    if cached ~= nil then
+        return cached
+    end
+    if elideCacheCount >= ELIDE_CACHE_MAX then
+        elideCache = {}
+        elideCacheCount = 0
+    end
+    local shown = elidePath(rel)
+    elideCache[rel] = shown
+    elideCacheCount = elideCacheCount + 1
+    return shown
+end
+
 -- Count the cache the panel is about to search. buildIndex records the total
 -- as a side effect of building, but a panel opening on a cache that is already
 -- fresh -- the common case, and the one the launcher leaves behind -- never
@@ -620,12 +234,19 @@ end
 -- >100 MB, and paying that read on every scope change is what made the button
 -- feel like it wedged the shell.
 local function readTotal(dir)
-    local target = scope
+    local target = shared.scope
     buildMs = nil -- belongs to the index of this scope, if that one recorded it
     local recorded = noctalia.readFile(dir .. "/count-" .. target)
     if recorded ~= nil then
-        local count, elapsed = trim(recorded):match("^(%d+)%s+(%d+)$")
-        total = tonumber(count or trim(recorded)) or 0
+        -- The `or shared.trim(recorded)` is NOT dead: 0.0.22 added the elapsed
+        -- millis to this sidecar, and one written before that holds the count
+        -- alone. That file is still on disk for any scope not rebuilt since —
+        -- count-all here is a bare "1166625" — and without the fallback the
+        -- match fails and the footer reports 0 indexed for a perfectly good
+        -- index. buildMs stays nil for those, which is exactly right: that
+        -- build never recorded one.
+        local count, elapsed = shared.trim(recorded):match("^(%d+)%s+(%d+)$")
+        total = tonumber(count or shared.trim(recorded)) or 0
         buildMs = tonumber(elapsed)
         return
     end
@@ -639,12 +260,12 @@ local function readTotal(dir)
         total = memo.count
         return
     end
-    local cmd = cacheSh(dir) .. '\nwc -l < "$CACHE" 2>/dev/null'
+    local cmd = shared.cacheSh(dir) .. '\nwc -l < "$CACHE" 2>/dev/null'
     noctalia.runAsync(cmd, function(result)
         if result.exitCode == 0 and not result.timedOut then
-            local count = tonumber(trim(result.stdout or "")) or 0
+            local count = tonumber(shared.trim(result.stdout or "")) or 0
             totals[target] = { count = count, size = info.size, mtime = info.mtime }
-            if scope == target then
+            if shared.scope == target then
                 total = count
                 render()
             end
@@ -656,13 +277,13 @@ buildIndex = function()
     if fzfMissing or indexing then
         return
     end
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir == nil then
-        errMsg = tr("err_index")
+        errMsg = shared.tr("err_index")
         render()
         return
     end
-    if #roots == 0 then
+    if #shared.roots == 0 then
         -- Scope "external" with nothing plugged in. Nothing to walk, and no
         -- cache to write either: render() says so, and the next call is one
         -- cheap early return rather than a spawn per keystroke.
@@ -674,79 +295,21 @@ buildIndex = function()
     end
     indexing = true
     errMsg = nil
-    local key = indexKey()
+    local key = shared.indexKey()
     -- The format this walk WRITES follows the roots it is about to visit, not
     -- the format of the index being replaced.
-    local builtRoots = roots
+    local builtRoots = shared.roots
     local absolute = #builtRoots > 1
-    local builtScope = scope
+    local builtScope = shared.scope
 
-    -- Names containing a newline would each forge extra one-per-fragment
-    -- records (a crafted name can smuggle '..' lines into the index), so
-    -- they are pruned unconditionally, before the volume noise and the user's
-    -- own exclusions.
-    local names = { "-name " .. shellQuote("*\n*") }
-    for _, pattern in ipairs(VOLUME_NOISE) do
-        table.insert(names, "-iname " .. shellQuote(pattern))
-    end
-    for _, name in ipairs(excludeNames()) do
-        table.insert(names, "-name " .. shellQuote(name))
-    end
-    local prune = "\\( " .. table.concat(names, " -o ") .. " \\) -prune -o "
-    local args = {}
-    for _, root in ipairs(roots) do
-        table.insert(args, shellQuote(root))
-    end
-    -- %P prints paths relative to the root, %p the whole path. Relative is
-    -- what a single root gets: it keeps the rows short and, more to the point,
-    -- keeps the common "/home/<user>/" prefix out of every line, where it
-    -- would be fuzzy-matched like any other text. With several roots a
-    -- relative record would be ambiguous, so those are absolute.
-    local printSpec = absolute
-        and "-type d -printf '%p/\\n' -o -printf '%p\\n'"
-        or "-type d -printf '%P/\\n' -o -printf '%P\\n'"
-    local walk = "find " .. table.concat(args, " ") .. " -mindepth 1 " .. prune
-        .. printSpec .. ' > "$TMP" 2>/dev/null'
-    -- find's own exit status is ignored, so permission errors inside the tree
-    -- don't fail the build. Cache and fingerprint are written to
-    -- mktemp-created private files and renamed into place: rename replaces
-    -- a planted symlink at the destination instead of following it. The
-    -- host guarantees $CACHE_DIR exists (created by pluginDataDir above).
-    -- The two cleanup lines drop the pre-0.0.20 single-scope cache and any
-    -- temp file a killed build left behind — only ones older than 90 minutes,
-    -- comfortably past the 30-minute build ceiling, so a walk running in the
-    -- other entry is never touched.
-    local cmd = cacheSh(dir)
-        .. '\nrm -f "$CACHE_DIR/index.list" "$CACHE_DIR/index.meta"\n'
-        .. 'find "$CACHE_DIR" -maxdepth 1 \\( -name \'list-*.*\' -o -name \'meta-*.*\''
-        .. " -o -name 'count-*.*' \\) -mmin +90 -delete 2>/dev/null\n"
-        -- Timed here rather than around runAsync: this is the walk itself,
-        -- without the queueing and callback hops the shell knows nothing about.
-        .. 'START=$(date +%s%3N)\n'
-        .. 'TMP=$(mktemp "$CACHE_DIR/list-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. walk .. "\n"
-        .. 'mv -f "$TMP" "$CACHE" || exit 1\n'
-        .. 'TMPM=$(mktemp "$CACHE_DIR/meta-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. "printf '%s' " .. shellQuote(key) .. ' > "$TMPM"\n'
-        .. 'mv -f "$TMPM" "$META" || exit 1\n'
-        -- The count is taken here, while the file is already hot, and left in a
-        -- sidecar together with the elapsed milliseconds: every later open
-        -- reads a dozen bytes instead of the whole index, and the footer can
-        -- still say how long the walk behind it took.
-        .. 'COUNT=$(wc -l < "$CACHE") || exit 1\n'
-        .. 'ELAPSED=$(( $(date +%s%3N) - START ))\n'
-        .. 'TMPN=$(mktemp "$CACHE_DIR/count-' .. scope .. '.XXXXXX") || exit 1\n'
-        .. 'printf "%s %s" "$COUNT" "$ELAPSED" > "$TMPN"\n'
-        .. 'mv -f "$TMPN" "$COUNTF" || exit 1\n'
-        .. 'printf "%s %s" "$COUNT" "$ELAPSED"'
+    local cmd = shared.buildCommand(dir, key, absolute)
 
     render()
-    local timeout = (scope == "folder") and BUILD_TIMEOUT_LOCAL or BUILD_TIMEOUT_DISKS
     local ok = noctalia.runAsync(cmd, function(result)
         indexing = false
         if result.exitCode == 0 and not result.timedOut then
             totals[builtScope] = nil -- size/mtime moved; recount lazily
-            if builtScope ~= scope then
+            if builtScope ~= shared.scope then
                 -- The scope was cycled while the walk ran, so what just landed
                 -- on disk is not what the panel is showing: none of it — the
                 -- count, the freshness — describes the current scope. Derive
@@ -755,16 +318,16 @@ buildIndex = function()
             else
                 -- The file on disk is the one this walk just wrote: read it
                 -- the way it was written.
-                indexRoots = builtRoots
-                absoluteRecords = absolute
+                shared.indexRoots = builtRoots
+                shared.absoluteRecords = absolute
                 haveIndex = true
-                local count, elapsed = trim(result.stdout or ""):match("^(%d+)%s+(%d+)$")
+                local count, elapsed = shared.trim(result.stdout or ""):match("^(%d+)%s+(%d+)$")
                 total = tonumber(count) or 0
                 buildMs = tonumber(elapsed)
-                if indexKey() == key then
+                if shared.indexKey() == key then
                     indexState = "fresh"
                     runSearch()
-                elseif autoIndexAllowed() then
+                elseif shared.autoIndexAllowed() then
                     -- Roots or exclusions moved during the walk (a disk came or
                     -- went). Chasing that is fine for the search folder.
                     buildIndex()
@@ -777,37 +340,53 @@ buildIndex = function()
             end
         else
             haveIndex = false
-            errMsg = tr("err_index")
+            errMsg = shared.tr("err_index")
         end
         render()
-    end, timeout)
+    end, shared.buildTimeout())
     if not ok then
         indexing = false
-        errMsg = tr("err_spawn")
+        errMsg = shared.tr("err_spawn")
         render()
     end
+end
+
+-- The fzf term that restricts the results to one direct child of the root.
+--
+-- '^' is fzf's EXACT prefix operator, not a fuzzy one (verified: '^x.y/' takes
+-- 'x.y/g', not 'xxy/g2'), and the trailing '/' keeps '^src/' off a sibling
+-- called 'srcold'. Only spaces need escaping — fzf splits terms on them; '!',
+-- '$' and '|' are special only at a token boundary this one does not put them
+-- at. Works on records relative to a single root (find -printf '%P'), which is
+-- the folder scope, the only scope offering the chart.
+local function folderToken(name)
+    return "^" .. name:gsub(" ", "\\ ") .. "/"
+end
+
+-- The restriction and what the user typed, ANDed as fzf does for
+-- space-separated terms.
+local function effectiveQuery()
+    if usageFilter == nil then
+        return query
+    end
+    local typed = shared.trim(query)
+    if typed == "" then
+        return folderToken(usageFilter)
+    end
+    return folderToken(usageFilter) .. " " .. typed
 end
 
 runSearch = function()
     if fzfMissing or indexing or searching or not haveIndex then
         return
     end
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir == nil then
         return
     end
     searching = true
-    local q = query
-    local limit = maxResults()
-    local cmd
-    if trim(q) == "" then
-        cmd = cacheSh(dir) .. '\nhead -n ' .. limit .. ' "$CACHE" 2>/dev/null'
-    else
-        -- head closes the pipe early; the pipeline status stays head's (0).
-        cmd = cacheSh(dir) .. "\nfzf" .. rankingFlag() .. " --filter=" .. shellQuote(q)
-            .. ' < "$CACHE" 2>/dev/null | head -n ' .. limit
-    end
-    local ok = noctalia.runAsync(cmd, function(result)
+    local q = effectiveQuery()
+    local ok = noctalia.runAsync(shared.searchCommand(dir, q, maxResults()), function(result)
         searching = false
         if not result.timedOut then
             results = {}
@@ -817,7 +396,9 @@ runSearch = function()
         end
         -- The query moved on while this search ran: chase it. The stale
         -- rows rendered below are overwritten as soon as it completes.
-        if query ~= q then
+        -- Compared on the composed query, so picking a folder from the chart
+        -- mid-search is chased exactly like a keystroke would be.
+        if effectiveQuery() ~= q then
             runSearch()
         end
         render()
@@ -827,70 +408,42 @@ runSearch = function()
     end
 end
 
--- An index record turned into a path, or nil when it could resolve outside the
--- roots it was supposed to come from. The cache is a plain user-editable file,
--- so records are untrusted. Only ever called from the two callbacks that act
--- on a row — never from render: it walks every path component, and paying that
--- per row per frame is what gets a script callback killed for exceeding its
--- CPU budget.
-local function absolutePath(record)
-    if record == "" or record:find("%c") ~= nil then
-        return nil
-    end
-    -- A directory keeps its trailing "/" in the index but not in a path meant
-    -- for xdg-open or for pasting into a shell.
-    local path = record:gsub("/+$", "")
-    for part in path:gmatch("[^/]+") do
-        if part == ".." then
-            return nil
-        end
-    end
-    -- Validated against the roots of the index the record came from, so a
-    -- record can still never escape a root, but one written for a disk that has
-    -- since been unplugged stays openable (xdg-open just fails if it is gone).
-    local from = #indexRoots > 0 and indexRoots or roots
-    if absoluteRecords then
-        for _, root in ipairs(from) do
-            if startsWith(path, root == "/" and "/" or root .. "/") then
-                return path
-            end
-        end
-        return nil
-    end
-    local root = from[1]
-    if root == nil or path == "" or path:sub(1, 1) == "/" then
-        return nil
-    end
-    if root == "/" then
-        return root .. path
-    end
-    return root .. "/" .. path
-end
-
 local function rejectRecord(rel)
     noctalia.log("file-search: refusing unsafe index record: " .. rel)
-    noctalia.notify(tr("title"), tr("err_bad_record"))
+    noctalia.notify(shared.tr("title"), shared.tr("err_bad_record"))
 end
 
 local function openEntry(rel)
-    local path = absolutePath(rel)
+    local path = shared.absolutePath(rel)
     if path == nil then
         rejectRecord(rel)
         return
     end
-    noctalia.runAsync("xdg-open " .. shellQuote(path) .. " >/dev/null 2>&1")
+    shared.openPath(path)
     panel.close()
 end
 
 -- Copy leaves the panel up so several rows can be picked off in a row.
 local function copyEntry(rel)
-    local path = absolutePath(rel)
+    local path = shared.absolutePath(rel)
     if path == nil then
         rejectRecord(rel)
         return
     end
     noctalia.copyToClipboard(path, "text/plain")
-    noctalia.notify(tr("title"), tr("copied_entry"))
+    noctalia.notify(shared.tr("title"), shared.tr("copied_entry"))
+end
+
+-- Just the last path segment. absolutePath has already dropped a directory
+-- record's trailing "/", so the match needs no help.
+local function copyName(rel)
+    local path = shared.absolutePath(rel)
+    if path == nil then
+        rejectRecord(rel)
+        return
+    end
+    noctalia.copyToClipboard(path:match("[^/]+$") or path, "text/plain")
+    noctalia.notify(shared.tr("title"), shared.tr("copied_name"))
 end
 
 -- file:// URI for a local path. Every byte outside the unreserved set is
@@ -910,12 +463,16 @@ end
 -- ShowItems on the org.freedesktop.FileManager1 interface is the portable way
 -- to say "reveal this": Thunar, Nautilus, Dolphin, Nemo, Caja and PCManFM-Qt
 -- all implement it, and the session bus activates the handler on demand, so
--- the file manager does not need to be running. When there is no such handler
--- (or no gdbus at all: the `||` also catches a 127 from the shell), the
+-- the file manager does not need to be running. When there is no such handler,
+-- or no gdbus at all (execvp failing is a 127 exit like any other), the
 -- fallback opens the containing folder through the MIME association, which is
 -- the same window minus the selection.
+--
+-- An argv (plugin_api >= 24) rather than a shell line: the GVariant literal
+-- carries a file name straight from the index and nothing parses it. That moves
+-- the `||` fallback out of the shell and into the callback.
 local function revealEntry(rel)
-    local path = absolutePath(rel)
+    local path = shared.absolutePath(rel)
     if path == nil then
         rejectRecord(rel)
         return
@@ -924,20 +481,59 @@ local function revealEntry(rel)
     if parent == nil or parent == "" then
         parent = "/"
     end
-    local cmd = "gdbus call --session --dest org.freedesktop.FileManager1"
-        .. " --object-path /org/freedesktop/FileManager1"
-        .. " --method org.freedesktop.FileManager1.ShowItems "
-        .. shellQuote('["' .. fileUri(path) .. '"]') .. " ''"
-        .. " >/dev/null 2>&1 || xdg-open " .. shellQuote(parent) .. " >/dev/null 2>&1"
-    noctalia.runAsync(cmd)
+    local ok = noctalia.runAsync({
+        "gdbus",
+        "call",
+        "--session",
+        "--dest",
+        "org.freedesktop.FileManager1",
+        "--object-path",
+        "/org/freedesktop/FileManager1",
+        "--method",
+        "org.freedesktop.FileManager1.ShowItems",
+        '["' .. fileUri(path) .. '"]',
+        "",
+    }, function(result)
+        if result.exitCode ~= 0 or result.timedOut then
+            shared.openPath(parent)
+        end
+    end, 5000)
+    if not ok then
+        shared.openPath(parent)
+    end
+end
+
+-- The result row's right-click menu (plugin_api >= 28). Only a ui.button's
+-- onRightClick reports the pointer serial openContextMenu needs, so the row
+-- itself is what raises it. `onActivate` must NAME a global (openContextMenu is
+-- a raw binding, not a UI tree prop, so closures are not registered for it),
+-- and the record rides along in `context` — a path, so it comes back verbatim
+-- and every action re-validates it through absolutePath.
+--
+-- The header is the elided path, not the full one: it is the same string the row
+-- shows, which is what makes the menu read as belonging to that row.
+local function openResultMenu(rel)
+    panel.openContextMenu({
+        onActivate = "onResultMenu",
+        context = rel,
+        items = {
+            { kind = "header", label = elidePathCached(rel) },
+            { id = "open", label = shared.tr("menu.open") },
+            { id = "reveal", label = shared.tr("menu.reveal") },
+            { kind = "separator" },
+            { id = "copy_path", label = shared.tr("menu.copy_path") },
+            { id = "copy_name", label = shared.tr("menu.copy_name") },
+        },
+    })
 end
 
 local function resultRow(rel, index)
     local isDir = rel:sub(-1) == "/"
     -- The row carries no tooltip on purpose: one string per row is enough
     -- extra weight, over a list this long, to get the render's callback killed
-    -- for exceeding its CPU budget. Right click yields the full path instead.
-    local shown = elidePath(rel)
+    -- for exceeding its CPU budget. The row menu's copy entries yield the
+    -- full path instead.
+    local shown = elidePathCached(rel)
     return ui.button({
         key = "hit-" .. index,
         glyph = isDir and "folder" or "file",
@@ -947,26 +543,258 @@ local function resultRow(rel, index)
         onClick = function()
             openEntry(rel) -- always the full record, never the elided label
         end,
-        -- The secondary action, whichever the header toggle currently names.
         -- Right rather than middle because a ui.button never receives the
         -- middle button: it accepts BTN_LEFT, plus BTN_RIGHT only once an
         -- onRightClick is attached, and no node in the declarative UI exposes
         -- a middle-click callback at all — that one is a bar-widget gesture.
-        -- Read at click time, not captured, so flipping the toggle changes
-        -- what the rows already on screen do.
         onRightClick = function()
-            if rowAction == "reveal" then
-                revealEntry(rel)
-            else
-                copyEntry(rel)
-            end
+            openResultMenu(rel)
         end,
     })
 end
 
--- Milliseconds as something a person reads at a glance: "820 ms", "12.4 s",
--- "7m 41s". A disk walk is minutes, a warm home folder is under a second, and
--- the same string has to serve both.
+-- Free space across every mount the current scope would walk (plugin_api >=
+-- 16). One noctalia.diskStats(path) call per mount — the same small, stable
+-- set `mounts` already holds, never per matched file — because each distinct
+-- path queried is retained by the host until the plugin unloads.
+--
+-- Memoized, because the caller is not what the comment above assumed. This
+-- feeds scopeButton()'s tooltip, so it runs from render() — and render() runs
+-- at SPINNER_STEP_MS while a first-time disk index builds, which turned "one
+-- call per mount" into one call per mount roughly eleven times a second. It is
+-- the same CPU-budget trap elidePathCached exists to close, except this one
+-- crosses into the host every frame instead of only burning Luau cycles. Free
+-- space has no business being sampled at frame rate anyway: it is a tooltip the
+-- user reads after hovering, so a few seconds stale is invisible.
+--
+-- Keyed on scope plus the mount list, so cycling the scope or a disk appearing
+-- refreshes it immediately instead of waiting out the TTL.
+local FREE_TTL_MS = 5000
+local freeCacheKey = nil
+local freeCacheValue = nil
+local freeCacheAtMs = 0
+
+local function diskFreeSummary()
+    if shared.scope == "folder" or #shared.mounts == 0 then
+        return nil
+    end
+    local key = shared.scope .. "\0" .. table.concat(shared.mounts, "\0")
+    local nowMs = noctalia.nowMs()
+    if key == freeCacheKey and nowMs - freeCacheAtMs < FREE_TTL_MS then
+        return freeCacheValue
+    end
+    local freeBytes = 0
+    local sampled = 0
+    for _, mount in ipairs(shared.mounts) do
+        local stats = noctalia.diskStats(mount)
+        if stats ~= nil then
+            freeBytes += stats.freeBytes
+            sampled += 1
+        end
+    end
+    freeCacheKey = key
+    freeCacheAtMs = nowMs
+    -- nil is cached too: with no readable mount, retrying every frame is the
+    -- worst case, not the safe one.
+    freeCacheValue = sampled > 0
+        and shared.tr("tip_scope_free", { free = shared.formatBytes(freeBytes), count = sampled })
+        or nil
+    return freeCacheValue
+end
+
+-- ── usage donut ──────────────────────────────────────────────────────────────
+
+local USAGE_SIZE = 108
+local USAGE_THICKNESS = 16
+local USAGE_LABEL_MAX = 16
+-- Pinned, because a Button sizes itself for the bar's chrome: at its natural
+-- height a legend row came out at ~50px, and seven of those made the legend
+-- three times the height of the donut. `height` sets a Button's min AND max.
+local USAGE_ROW_HEIGHT = 20
+
+-- Measure the current search root and redraw when it lands. Never on a disk
+-- scope: those roots are removable volumes, du over one is a minutes-long
+-- walk, and the panel already refuses to index them unasked.
+local function requestUsage(force)
+    if not showUsage or shared.scope ~= "folder" then
+        return
+    end
+    local root = shared.searchRoot()
+    local dataDir = shared.dataDir()
+    usage.scan(root, dataDir, force, function()
+        if usage.state == "ready" then
+            usage.writeSvg(
+                dataDir, USAGE_SIZE, USAGE_THICKNESS,
+                shared.formatBytes(usage.total),
+                shared.tr("usage_center")
+            )
+        end
+        render()
+    end)
+end
+
+-- Restrict the results to a folder from the chart, or lift the restriction by
+-- picking the same one again.
+--
+-- Spelled out rather than `(usageFilter == name) and nil or name`, the Lua trap
+-- that shipped in the first cut: `and nil` yields nil, which is falsy, so `or`
+-- takes the other branch and the expression returns `name` in BOTH cases.
+local function pickUsageFolder(name)
+    if usageFilter == name then
+        usageFilter = nil
+    else
+        usageFilter = name
+    end
+    render()
+    runSearch()
+end
+
+-- One legend row: swatch, folder, size and share. The swatch takes the SAME hex
+-- the SVG used, which is why the two halves of the chart agree.
+--
+-- Only the name is a Button, growing into the space between swatch and size, so
+-- the hover highlight covers the row while the numbers keep their right-aligned
+-- column. Only "folder" slices get one — "other" and the loose files name
+-- nothing fzf could be pointed at.
+local function usageLegendRow(slice, index)
+    -- utf8.len returns nil on an invalid sequence, which headChars would then
+    -- split mid-character. Left whole rather than risking a throw in render().
+    local label = slice.label
+    local labelLen = utf8.len(label)
+    if labelLen ~= nil and labelLen > USAGE_LABEL_MAX then
+        label = headChars(label, USAGE_LABEL_MAX - 1) .. ELLIPSIS
+    end
+    local share = usage.total > 0 and (slice.bytes / usage.total * 100) or 0
+    local name
+    if slice.kind == "folder" then
+        local active = usageFilter == slice.label
+        -- Keyed apart from the label below: a slice can change kind between
+        -- measurements, and the reconciler matches children by type AND key.
+        name = ui.button({
+            key = "name-folder",
+            text = label,
+            fontSize = 11,
+            variant = "ghost",
+            contentAlign = "start",
+            selected = active,
+            flexGrow = 1,
+            height = USAGE_ROW_HEIGHT,
+            tooltip = shared.tr(active and "tip_usage_folder_clear" or "tip_usage_folder", {
+                folder = slice.label,
+            }),
+            onClick = function()
+                pickUsageFolder(slice.label)
+            end,
+        })
+    else
+        name = ui.label({ key = "name-plain", text = label, fontSize = 11, color = "on_surface_variant", flexGrow = 1 })
+    end
+    return ui.row({ key = "ulegend-" .. index, gap = 6, align = "center", height = USAGE_ROW_HEIGHT }, {
+        ui.box({ key = "swatch", fill = slice.color, radius = 2, width = 9, height = 9 }),
+        name,
+        -- One label, not two: a label honours maxWidth but not width, so a
+        -- separate percent column would sit at a different offset per row.
+        ui.label({
+            key = "size",
+            text = shared.tr("usage_amount", {
+                size = shared.formatBytes(slice.bytes),
+                share = string.format("%.0f", share),
+            }),
+            fontSize = 11,
+            color = "on_surface_variant",
+        }),
+    })
+end
+
+-- The whole strip, or nil when it is off — which leaves the panel exactly the
+-- shape it had before the chart existed.
+local function usageSection()
+    if not showUsage or shared.scope ~= "folder" then
+        return nil
+    end
+
+    local children = {}
+    if usage.state == "ready" and usage.imagePath ~= nil then
+        local legend = {}
+        for index, slice in ipairs(usage.slices) do
+            table.insert(legend, usageLegendRow(slice, index))
+        end
+        -- Nothing else in the panel is a list of buttons that look like text,
+        -- so the rows being clickable is said once, in words. Dropped once a
+        -- restriction is on: the strip above the results is then what to read.
+        if usageFilter == nil then
+            table.insert(legend, ui.label({
+                key = "ulegend-hint",
+                text = shared.tr("usage_hint"),
+                fontSize = 10,
+                color = "on_surface_variant",
+            }))
+        end
+        -- Mount points are absent from the total, since `du -x` never crosses a
+        -- filesystem boundary. Naming them is the difference between a number
+        -- that is incomplete and one that is wrong.
+        if #usage.skipped > 0 then
+            table.insert(legend, ui.label({
+                key = "ulegend-skipped",
+                text = shared.tr("usage_skipped", { names = table.concat(usage.skipped, ", ") }),
+                fontSize = 10,
+                color = "on_surface_variant",
+            }))
+        end
+        table.insert(children, ui.image({
+            key = "usage-img",
+            path = usage.imagePath,
+            width = USAGE_SIZE,
+            height = USAGE_SIZE,
+        }))
+        table.insert(children, ui.column({ key = "usage-legend", gap = 1, flexGrow = 1 }, legend))
+    else
+        local text
+        if usage.state == "scanning" then
+            text = shared.tr("usage_scanning")
+        elseif usage.state == "error" then
+            text = shared.tr("usage_error", { reason = usage.errText or "?" })
+        else
+            text = shared.tr("usage_idle")
+        end
+        table.insert(children, ui.label({
+            key = "usage-msg",
+            text = text,
+            fontSize = 11,
+            color = usage.state == "error" and "error" or "on_surface_variant",
+            flexGrow = 1,
+        }))
+    end
+
+    return ui.row({ key = "usage", gap = 12, align = "center" }, children)
+end
+
+-- The active restriction as its own strip under the query input, or nil. In
+-- words with one way out, rather than as '^winboat/' inside the input, where it
+-- would be indistinguishable from what the user typed.
+local function usageFilterStrip()
+    if usageFilter == nil then
+        return nil
+    end
+    return ui.row({ key = "filter", gap = 6, align = "center" }, {
+        ui.glyph({ key = "filter-glyph", name = "folder", size = 12, color = "primary" }),
+        ui.label({
+            key = "filter-text",
+            text = shared.tr("usage_filter", { folder = usageFilter }),
+            fontSize = 11,
+            color = "primary",
+            flexGrow = 1,
+        }),
+        ui.button({
+            key = "filter-clear",
+            glyph = "close",
+            variant = "ghost",
+            tooltip = shared.tr("tip_usage_filter_clear"),
+            onClick = "onClearUsageFilter",
+        }),
+    })
+end
+
 local function formatDuration(ms)
     if ms < 1000 then
         return string.format("%d ms", ms)
@@ -978,11 +806,12 @@ local function formatDuration(ms)
     return string.format("%dm %02ds", math.floor(seconds / 60), math.floor(seconds % 60))
 end
 
--- One dim line of fzf's extended-search operators, between the results and the
--- status bar. They are the difference between "many matches" and "the one", and
--- nothing else in the panel hints that the query field understands more than
--- letters. One label, not a row of chips: the cheapest node count for something
--- that renders on every keystroke.
+-- One dim line of fzf's extended-search operators, directly under the query
+-- input — next to the field they describe, rather than at the far end of the
+-- panel where the usage chart had pushed them out of sight of it. They are the
+-- difference between "many matches" and "the one", and nothing else here hints
+-- that the field understands more than letters. One label, not a row of chips:
+-- the cheapest node count for something that renders on every keystroke.
 -- Two labels rather than one string: the caption says what the row is, dimmed
 -- so it reads as a label and not as part of the syntax, and the operators
 -- themselves stay in the brighter colour because they are the content.
@@ -990,11 +819,11 @@ local function syntaxLegend()
     return ui.row({ key = "legend", gap = 6, align = "center" }, {
         ui.label({
             key = "legend-caption",
-            text = tr("syntax_hint_label"),
+            text = shared.tr("syntax_hint_label"),
             fontSize = 10,
             color = "on_surface_variant",
         }),
-        ui.label({ key = "legend-ops", text = tr("syntax_hint"), fontSize = 10, color = "on_surface" }),
+        ui.label({ key = "legend-ops", text = shared.tr("syntax_hint"), fontSize = 10, color = "on_surface" }),
     })
 end
 
@@ -1009,19 +838,22 @@ local function statusFooter()
     if indexing then
         -- One root gets named; several would wrap the footer onto a second
         -- line, so they are counted instead.
-        left = #roots > 1
-            and tr("status_indexing_multi", { count = #roots })
-            or tr("status_indexing", { path = roots[1] or searchRoot() })
+        left = #shared.roots > 1
+            and shared.tr("status_indexing_multi", { count = #shared.roots })
+            or shared.tr("status_indexing", { path = shared.roots[1] or shared.searchRoot() })
+        if spinnerTicking then
+            left = SPINNER_FRAMES[spinnerIndex] .. "  " .. left
+        end
         tone = "secondary"
     else
-        left = tr("counts", { shown = #results, total = total or 0 })
-        if scope ~= "folder" then
-            left = left .. tr("counts_disks", { disks = #mounts })
+        left = shared.tr("counts", { shown = #results, total = total or 0 })
+        if shared.scope ~= "folder" then
+            left = left .. shared.tr("counts_disks", { disks = #shared.mounts })
         end
         if indexState == "stale" then
             -- Searchable, but built for a different scope or disk set. Saying
             -- so is the honest alternative to silently re-walking a 5 TB drive.
-            left = left .. tr("counts_stale")
+            left = left .. shared.tr("counts_stale")
             tone = "secondary"
         else
             tone = "on_surface_variant"
@@ -1033,7 +865,7 @@ local function statusFooter()
     if buildMs ~= nil then
         table.insert(children, ui.label({
             key = "elapsed",
-            text = tr("build_time", { duration = formatDuration(buildMs) }),
+            text = shared.tr("build_time", { duration = formatDuration(buildMs) }),
             fontSize = 11,
             color = "on_surface_variant",
         }))
@@ -1041,67 +873,73 @@ local function statusFooter()
     return ui.row({ key = "footer", gap = 8, align = "center" }, children)
 end
 
--- The scope button cycles folder → folder+disks → disks only. A cycling button
--- rather than a ui.select: the panel is 480px tall and the header row is the
--- only space that costs nothing, and the tooltip names both the current scope
--- and the next one, which a select's collapsed state would not.
--- Names what a right click does, and switches it. Its glyph is the answer to
--- "what happens if I right-click a result", which is the question a user of a
--- two-gesture list actually asks.
-local function rowActionButton()
-    return ui.button({
-        key = "rowaction-" .. rowAction,
-        glyph = ROW_ACTION_GLYPHS[rowAction],
-        variant = "ghost",
-        tooltip = tr("tip_row_action", {
-            current = tr("row_action." .. rowAction),
-            next = tr("row_action." .. NEXT_ROW_ACTION[rowAction]),
-        }),
-        onClick = "onCycleRowAction",
-    })
-end
-
 -- Names the scoring scheme and switches it. The tooltip has to carry the whole
 -- explanation: the difference only shows up in the order of the rows, and there
 -- is nowhere else to say what changed. When fzf is too old for --scheme the
 -- button stays on the generic scheme and says why, rather than disappearing.
 local function rankingButton()
-    local tip = schemeSupported
-        and tr("tip_ranking", {
-            current = tr("ranking." .. ranking),
-            next = tr("ranking." .. NEXT_RANKING[ranking]),
+    local tip = shared.schemeSupported
+        and shared.tr("tip_ranking", {
+            current = shared.tr("ranking." .. shared.ranking),
+            next = shared.tr("ranking." .. shared.NEXT_RANKING[shared.ranking]),
         })
-        or tr("tip_ranking_unsupported")
+        or shared.tr("tip_ranking_unsupported")
     return ui.button({
-        key = "ranking-" .. ranking,
-        glyph = RANKING_GLYPHS[schemeSupported and ranking or "default"],
+        key = "ranking-" .. shared.ranking,
+        glyph = shared.RANKING_GLYPHS[shared.schemeSupported and shared.ranking or "default"],
         variant = "ghost",
         tooltip = tip,
         onClick = "onCycleRanking",
     })
 end
 
-local function scopeButton()
+-- Shows and hides the usage donut. Disabled outside the folder scope, where
+-- there is nothing it could measure without walking a removable disk.
+local function usageButton()
     return ui.button({
-        key = "scope-" .. scope,
-        glyph = SCOPE_GLYPHS[scope],
+        key = "usage-toggle",
+        glyph = "chart-donut",
+        variant = showUsage and "secondary" or "ghost",
+        enabled = shared.scope == "folder",
+        tooltip = shared.scope == "folder"
+            and shared.tr(showUsage and "tip_usage_hide" or "tip_usage_show")
+            or shared.tr("tip_usage_folder_only"),
+        onClick = "onToggleUsage",
+    })
+end
+
+-- The scope button cycles folder → folder+disks → disks only. A cycling button
+-- rather than a ui.select: the panel is 480px tall and the header row is the
+-- only space that costs nothing, and the tooltip names both the current scope
+-- and the next one, which a select's collapsed state would not.
+local function scopeButton()
+    local tooltip = shared.tr("tip_scope", {
+        current = shared.tr("scope." .. shared.scope),
+        next = shared.tr("scope." .. shared.NEXT_SCOPE[shared.scope]),
+    })
+    local free = diskFreeSummary()
+    if free ~= nil then
+        tooltip = tooltip .. "\n" .. free
+    end
+    return ui.button({
+        key = "scope-" .. shared.scope,
+        glyph = shared.SCOPE_GLYPHS[shared.scope],
         variant = "ghost",
-        tooltip = tr("tip_scope", {
-            current = tr("scope." .. scope),
-            next = tr("scope." .. NEXT_SCOPE[scope]),
-        }),
+        tooltip = tooltip,
         onClick = "onCycleScope",
     })
 end
 
 render = function()
+    setSpinnerTicking(indexing and #results == 0)
+
     -- Every child of the panel and of the header carries a stable key, so the
     -- reconciler matches roles instead of guessing by position and type.
     local children = {
         ui.row({ key = "header", gap = 6, align = "center" }, {
             ui.label({
                 key = "title",
-                text = tr("title"),
+                text = shared.tr("title"),
                 fontSize = 16,
                 fontWeight = "bold",
                 color = "on_surface",
@@ -1112,21 +950,27 @@ render = function()
             ui.label({ key = "version", text = pluginVersion, fontSize = 10, color = "on_surface_variant" }),
             ui.spacer({ key = "gap", flexGrow = 1 }),
             rankingButton(),
-            rowActionButton(),
+            usageButton(),
             scopeButton(),
-            ui.button({ key = "refresh", glyph = "refresh", variant = "ghost", tooltip = tr("tip_refresh"), onClick = "onRefreshIndex" }),
-            ui.button({ key = "settings", glyph = "settings", variant = "ghost", tooltip = tr("tip_settings"), onClick = "onOpenSettings" }),
-            ui.button({ key = "close", glyph = "close", variant = "ghost", tooltip = tr("tip_close"), onClick = "onClosePanel" }),
+            ui.button({ key = "refresh", glyph = "refresh", variant = "ghost", tooltip = shared.tr("tip_refresh"), onClick = "onRefreshIndex" }),
+            ui.button({ key = "settings", glyph = "settings", variant = "ghost", tooltip = shared.tr("tip_settings"), onClick = "onOpenSettings" }),
+            ui.button({ key = "close", glyph = "close", variant = "ghost", tooltip = shared.tr("tip_close"), onClick = "onClosePanel" }),
         }),
         ui.input({
             key = "query-" .. inputRev,
             value = query,
             focus = true,
-            placeholder = tr("search_placeholder"),
+            placeholder = shared.tr("search_placeholder"),
             onChange = "onQueryChanged",
             onSubmit = "onOpenFirst",
         }),
+        syntaxLegend(),
     }
+
+    local strip = usageFilterStrip()
+    if strip ~= nil then
+        table.insert(children, strip)
+    end
 
     -- Whatever the state, the body is ONE keyed column that grows: the results
     -- list and every message live inside it. Swapping node types at the top
@@ -1138,22 +982,22 @@ render = function()
     -- from the previous tenant. A constant shape has nothing to re-match.
     local body
     if fzfMissing then
-        body = ui.label({ key = "body-msg", text = tr("err_no_fzf"), color = "error", flexGrow = 1 })
+        body = ui.label({ key = "body-msg", text = shared.tr("err_no_fzf"), color = "error", flexGrow = 1 })
     elseif errMsg ~= nil then
         body = ui.label({ key = "body-msg", text = errMsg, color = "error", flexGrow = 1 })
-    elseif #roots == 0 and not indexing then
+    elseif #shared.roots == 0 and not indexing then
         -- Only reachable with scope "external": nothing to search, and
         -- "no matches" would blame the query for it.
-        body = ui.label({ key = "body-msg", text = tr("no_external"), color = "on_surface_variant", flexGrow = 1 })
+        body = ui.label({ key = "body-msg", text = shared.tr("no_external"), color = "on_surface_variant", flexGrow = 1 })
     elseif indexState == "missing" and not indexing then
         -- A disk scope that has never been indexed. Walking it is a
         -- minutes-long operation on a large drive, so it is offered rather
         -- than performed.
-        body = ui.label({ key = "body-msg", text = tr("index_missing"), color = "on_surface_variant", flexGrow = 1 })
-    elseif #results == 0 and not indexing and trim(query) ~= "" then
+        body = ui.label({ key = "body-msg", text = shared.tr("index_missing"), color = "on_surface_variant", flexGrow = 1 })
+    elseif #results == 0 and not indexing and shared.trim(query) ~= "" then
         body = ui.label({
             key = "body-msg",
-            text = tr("no_results", { query = query }),
+            text = shared.tr("no_results", { query = query }),
             color = "on_surface_variant",
             flexGrow = 1,
         })
@@ -1165,7 +1009,12 @@ render = function()
         body = ui.scroll({ key = "hits", flexGrow = 1, gap = 2 }, rows)
     end
     table.insert(children, ui.column({ key = "body", flexGrow = 1, align = "stretch" }, { body }))
-    table.insert(children, syntaxLegend())
+    -- Below the results: the chart describes the folder, not the query.
+    local chart = usageSection()
+    if chart ~= nil then
+        table.insert(children, ui.separator({ key = "usage-rule" }))
+        table.insert(children, chart)
+    end
     table.insert(children, statusFooter())
 
     panel.render(ui.column({ flexGrow = 1, gap = 12, align = "stretch" }, children))
@@ -1176,24 +1025,24 @@ end
 -- autoIndexAllowed() says so; otherwise the existing index is searched as-is
 -- and flagged, or the panel asks for a rebuild when there is none at all.
 applyState = function()
-    roots = computeRoots()
-    local dir = dataDir()
+    shared.roots = shared.computeRoots()
+    local dir = shared.dataDir()
     if dir == nil then
-        errMsg = tr("err_index")
+        errMsg = shared.tr("err_index")
         render()
         return
     end
     -- How to read what is on disk; a walk started below overwrites both.
-    indexRoots = indexRootsOf(dir) or roots
-    absoluteRecords = #indexRoots > 1
-    if cacheFresh(dir) then
+    shared.indexRoots = shared.indexRootsOf(dir) or shared.roots
+    shared.absoluteRecords = #shared.indexRoots > 1
+    if shared.cacheFresh(dir) then
         haveIndex = true
         indexState = "fresh"
         -- buildIndex would have set the total; reusing a cache has to go and
         -- count it (memoized).
         readTotal(dir)
         runSearch()
-    elseif autoIndexAllowed() then
+    elseif shared.autoIndexAllowed() then
         results = {}
         total = nil
         buildIndex()
@@ -1201,7 +1050,7 @@ applyState = function()
         -- Out of date, and not ours to fix on our own: an index built for
         -- another disk set still answers most queries, so it is searched and
         -- labelled rather than thrown away.
-        haveIndex = noctalia.fileExists(dir .. "/list-" .. scope)
+        haveIndex = noctalia.fileExists(dir .. "/list-" .. shared.scope)
         indexState = haveIndex and "stale" or "missing"
         if haveIndex then
             readTotal(dir)
@@ -1231,16 +1080,16 @@ local function requestReload(force, build)
         return
     end
     reloading = true
-    probeMounts(force, function()
+    shared.probeMounts(force, function()
         reloading = false
         if build then
-            roots = computeRoots()
+            shared.roots = shared.computeRoots()
             -- The index being replaced stays readable until the walk lands, so
             -- a row clicked meanwhile still resolves.
-            local dir = dataDir()
+            local dir = shared.dataDir()
             if dir ~= nil then
-                indexRoots = indexRootsOf(dir) or roots
-                absoluteRecords = #indexRoots > 1
+                shared.indexRoots = shared.indexRootsOf(dir) or shared.roots
+                shared.absoluteRecords = #shared.indexRoots > 1
             end
             results = {}
             total = nil
@@ -1265,19 +1114,31 @@ function onOpen(_context)
     query = ""
     results = {}
     errMsg = nil
+    -- Not carried across opens: a restriction whose origin is off screen
+    -- ("why does this find nothing?") is worse than re-picking it.
+    usageFilter = nil
     -- Not trusted across opens: the scope may have moved under us (the
     -- launcher can cycle it), so nothing is searched until reload() has
     -- checked the fingerprint of the cache this scope actually uses.
     haveIndex = false
     inputRev += 1
     noctalia.state.set("file_search_open", true)
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir ~= nil then
         -- Re-read on every open: the launcher may have cycled the scope, and
         -- a script reload drops both of these from memory.
-        scope = readScope(dir)
-        rowAction = readRowAction(dir)
-        ranking = readRanking(dir)
+        shared.scope = shared.readScope(dir)
+        shared.ranking = shared.readRanking(dir)
+        showUsage = readShowUsage(dir)
+        -- An earlier session's measurement, so the chart is up with the panel
+        -- and du only runs when it is actually out of date.
+        if usage.load(dir) then
+            usage.writeSvg(
+                dir, USAGE_SIZE, USAGE_THICKNESS,
+                shared.formatBytes(usage.total),
+                shared.tr("usage_center")
+            )
+        end
     end
     if fzfMissing then
         render()
@@ -1285,10 +1146,32 @@ function onOpen(_context)
     end
     render() -- the panel is up while lsblk answers
     requestReload(false, false)
+    -- Independent of the index: one being stale says nothing about the other.
+    -- Cheap on a repeat open — usage.scan honours its own TTL.
+    requestUsage(false)
 end
 
 function onClose()
+    -- Stop the frame tick even mid-build; the next onOpen re-arms it if the
+    -- build is somehow still running (buildIndex survives the panel closing).
+    setSpinnerTicking(false)
     noctalia.state.set("file_search_open", false)
+end
+
+-- plugin_api >= 18. Throttled to SPINNER_STEP_MS regardless of the host's
+-- actual tick rate; render() itself flips setNeedsFrameTick off once indexing
+-- ends or results stop being empty, so this never spins forever unattended.
+function onFrameTick(deltaMs)
+    if not spinnerTicking then
+        return
+    end
+    spinnerAccumMs += deltaMs
+    if spinnerAccumMs < SPINNER_STEP_MS then
+        return
+    end
+    spinnerAccumMs = 0
+    spinnerIndex = (spinnerIndex % #SPINNER_FRAMES) + 1
+    render()
 end
 
 function onConfigChanged()
@@ -1299,10 +1182,14 @@ function onConfigChanged()
     -- panel is closed too, when the launcher may have cycled the scope and the
     -- in-memory mount list can predate it. Rebuilding a disk index from a stale
     -- (empty) list would throw away a good index and take minutes to redo.
-    local dir = dataDir()
+    local dir = shared.dataDir()
     if dir ~= nil then
-        scope = readScope(dir)
+        shared.scope = shared.readScope(dir)
     end
+    -- Expired, not redone: this also fires with the panel closed. A changed
+    -- search_folder invalidates itself (usage.fresh compares the root); a
+    -- changed exclusion list does not, which is what this covers.
+    usage.scannedAt = 0
     requestReload(false, false)
 end
 
@@ -1328,6 +1215,48 @@ function onRefreshIndex()
     -- A refresh is also how a disk plugged in after the panel opened gets
     -- noticed, so the mount scan is forced rather than reused.
     requestReload(true, true)
+    -- TTL ignored: "refresh" has to mean everything the panel shows.
+    requestUsage(true)
+end
+
+-- The strip's ✕. Same effect as re-clicking the highlighted legend row, offered
+-- where the restriction is shown: the chart can be switched off while it is on.
+function onClearUsageFilter()
+    if usageFilter == nil then
+        return
+    end
+    usageFilter = nil
+    render()
+    runSearch()
+end
+
+-- Hiding does not discard the measurement, so showing it again is instant.
+function onToggleUsage()
+    if shared.scope ~= "folder" then
+        return
+    end
+    showUsage = not showUsage
+    local dir = shared.dataDir()
+    if dir ~= nil then
+        writeShowUsage(dir, showUsage)
+    end
+    render()
+    requestUsage(false)
+end
+
+-- The index is untouched; only the order of the rows changes, so the current
+-- query is simply run again through the other scheme.
+function onCycleRanking()
+    if not shared.schemeSupported then
+        return
+    end
+    shared.ranking = shared.NEXT_RANKING[shared.ranking] or shared.DEFAULT_RANKING
+    local dir = shared.dataDir()
+    if dir ~= nil then
+        shared.writeRanking(dir, shared.ranking)
+    end
+    render()
+    runSearch()
 end
 
 -- Allowed mid-build on purpose: a walk over a slow disk can run for minutes and
@@ -1338,42 +1267,39 @@ end
 -- The press itself is deliberately cheap — a 6-byte write and a render. Every
 -- process it might need (mount scan, count, search) goes through
 -- requestReload, which collapses a burst of presses into one pass.
--- The index is untouched; only the order of the rows changes, so the current
--- query is simply run again through the other scheme.
-function onCycleRanking()
-    if not schemeSupported then
-        return
-    end
-    ranking = NEXT_RANKING[ranking] or DEFAULT_RANKING
-    local dir = dataDir()
-    if dir ~= nil then
-        writeRanking(dir, ranking)
-    end
-    render()
-    runSearch()
-end
-
--- Nothing to reload: this only changes what a right click will do next.
-function onCycleRowAction()
-    rowAction = NEXT_ROW_ACTION[rowAction] or DEFAULT_ROW_ACTION
-    local dir = dataDir()
-    if dir ~= nil then
-        writeRowAction(dir, rowAction)
-    end
-    render()
-end
-
 function onCycleScope()
-    scope = NEXT_SCOPE[scope] or DEFAULT_SCOPE
-    local dir = dataDir()
+    shared.scope = shared.NEXT_SCOPE[shared.scope] or shared.DEFAULT_SCOPE
+    local dir = shared.dataDir()
     if dir ~= nil then
-        writeScope(dir, scope)
+        shared.writeScope(dir, shared.scope)
     end
     results = {}
     total = nil
     errMsg = nil
+    -- The token is a relative-path prefix; a disk scope stores absolute
+    -- records, where it would silently match nothing.
+    usageFilter = nil
     render()
     requestReload(false, false)
+    -- A no-op on a disk scope, so this is safe on every leg.
+    requestUsage(false)
+end
+
+-- Dispatch for a result row's context menu. `action` is the id of the entry
+-- picked, `context` the index record the menu was opened on.
+function onResultMenu(action, context)
+    if type(context) ~= "string" or context == "" then
+        return
+    end
+    if action == "open" then
+        openEntry(context)
+    elseif action == "reveal" then
+        revealEntry(context)
+    elseif action == "copy_path" then
+        copyEntry(context)
+    elseif action == "copy_name" then
+        copyName(context)
+    end
 end
 
 -- Opens the settings window on this plugin's own page (the host supplies the
@@ -1387,4 +1313,10 @@ function onClosePanel()
     panel.close()
 end
 
-probeFzfScheme()
+shared.probeFzfScheme()
+
+-- usage.luau builds the slice labels, so the two it invents rather than reads
+-- off the filesystem are handed to it from here — every user-visible string
+-- still comes out of translations/en.json.
+usage.looseLabel = shared.tr("usage_loose")
+usage.otherLabel = shared.tr("usage_other")

--- a/file-search/plugin.toml
+++ b/file-search/plugin.toml
@@ -2,20 +2,29 @@
 # The bar glyph toggles a search panel: the search folder is indexed with
 # `find` (honoring the excluded directories), every keystroke is matched
 # through `fzf --filter`, and picking a result opens it with the system
-# MIME association (xdg-open). The panel's disk button widens the search to
-# the mounted USB/removable volumes, detected with `lsblk`.
+# MIME association (xdg-open). Right-click a result for a context menu with
+# open, reveal in the file manager, copy path and copy name. The panel's disk
+# button widens the search to the mounted USB/removable volumes, detected
+# with `lsblk`.
 
 id = "nightwatch75/file-search"
 name = "File Search"
-version = "0.0.25"
-plugin_api = 15
+version = "0.2.0"
+# 28 for panel.openContextMenu: a result row's right-click menu. Also 22 for
+# relative luau imports — the three entries share shared.luau, which owns the
+# index fingerprint they all have to agree on — and 24 for argv process
+# execution: the usage chart spawns `du` with the user's own exclusion patterns
+# as arguments, xdg-open takes a path straight from the index and the reveal
+# call carries a file name inside a GVariant literal, and an argv is exec'd
+# directly, so no shell ever parses any of them.
+plugin_api = 28
 author = "nightwatch75"
 license = "MIT"
 # The exact commands the plugin spawns (fzf, lsblk and gdbus aside, findutils +
 # coreutils + xdg-utils on any Linux desktop). lsblk only runs while the search
 # scope includes the external disks, gdbus only on a reveal-in-file-manager
 # click, and that one falls back to xdg-open when it is missing.
-dependencies = ["fzf", "find", "lsblk", "gdbus", "mktemp", "mv", "wc", "head", "rm", "date", "xdg-open"]
+dependencies = ["fzf", "find", "lsblk", "gdbus", "mktemp", "mv", "wc", "head", "rm", "date", "xdg-open", "du"]
 tags = ["bar", "launcher", "panel", "utility", "productivity"]
 icon = "search"
 description = "Search files and folders as you type, fuzzy-matched with fzf; open results with the system MIME association."
@@ -43,6 +52,18 @@ label_key = "settings.show_hidden.label"
 description_key = "settings.show_hidden.description"
 default = false
 
+# Kept apart from exclude_dirs above: that one defaults to hiding .git and
+# node_modules from the index, and a usage chart that hides them answers the
+# wrong question — what fills a source folder usually IS .git. Empty by
+# default, since `du -x` already refuses to cross a filesystem boundary and a
+# slow network or FUSE mount under the search folder costs nothing.
+[[setting]]
+key = "usage_exclude_dirs"
+type = "string"
+label_key = "settings.usage_exclude_dirs.label"
+description_key = "settings.usage_exclude_dirs.description"
+default = ""
+
 [[setting]]
 key = "max_results"
 type = "int"
@@ -53,7 +74,12 @@ min = 10
 max = 200
 
 # Keyboard-first flow: the noctalia launcher provides native arrows + Enter
-# navigation, which plugin panels cannot receive from the current Luau API.
+# navigation over a long result list. A panel cannot match that. Not for want of
+# key events — panel `capture_keys` has existed since plugin_api 13 — but
+# because `ui.scroll` still exposes no way to bring a given child into view
+# (its only programmatic move is scrollToBottomRev, added in 21). A selection
+# driven past the fold would simply go invisible, so keyboard navigation in the
+# panel would need a hand-rolled windowed render to be usable at all.
 [[launcher_provider]]
 id = "launcher"
 entry = "launcher.luau"
@@ -65,7 +91,13 @@ include_in_global_search = false
 id = "panel"
 entry = "panel.luau"
 width = 520
-height = 480
+# 720, up from 480, because the usage chart added ~200px under the results:
+# a 108px donut, seven legend rows, the click hint and the skipped-mounts line,
+# which between them are taller than the chart itself. At 600 the result list
+# was back down to four rows. A panel cannot resize itself — the height is read
+# once, from here — so it is sized for the chart being on, which is the
+# default; with the chart hidden the extra room goes to the results.
+height = 720
 placement = "attached"
 open_near_click = true
 

--- a/file-search/shared.luau
+++ b/file-search/shared.luau
@@ -1,0 +1,668 @@
+--!nonstrict
+-- shared — the search core behind all three entries (bar widget, panel,
+-- launcher provider), pulled in via require() (relative same-plugin import,
+-- plugin_api >= 22).
+--
+-- Before 0.0.28 every helper below lived twice, copied by hand between
+-- panel.luau and launcher.luau, with a comment in each asking the next reader
+-- to keep them in step. They had already drifted: excludeNames() logged a bad
+-- entry in one copy and swallowed it in the other, readRanking() validated
+-- against a hard-coded pair of words instead of the constant. The fingerprint
+-- functions are the reason that mattered — indexKey() and cacheSh() are how one
+-- entry recognizes an index the other built, so a divergence there does not
+-- fail loudly, it silently makes each entry re-walk the tree the other just
+-- walked.
+--
+-- The module owns the search STATE as well as the functions, because almost
+-- every helper reads it: `scope` decides the cache paths, `roots` and
+-- `indexRoots` decide how a record resolves, `mounts` decides the roots. The
+-- entries read and write those fields directly (shared.scope = ...); each entry
+-- is its own Luau host, so each gets its own instance of this module and no
+-- state is shared between them behind the entries' backs — the files under
+-- pluginDataDir() remain the only channel between the entries, exactly as
+-- before.
+--
+-- What stays out: anything one entry alone has. The panel keeps its row menu,
+-- path elision, spinner and footer counts; the launcher keeps its row
+-- construction and its query echo.
+
+local shared = {}
+
+-- ── constants ────────────────────────────────────────────────────────────────
+
+-- Bumped whenever the record format or the pruned-name list below changes: it
+-- is part of the cache fingerprint, so an index built by an older version of
+-- this plugin is rebuilt instead of being read with the wrong rules.
+shared.INDEX_FORMAT = "2"
+
+-- Volume metadata that other operating systems leave on removable media, plus
+-- the filesystem-level ones. None of it is a user file and some of it is huge
+-- (a Time Machine sparsebundle or a Spotlight store is tens of thousands of
+-- entries), so it is pruned at every root, not only on external disks — the
+-- names are vendor-fixed and never collide with real content. Matched with
+-- -iname because Windows has shipped both "$RECYCLE.BIN" and "$Recycle.Bin".
+-- Most of the macOS ones start with a dot and are already covered when hidden
+-- entries are off; they are listed so that turning hidden entries ON does not
+-- flood the index.
+shared.VOLUME_NOISE = {
+    "lost+found",
+    -- Windows / NTFS
+    "$RECYCLE.BIN", "RECYCLER", "System Volume Information",
+    -- Linux XDG trash on removable media (.Trash-<uid>)
+    ".Trash-*",
+    -- macOS volume services
+    ".Spotlight-V100", ".fseventsd", ".Trashes", ".TemporaryItems",
+    ".DocumentRevisions-V100", ".PKInstallSandboxManager",
+    -- macOS Time Machine
+    "Backups.backupdb", "*.sparsebundle", "*.backupbundle",
+    -- AppleDouble sidecars and AFP/netatalk leftovers
+    "._*", ".DS_Store", ".AppleDouble", ".AppleDB", ".AppleDesktop",
+    "Network Trash Folder", "Temporary Items", "TheVolumeSettingsFolder",
+}
+
+-- Search scope: which roots the index covers. Persisted as a one-word file in
+-- the plugin data directory because a plugin cannot write its own settings —
+-- there is no setConfig in the host API — and every entry has to read the same
+-- choice.
+shared.SCOPE_GLYPHS = { folder = "folder", all = "folders", external = "usb" }
+shared.NEXT_SCOPE = { folder = "all", all = "external", external = "folder" }
+shared.DEFAULT_SCOPE = "folder"
+
+-- How fzf scores a match, switched by the panel's third header button and
+-- persisted next to the scope. "path" is fzf's --scheme=path: it treats / as a
+-- strong boundary, so a match that starts a file or folder name beats the same
+-- letters buried in a long directory. "default" is fzf's generic scoring, which
+-- mostly rewards the shortest path. Path wins on most queries here — "config"
+-- finds .ssh/config instead of a Steam directory five levels down — but not on
+-- all of them, which is exactly why it is a toggle and not a constant.
+shared.RANKING_GLYPHS = { default = "arrows-sort", path = "sitemap" }
+shared.NEXT_RANKING = { default = "path", path = "default" }
+shared.DEFAULT_RANKING = "path"
+
+-- A walk over a USB spinning disk is seek-bound and can run for tens of
+-- minutes on a multi-terabyte drive, where the search folder alone is seconds;
+-- the timeout follows the scope. Nothing at that price is ever started on its
+-- own — see autoIndexAllowed.
+shared.BUILD_TIMEOUT_LOCAL = 180000
+shared.BUILD_TIMEOUT_DISKS = 1800000
+
+-- Seconds a mount scan stays good for. Long enough that a burst of keystrokes
+-- (or mashing the panel's scope button) costs one lsblk at most, short enough
+-- that a disk plugged in mid-session shows up without a manual refresh.
+shared.MOUNT_TTL = 30
+
+-- ── state ────────────────────────────────────────────────────────────────────
+
+shared.scope = shared.DEFAULT_SCOPE
+shared.ranking = shared.DEFAULT_RANKING
+-- Whether the installed fzf understands --scheme, decided once per script load
+-- (see probeFzfScheme). False until it answers, and on any fzf too old for it.
+shared.schemeSupported = false
+shared.mounts = {}          -- mount points of the detected removable volumes
+shared.mountsAt = 0         -- unix seconds of the last mount scan (0 = never)
+shared.roots = {}           -- what an index built now would cover, ancestors first
+shared.indexRoots = {}      -- what the index ON DISK was built with (indexRootsOf)
+shared.absoluteRecords = false -- records are absolute (set when #indexRoots > 1)
+
+local probing = false
+local pendingProbeDone = nil
+
+-- ── small helpers ────────────────────────────────────────────────────────────
+
+function shared.tr(key, args)
+    return noctalia.tr(key, args)
+end
+
+function shared.trim(value)
+    return (value:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+function shared.shellQuote(value)
+    return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+
+function shared.startsWith(value, prefix)
+    return value:sub(1, #prefix) == prefix
+end
+
+-- plugin_api >= 16: a direct wall-clock read, no string formatting/parsing (and
+-- no dependency on "%s" staying a Unix-epoch format) for a value only ever
+-- diffed against itself.
+function shared.now()
+    return noctalia.nowMs() / 1000
+end
+
+-- Byte counts as a person reads them. One implementation, because there were
+-- two and they disagreed: the panel's rounded to one decimal above KB and the
+-- chart's dropped the decimal at three digits, so the same measurement showed
+-- as "110.4 GB" in the free-space tooltip and "110 GB" in the donut. Three
+-- significant figures throughout is the rule kept — a tenth of a gigabyte is
+-- precision this plugin does not have and nobody asked for.
+function shared.formatBytes(n)
+    local units = { "B", "KB", "MB", "GB", "TB" }
+    local index, value = 1, n + 0.0
+    while value >= 1024 and index < #units do
+        value /= 1024
+        index += 1
+    end
+    if value >= 100 or index == 1 then
+        return string.format("%.0f %s", value, units[index])
+    end
+    return string.format("%.1f %s", value, units[index])
+end
+
+-- Open a path with the system MIME association. An argv (plugin_api >= 24) is
+-- exec'd directly, so nothing parses the path and it needs no quoting; the host
+-- points a detached child's stdio at /dev/null itself.
+function shared.openPath(path)
+    noctalia.runAsync({ "xdg-open", path })
+end
+
+-- ── fzf capability + scoring ─────────────────────────────────────────────────
+
+-- --scheme=path arrived in fzf 0.36; an older build exits with "unknown option"
+-- and the entry would show an empty list forever. So the flag is only ever used
+-- after the installed version says it is understood — one spawn per script
+-- load, generic ranking until it answers.
+function shared.probeFzfScheme()
+    noctalia.runAsync("fzf --version 2>/dev/null", function(result)
+        local major, minor = (result.stdout or ""):match("(%d+)%.(%d+)")
+        major, minor = tonumber(major), tonumber(minor)
+        shared.schemeSupported = major ~= nil and minor ~= nil and (major > 0 or minor >= 36)
+    end, 5000)
+end
+
+-- The scoring flag for the next search: what the toggle asks for, if fzf can.
+function shared.rankingFlag()
+    return (shared.ranking == "path" and shared.schemeSupported) and " --scheme=path" or ""
+end
+
+-- Whether the plugin may walk the tree by itself. It may for the search folder,
+-- which is local and takes seconds; it may NOT once an external disk is in
+-- scope. A 5 TB mechanical USB drive takes minutes per walk and would otherwise
+-- be re-walked on every scope change, settings change, disk plug and panel
+-- open — the panel's refresh button (and the launcher's rebuild row) is the
+-- only way.
+function shared.autoIndexAllowed()
+    return shared.scope == "folder"
+end
+
+-- ── plugin data directory ────────────────────────────────────────────────────
+
+-- Private per-plugin storage (XDG state); the host creates the directory on
+-- every call. nil (with a log line) when no state directory resolves.
+function shared.dataDir()
+    local dir, err = noctalia.pluginDataDir()
+    if dir == nil then
+        noctalia.log("file-search: pluginDataDir failed: " .. tostring(err))
+        return nil
+    end
+    return dir
+end
+
+-- Shell header shared by every cache command. One cache pair per scope, so
+-- switching to the disks and back does not re-walk the search folder; the
+-- .meta sidecar holds the settings fingerprint the cache was built with, so
+-- every entry can tell a stale index apart. The scope is a word from
+-- SCOPE_GLYPHS, never free text, so it is safe inside the path.
+function shared.cacheSh(dir)
+    return "CACHE_DIR=" .. shared.shellQuote(dir)
+        .. '\nCACHE="$CACHE_DIR/list-' .. shared.scope .. '"'
+        .. '\nMETA="$CACHE_DIR/meta-' .. shared.scope .. '"'
+        .. '\nCOUNTF="$CACHE_DIR/count-' .. shared.scope .. '"'
+end
+
+function shared.readScope(dir)
+    local raw = noctalia.readFile(dir .. "/scope")
+    if type(raw) == "string" then
+        local value = shared.trim(raw)
+        if shared.SCOPE_GLYPHS[value] ~= nil then
+            return value
+        end
+    end
+    return shared.DEFAULT_SCOPE
+end
+
+function shared.writeScope(dir, value)
+    local ok, err = noctalia.writeFile(dir .. "/scope", value)
+    if not ok then
+        noctalia.log("file-search: could not persist the scope: " .. tostring(err))
+    end
+end
+
+function shared.readRanking(dir)
+    local raw = noctalia.readFile(dir .. "/ranking")
+    if type(raw) == "string" then
+        local value = shared.trim(raw)
+        if shared.RANKING_GLYPHS[value] ~= nil then
+            return value
+        end
+    end
+    return shared.DEFAULT_RANKING
+end
+
+function shared.writeRanking(dir, value)
+    local ok, err = noctalia.writeFile(dir .. "/ranking", value)
+    if not ok then
+        noctalia.log("file-search: could not persist the ranking: " .. tostring(err))
+    end
+end
+
+-- ── settings ─────────────────────────────────────────────────────────────────
+
+function shared.searchRoot()
+    local dir = noctalia.getConfig("search_folder")
+    if dir == nil or dir == "" then
+        dir = noctalia.getenv("HOME") or "/tmp"
+    else
+        dir = noctalia.expandPath(dir)
+    end
+    dir = dir:gsub("/+$", "")
+    if dir == "" then
+        dir = "/"
+    end
+    return dir
+end
+
+-- Excluded directory names from the setting, split on ',' or ';'. Matching
+-- is by basename (find -name), so entries containing '/' are skipped and
+-- logged. Hidden entries are folded in as an extra '.*' pattern.
+function shared.excludeNames()
+    local raw = noctalia.getConfig("exclude_dirs")
+    if type(raw) ~= "string" then
+        raw = ""
+    end
+    local names = {}
+    for entry in raw:gmatch("[^,;]+") do
+        local name = shared.trim(entry)
+        if name:find("/") then
+            noctalia.log("file-search: ignoring exclude entry with '/': '" .. name .. "'")
+        elseif name ~= "" then
+            table.insert(names, name)
+        end
+    end
+    if noctalia.getConfig("show_hidden") ~= true then
+        table.insert(names, ".*")
+    end
+    return names
+end
+
+-- ── removable volume detection ───────────────────────────────────────────────
+
+-- A mount point worth indexing: absolute, not the system root, no control
+-- character (it becomes a shell word and a cache record), and not the boot
+-- partition, which is a mount of firmware files even when it sits on a stick.
+function shared.usableMount(path)
+    if path == nil or path == "" or path:sub(1, 1) ~= "/" then
+        return false
+    end
+    if path == "/" or path:find("%c") ~= nil then
+        return false
+    end
+    return path ~= "/boot" and not shared.startsWith(path, "/boot/")
+end
+
+-- lsblk --pairs quotes every value; depending on the util-linux version a
+-- space or a quote inside one can come back as a \xNN escape. nil for an
+-- escaped control byte: the whole mount point is then dropped by the caller,
+-- rather than kept with a literal "\x0a" in it that no path would match.
+function shared.unescapeHex(value)
+    local rejected = false
+    local out = value:gsub("\\x(%x%x)", function(hex)
+        local code = tonumber(hex, 16)
+        if code == nil or code < 32 or code == 127 then
+            rejected = true
+            return ""
+        end
+        return string.char(code)
+    end)
+    if rejected then
+        return nil
+    end
+    return out
+end
+
+function shared.pairValue(line, key)
+    return (" " .. line):match(" " .. key .. '="(.-)"')
+end
+
+-- Mount points of the volumes that came from a USB port or report themselves
+-- removable (sticks, SD cards, optical media).
+--
+-- The interesting attribute lives on the DISK, not on the partition that is
+-- actually mounted: a USB partition row reports TRAN="" and, for a bus-powered
+-- SSD, RM="0" as well — only its parent disk says TRAN="usb". So the PKNAME
+-- chain is walked upwards (one more level for an encrypted stick: crypt →
+-- part → disk). HOTPLUG is deliberately not part of the test: some NVMe and
+-- hot-swap SATA controllers report HOTPLUG="1" for internal drives.
+function shared.parseLsblk(out)
+    local rows, byName = {}, {}
+    for line in out:gmatch("[^\n]+") do
+        local name = shared.pairValue(line, "NAME")
+        if name ~= nil and name ~= "" then
+            local row = {
+                parent = shared.pairValue(line, "PKNAME") or "",
+                removable = shared.pairValue(line, "RM") == "1",
+                transport = shared.pairValue(line, "TRAN") or "",
+                mount = shared.unescapeHex(shared.pairValue(line, "MOUNTPOINT") or ""),
+            }
+            byName[name] = row
+            table.insert(rows, row)
+        end
+    end
+    local found = {}
+    for _, row in ipairs(rows) do
+        if shared.usableMount(row.mount) then
+            local node, depth = row, 0
+            -- Capped: PKNAME comes from outside and a cycle would hang here.
+            while node ~= nil and depth < 4 do
+                if node.transport == "usb" or node.removable then
+                    table.insert(found, row.mount)
+                    break
+                end
+                node = (node.parent ~= "") and byName[node.parent] or nil
+                depth += 1
+            end
+        end
+    end
+    return found
+end
+
+-- Fallback for a system without util-linux: the mount table still exposes the
+-- udisks2 convention every mainstream desktop mounts removable media with
+-- (/run/media/<user>/<label>), plus the older /media/<user>|<label> layout of
+-- udisks1 and pmount. Paths in /proc/mounts spell space and tab as an octal
+-- escape. Internal disks mounted by hand under /mnt are NOT picked up here —
+-- same as with lsblk, where they are neither USB nor removable.
+function shared.fallbackMounts()
+    local text = noctalia.readFile("/proc/mounts")
+    if type(text) ~= "string" then
+        return {}
+    end
+    local found = {}
+    for line in text:gmatch("[^\n]+") do
+        local raw = line:match("^%S+%s+(%S+)%s")
+        if raw ~= nil then
+            local rejected = false
+            local path = raw:gsub("\\(%d%d%d)", function(octal)
+                local code = tonumber(octal, 8)
+                if code == nil or code < 32 or code == 127 then
+                    rejected = true
+                    return ""
+                end
+                return string.char(code)
+            end)
+            if rejected then
+                path = ""
+            end
+            local rest = path:match("^/run/media/[^/]+/(.+)$") or path:match("^/media/(.+)$")
+            if rest ~= nil and rest ~= "" and shared.usableMount(path) then
+                table.insert(found, path)
+            end
+        end
+    end
+    return found
+end
+
+-- Whether a mount scan is in flight. The launcher checks it to park the query
+-- it would otherwise have handed to a probe that is already running.
+function shared.probeBusy()
+    return probing
+end
+
+-- Refresh `shared.mounts`, then continue. Async because lsblk is a process:
+-- every caller has to be written as a continuation. Skipped entirely — no spawn
+-- at all — while the scope is the search folder, so the default costs nothing,
+-- and a scan younger than MOUNT_TTL is reused unless `force` says otherwise
+-- (the panel's refresh button forces one, since noticing a disk is the point of
+-- it).
+--
+-- A caller arriving while a scan is in flight does NOT get a second scan and
+-- does not get called back immediately with the list that is about to be
+-- replaced: its continuation takes the place of any other one waiting, and runs
+-- when the scan lands. Latest-wins, because both callers are "show what is
+-- current now" and the later one knows more. In practice neither entry gets
+-- there — the panel serialises through requestReload and the launcher parks the
+-- query itself (probeBusy above).
+function shared.probeMounts(force, done)
+    if shared.scope == "folder" then
+        shared.mounts = {}
+        done()
+        return
+    end
+    if not force and shared.mountsAt > 0 and (shared.now() - shared.mountsAt) < shared.MOUNT_TTL then
+        done()
+        return
+    end
+    if probing then
+        pendingProbeDone = done
+        return
+    end
+    local function finish()
+        shared.mountsAt = shared.now()
+        probing = false
+        local queued = pendingProbeDone
+        pendingProbeDone = nil
+        done()
+        if queued ~= nil then
+            queued()
+        end
+    end
+    if not noctalia.commandExists("lsblk") then
+        shared.mounts = shared.fallbackMounts()
+        finish()
+        return
+    end
+    probing = true
+    local ok = noctalia.runAsync("lsblk -P -o NAME,PKNAME,RM,TRAN,MOUNTPOINT 2>/dev/null", function(result)
+        if result.exitCode == 0 and not result.timedOut then
+            shared.mounts = shared.parseLsblk(result.stdout or "")
+        else
+            shared.mounts = shared.fallbackMounts()
+        end
+        finish()
+    end, 10000)
+    if not ok then
+        shared.mounts = shared.fallbackMounts()
+        finish()
+    end
+end
+
+-- ── index identity ───────────────────────────────────────────────────────────
+
+-- The roots the index covers, ancestors first and without overlaps: a volume
+-- mounted inside the search folder (or inside another volume) would otherwise
+-- be walked twice and produce duplicate rows. Sorting puts a parent before its
+-- children, so one pass is enough to drop the nested ones.
+function shared.computeRoots()
+    local list = {}
+    if shared.scope ~= "external" then
+        table.insert(list, shared.searchRoot())
+    end
+    if shared.scope ~= "folder" then
+        for _, mount in ipairs(shared.mounts) do
+            table.insert(list, (mount:gsub("/+$", "")))
+        end
+    end
+    table.sort(list)
+    local kept = {}
+    for _, path in ipairs(list) do
+        local nested = false
+        for _, parent in ipairs(kept) do
+            if path == parent or shared.startsWith(path, parent == "/" and "/" or parent .. "/") then
+                nested = true
+                break
+            end
+        end
+        if path ~= "" and not nested then
+            table.insert(kept, path)
+        end
+    end
+    return kept
+end
+
+-- Everything that decides how the cache was built. Its two lists are joined
+-- with a separator no root and no exclusion name can contain, so a name can
+-- never be read back as a root. This string is the contract between the
+-- entries: whichever one built the index, the others recognize it by this.
+function shared.indexKey()
+    return shared.INDEX_FORMAT .. "\n" .. shared.scope
+        .. "\n--\n" .. table.concat(shared.roots, "\n")
+        .. "\n--\n" .. table.concat(shared.excludeNames(), "\n")
+end
+
+-- The cache on disk is current when its fingerprint matches, whichever entry
+-- built it.
+function shared.cacheFresh(dir)
+    return noctalia.readFile(dir .. "/meta-" .. shared.scope) == shared.indexKey()
+end
+
+-- The roots the index on disk was built with, read back out of its fingerprint,
+-- or nil when there is no index. Records must be read the way they were
+-- WRITTEN, not the way a fresh walk would write them now: unplug one of two
+-- disks and the file still holds absolute records, so deciding the format from
+-- the current mount list would make every row unopenable — including the rows
+-- of the disk still attached — until the next rebuild.
+function shared.indexRootsOf(dir)
+    local meta = noctalia.readFile(dir .. "/meta-" .. shared.scope)
+    if type(meta) ~= "string" then
+        return nil
+    end
+    local section = meta:match("\n%-%-\n(.-)\n%-%-\n")
+    if section == nil then
+        return nil
+    end
+    local list = {}
+    for line in section:gmatch("[^\n]+") do
+        table.insert(list, line)
+    end
+    return #list > 0 and list or nil
+end
+
+-- An index record turned into a path, or nil when it could resolve outside the
+-- roots it was supposed to come from. The cache is a plain user-editable file,
+-- so records are untrusted. Only ever called from a callback that acts on a row
+-- — never from a render: it walks every path component, and paying that per row
+-- per frame is what gets a script callback killed for exceeding its CPU budget.
+function shared.absolutePath(record)
+    if record == "" or record:find("%c") ~= nil then
+        return nil
+    end
+    -- A directory keeps its trailing "/" in the index but not in a path meant
+    -- for xdg-open or for pasting into a shell.
+    local path = record:gsub("/+$", "")
+    for part in path:gmatch("[^/]+") do
+        if part == ".." then
+            return nil
+        end
+    end
+    -- Validated against the roots of the index the record came from, so a
+    -- record can still never escape a root, but one written for a disk that has
+    -- since been unplugged stays openable (xdg-open just fails if it is gone).
+    local from = #shared.indexRoots > 0 and shared.indexRoots or shared.roots
+    if shared.absoluteRecords then
+        for _, root in ipairs(from) do
+            if shared.startsWith(path, root == "/" and "/" or root .. "/") then
+                return path
+            end
+        end
+        return nil
+    end
+    local root = from[1]
+    if root == nil or path == "" or path:sub(1, 1) == "/" then
+        return nil
+    end
+    if root == "/" then
+        return root .. path
+    end
+    return root .. "/" .. path
+end
+
+-- ── the two commands ─────────────────────────────────────────────────────────
+
+-- Seconds a walk of the current scope is allowed to take.
+function shared.buildTimeout()
+    return (shared.scope == "folder") and shared.BUILD_TIMEOUT_LOCAL or shared.BUILD_TIMEOUT_DISKS
+end
+
+-- The tree walk, written for `key` as the fingerprint it will leave behind.
+-- Returns the shell script; the caller decides the timeout and what to do with
+-- the result.
+--
+-- find's own exit status is ignored, so permission errors inside the tree don't
+-- fail the build. Cache and fingerprint are written to mktemp-created private
+-- files and renamed into place: rename replaces a planted symlink at the
+-- destination instead of following it. The host guarantees $CACHE_DIR exists
+-- (created by pluginDataDir above). The two cleanup lines drop the pre-0.0.20
+-- single-scope cache and any temp file a killed build left behind — only ones
+-- older than 90 minutes, comfortably past the 30-minute build ceiling, so a
+-- walk running in another entry is never touched.
+--
+-- On success it prints "<count> <elapsed_ms>" and leaves the same pair in the
+-- count sidecar, so the panel's footer can report both without re-reading an
+-- index that may be 100 MB. The launcher ignores the output and reads nothing.
+function shared.buildCommand(dir, key, absolute)
+    -- Names containing a newline would each forge extra one-per-fragment
+    -- records (a crafted name can smuggle '..' lines into the index), so
+    -- they are pruned unconditionally, before the volume noise and the user's
+    -- own exclusions.
+    local names = { "-name " .. shared.shellQuote("*\n*") }
+    for _, pattern in ipairs(shared.VOLUME_NOISE) do
+        table.insert(names, "-iname " .. shared.shellQuote(pattern))
+    end
+    for _, name in ipairs(shared.excludeNames()) do
+        table.insert(names, "-name " .. shared.shellQuote(name))
+    end
+    local prune = "\\( " .. table.concat(names, " -o ") .. " \\) -prune -o "
+    local args = {}
+    for _, root in ipairs(shared.roots) do
+        table.insert(args, shared.shellQuote(root))
+    end
+    -- %P prints paths relative to the root, %p the whole path. Relative is
+    -- what a single root gets: it keeps the rows short and, more to the point,
+    -- keeps the common "/home/<user>/" prefix out of every line, where it
+    -- would be fuzzy-matched like any other text. With several roots a
+    -- relative record would be ambiguous, so those are absolute.
+    local printSpec = absolute
+        and "-type d -printf '%p/\\n' -o -printf '%p\\n'"
+        or "-type d -printf '%P/\\n' -o -printf '%P\\n'"
+    local walk = "find " .. table.concat(args, " ") .. " -mindepth 1 " .. prune
+        .. printSpec .. ' > "$TMP" 2>/dev/null'
+
+    return shared.cacheSh(dir)
+        .. '\nrm -f "$CACHE_DIR/index.list" "$CACHE_DIR/index.meta"\n'
+        .. 'find "$CACHE_DIR" -maxdepth 1 \\( -name \'list-*.*\' -o -name \'meta-*.*\''
+        .. " -o -name 'count-*.*' \\) -mmin +90 -delete 2>/dev/null\n"
+        -- Timed here rather than around runAsync: this is the walk itself,
+        -- without the queueing and callback hops the shell knows nothing about.
+        .. 'START=$(date +%s%3N)\n'
+        .. 'TMP=$(mktemp "$CACHE_DIR/list-' .. shared.scope .. '.XXXXXX") || exit 1\n'
+        .. walk .. "\n"
+        .. 'mv -f "$TMP" "$CACHE" || exit 1\n'
+        .. 'TMPM=$(mktemp "$CACHE_DIR/meta-' .. shared.scope .. '.XXXXXX") || exit 1\n'
+        .. "printf '%s' " .. shared.shellQuote(key) .. ' > "$TMPM"\n'
+        .. 'mv -f "$TMPM" "$META" || exit 1\n'
+        -- The count is taken here, while the file is already hot, and left in a
+        -- sidecar together with the elapsed milliseconds: every later open
+        -- reads a dozen bytes instead of the whole index.
+        .. 'COUNT=$(wc -l < "$CACHE") || exit 1\n'
+        .. 'ELAPSED=$(( $(date +%s%3N) - START ))\n'
+        .. 'TMPN=$(mktemp "$CACHE_DIR/count-' .. shared.scope .. '.XXXXXX") || exit 1\n'
+        .. 'printf "%s %s" "$COUNT" "$ELAPSED" > "$TMPN"\n'
+        .. 'mv -f "$TMPN" "$COUNTF" || exit 1\n'
+        .. 'printf "%s %s" "$COUNT" "$ELAPSED"'
+end
+
+-- One search over the cache, capped at `limit` rows. An empty query is the
+-- head of the index rather than an fzf run over everything. head closes the
+-- pipe early; the pipeline status stays head's (0).
+function shared.searchCommand(dir, text, limit)
+    if shared.trim(text) == "" then
+        return shared.cacheSh(dir) .. '\nhead -n ' .. limit .. ' "$CACHE" 2>/dev/null'
+    end
+    return shared.cacheSh(dir) .. "\nfzf" .. shared.rankingFlag()
+        .. " --filter=" .. shared.shellQuote(text)
+        .. ' < "$CACHE" 2>/dev/null | head -n ' .. limit
+end
+
+return shared

--- a/file-search/translations/en.json
+++ b/file-search/translations/en.json
@@ -1,7 +1,7 @@
 {
   "build_time": "indexed in {duration}",
   "copied_entry": "Path copied to clipboard",
-  "copied_path": "Search folder path copied to clipboard",
+  "copied_name": "Name copied to clipboard",
   "counts": "{shown} shown · {total} indexed",
   "counts_disks": " · {disks} external",
   "counts_stale": " · out of date",
@@ -14,20 +14,21 @@
     "index_missing": "No index for this scope yet",
     "indexing": "Indexing files…",
     "no_results": "No matches",
-    "reindex_done": "Search index dropped — it rebuilds on the next search",
     "reindex_title": "Rebuild search index",
     "scope_next": "Switch to: {next}",
     "scope_title": "Searching: {current}"
+  },
+  "menu": {
+    "copy_name": "Copy name",
+    "copy_path": "Copy full path",
+    "open": "Open",
+    "reveal": "Show in file manager"
   },
   "no_external": "No external disk mounted — plug one in, then rebuild the index",
   "no_results": "No matches for \"{query}\"",
   "ranking": {
     "default": "generic — the shortest path wins",
     "path": "path-aware — a match starting a name wins"
-  },
-  "row_action": {
-    "copy": "copies its path",
-    "reveal": "shows it in the file manager"
   },
   "scope": {
     "all": "search folder + external disks",
@@ -55,6 +56,10 @@
     "show_hidden": {
       "description": "Index files and folders whose name starts with a dot.",
       "label": "Include hidden entries"
+    },
+    "usage_exclude_dirs": {
+      "description": "Folders left out of the disk usage chart, separated by ',' or ';'. A bare name matches anywhere below the search folder; a path (absolute, or starting with ~) matches that one folder. Folders on another filesystem are already skipped.",
+      "label": "Usage chart: excluded folders"
     }
   },
   "status_indexing": "Indexing {path}…",
@@ -65,10 +70,26 @@
   "tip_ranking": "Ranking: {current}\ne.g. \"config\" → .ssh/config, not …/Steam Controller Configs/\nClick to switch to: {next}",
   "tip_ranking_unsupported": "Path-aware ranking needs fzf 0.36 or newer",
   "tip_refresh": "Rebuild the file index",
-  "tip_row_action": "Right click on a result {current}\nClick to switch to: {next}",
   "tip_scope": "Searching: {current}\nClick to search {next}",
+  "tip_scope_free": "{free} free across {count} disk(s)",
   "tip_settings": "Plugin settings",
+  "tip_usage_filter_clear": "Search the whole folder again",
+  "tip_usage_folder": "Search only inside {folder}",
+  "tip_usage_folder_clear": "Stop searching only inside {folder}",
+  "tip_usage_folder_only": "The usage chart only measures the search folder",
+  "tip_usage_hide": "Hide the disk usage chart",
+  "tip_usage_show": "Show what fills the search folder",
   "title": "File Search",
   "tooltip_closed": "File search — {path}\nClick to search · right-click: folder",
-  "tooltip_open": "File search open — {path}\nClick to close"
+  "tooltip_open": "File search open — {path}\nClick to close",
+  "usage_amount": "{size} · {share}%",
+  "usage_center": "used",
+  "usage_error": "Disk usage unavailable ({reason}).",
+  "usage_filter": "Searching inside {folder}",
+  "usage_hint": "click a folder to search inside it",
+  "usage_idle": "Disk usage not measured yet.",
+  "usage_loose": "(loose files)",
+  "usage_other": "other",
+  "usage_scanning": "Measuring disk usage…",
+  "usage_skipped": "not counted: {names} (other filesystem)"
 }

--- a/file-search/usage.luau
+++ b/file-search/usage.luau
@@ -1,0 +1,457 @@
+--!nonstrict
+-- file-search — disk usage donut for the panel.
+--
+-- `du` measures the direct children of the search root; the biggest few become
+-- a donut, the rest is folded into one "other" slice.
+--
+-- The chart is an SVG written into the plugin data directory and shown with
+-- ui.image. The noctalia ui tree has no arc element (ui.graph is a line
+-- sparkline) and the host rasterizes SVG through librsvg, so a generated file
+-- is the only way to draw one. A data: URI does not work: the panel's path
+-- resolver treats anything not starting with '/' or '~' as relative to the
+-- plugin directory.
+--
+-- Colours are hardcoded in two ramps chosen with isDarkMode(). The ui tree
+-- takes theme *role* names, but no API returns the palette as hex, so an SVG
+-- cannot follow the theme; the legend's swatches reuse these same values.
+--
+-- du is spawned as an argv (plugin_api >= 24), never as a shell line.
+
+-- Only for formatBytes and now(): both existed here as private copies until the
+-- byte formatter drifted from the panel's and the same measurement started
+-- reading as "110 GB" in the donut and "110.4 GB" in the free-space tooltip.
+-- require is cached per VM, so this is the same table panel.luau holds.
+local shared = require("./shared.luau")
+
+local usage = {}
+
+-- Eight, which is also the length of the palette, so no folder ever borrows a
+-- colour already on screen. Six left "other" as the second-biggest slice on a
+-- home directory (21% of it) while hiding two folders larger than the smallest
+-- one shown — and "other" is the one slice that cannot be clicked into.
+usage.MAX_SLICES = 8
+
+-- A day: du over a home directory takes ~7 seconds, disk usage moves over
+-- days, and the measurement is saved to disk. ↻ ignores this.
+usage.TTL_SECONDS = 86400
+usage.TIMEOUT_MS = 120000
+
+-- Fixed order, so a folder keeps its colour between measurements.
+usage.PALETTE_DARK = {
+    "#7aa2f7", "#9ece6a", "#e0af68", "#f7768e",
+    "#bb9af7", "#2ac3de", "#ff9e64", "#73daca",
+}
+usage.PALETTE_LIGHT = {
+    "#3b5fc0", "#4f8a2b", "#b07708", "#c2405a",
+    "#7c4dbd", "#0e7490", "#c25a12", "#2f8f7a",
+}
+
+-- ── measured state ───────────────────────────────────────────────────────────
+
+usage.state = "idle"   -- "idle" | "scanning" | "ready" | "error"
+-- { label, bytes, color, kind }, biggest first. kind is "folder", "loose"
+-- (what the root holds outside any subfolder) or "other" (the merged tail);
+-- only "folder" names something the panel can search inside.
+usage.slices = {}
+usage.total = 0        -- bytes of the scanned root itself
+usage.root = nil       -- what the numbers above describe
+usage.scannedAt = 0    -- unix seconds, 0 = never
+usage.errText = nil
+usage.imagePath = nil  -- current SVG, nil until one is written
+usage.skipped = {}     -- mount points under the root, so they can be named
+
+-- Set by the panel from translations/en.json: this module builds the slice
+-- labels, but user-visible strings still live in the translation file.
+usage.looseLabel = "(files)"
+usage.otherLabel = "other"
+
+-- Two fixed names, alternating: ui.image reloads only when the path string
+-- changes, and a counter would restart at zero on every reload and delete the
+-- file this run just wrote, leaking the older ones.
+local SVG_NAMES = { "usage-a.svg", "usage-b.svg" }
+local svgSlot = 0
+local scanning = false
+
+-- ── settings ─────────────────────────────────────────────────────────────────
+
+-- Kept apart from the index's exclude_dirs, which defaults to hiding .git and
+-- node_modules — what fills a source folder usually IS .git.
+--
+-- du's semantics, verified: a bare name matches anywhere below the root, a path
+-- matches exactly one folder. A leading '~' has to be expanded here, since the
+-- argv never reaches a shell and du would take it literally and match nothing,
+-- silently. Values are otherwise passed through; only a newline or NUL is
+-- rejected, as the one thing that could make a pattern mean something else.
+function usage.excludes()
+    local raw = noctalia.getConfig("usage_exclude_dirs")
+    if type(raw) ~= "string" then
+        return {}
+    end
+    local out = {}
+    for entry in raw:gmatch("[^,;]+") do
+        local name = entry:match("^%s*(.-)%s*$")
+        if name ~= "" then
+            if name:find("[\n\r%z]") then
+                noctalia.log("file-search: ignoring usage exclude with a control character")
+            else
+                if name:sub(1, 1) == "~" then
+                    name = noctalia.expandPath(name)
+                end
+                -- du matches the path as it builds it, never with a trailing
+                -- slash, so one here would make the pattern miss.
+                if #name > 1 then
+                    name = name:gsub("/+$", "")
+                end
+                table.insert(out, name)
+            end
+        end
+    end
+    return out
+end
+
+-- ── mounts ───────────────────────────────────────────────────────────────────
+
+-- Mount points directly inside `root`, from /proc/self/mounts: one file read,
+-- no process, no new dependency. They are not excluded here — `du -x` already
+-- refuses to cross a filesystem boundary — only named, so the panel can say
+-- what is missing from the total rather than under-report it.
+function usage.mountChildren(root)
+    local text = noctalia.readFile("/proc/self/mounts")
+    if type(text) ~= "string" then
+        return {}
+    end
+    local prefix = root .. "/"
+    local names, seen = {}, {}
+    for line in text:gmatch("[^\n]+") do
+        -- Second field is the target, with spaces and newlines octal-escaped.
+        local target = line:match("^%S+%s+(%S+)")
+        if target ~= nil then
+            target = target:gsub("\\(%d%d%d)", function(digits)
+                return string.char(tonumber(digits, 8))
+            end)
+            if target:sub(1, #prefix) == prefix then
+                local rest = target:sub(#prefix + 1)
+                if rest ~= "" and not rest:find("/") and not seen[rest] then
+                    seen[rest] = true
+                    table.insert(names, rest)
+                end
+            end
+        end
+    end
+    table.sort(names)
+    return names
+end
+
+-- ── du output ────────────────────────────────────────────────────────────────
+
+-- One `<bytes>\t<path>` line per direct child, the root itself last.
+--
+-- Records are validated, not trusted: du separates them with a newline and a
+-- directory name may contain one, so a crafted name can forge a line. Keeping
+-- only paths that are a direct child of the root is what a forged fragment
+-- cannot produce — it would have to reproduce the root prefix inside a name
+-- below that same root.
+local function parseDu(out, root)
+    local entries, rootBytes = {}, nil
+    local prefix = root .. "/"
+    for line in out:gmatch("[^\n]+") do
+        local bytes, path = line:match("^(%d+)\t(.+)$")
+        if bytes ~= nil then
+            bytes = tonumber(bytes)
+            if path == root then
+                rootBytes = bytes
+            elseif path:sub(1, #prefix) == prefix then
+                local name = path:sub(#prefix + 1)
+                -- An exclusion given as a bare name empties every folder whose
+                -- CONTENTS it matched instead of removing the folder, and a
+                -- "0 B · 0%" legend row is noise.
+                if name ~= "" and not name:find("/") and bytes > 0 then
+                    table.insert(entries, { name = name, bytes = bytes })
+                end
+            end
+        end
+    end
+    return entries, rootBytes
+end
+
+-- Colour by position, in place. Separate from building the slices because a
+-- measurement restored from disk was written under whatever theme was up then,
+-- so colours are re-derived on load rather than persisted.
+function usage.paint(slices)
+    local palette = noctalia.isDarkMode() and usage.PALETTE_DARK or usage.PALETTE_LIGHT
+    local rank = 0
+    for _, slice in ipairs(slices) do
+        if slice.kind == "other" then
+            -- Outside the ramp: a leftover, not a folder. Dark enough to still
+            -- read as a 9px swatch on the light theme.
+            slice.color = noctalia.isDarkMode() and "#5b6180" or "#9aa2b8"
+        else
+            rank += 1
+            slice.color = palette[((rank - 1) % #palette) + 1]
+        end
+    end
+    return slices
+end
+
+-- Biggest MAX_SLICES children, the tail merged, plus whatever the root holds
+-- outside any child folder — without that last one the parts visibly fail to
+-- add up to the number in the middle.
+local function toSlices(entries, rootBytes, looseLabel, otherLabel)
+    table.sort(entries, function(a, b)
+        return a.bytes > b.bytes
+    end)
+
+    local childSum = 0
+    for _, entry in ipairs(entries) do
+        childSum += entry.bytes
+    end
+    local loose = rootBytes - childSum
+    if loose > 0 then
+        table.insert(entries, { name = looseLabel, bytes = loose, kind = "loose" })
+        table.sort(entries, function(a, b)
+            return a.bytes > b.bytes
+        end)
+    end
+
+    local slices, tail = {}, 0
+    for index, entry in ipairs(entries) do
+        if index <= usage.MAX_SLICES then
+            table.insert(slices, {
+                label = entry.name,
+                bytes = entry.bytes,
+                kind = entry.kind or "folder",
+            })
+        else
+            tail += entry.bytes
+        end
+    end
+    if tail > 0 then
+        table.insert(slices, { label = otherLabel, bytes = tail, kind = "other" })
+    end
+    return usage.paint(slices)
+end
+
+-- ── SVG ──────────────────────────────────────────────────────────────────────
+
+local function escapeXml(text)
+    return (text:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"):gsub('"', "&quot;"))
+end
+
+-- A dashed circle, not an arc path: "run, remainder" with a negative dashoffset
+-- puts one visible run anywhere on the ring, with no large-arc-flag case to get
+-- wrong at half the circle.
+local function segment(cx, cy, radius, width, color, fromFraction, lengthFraction)
+    local circumference = 2 * math.pi * radius
+    -- A hairline gap between neighbours. Subtracted from the run, never added,
+    -- or the ring drifts.
+    local run = circumference * lengthFraction - 1.5
+    if run <= 0 then
+        return ""
+    end
+    return string.format(
+        '<circle cx="%.2f" cy="%.2f" r="%.2f" fill="none" stroke="%s" stroke-width="%.2f"'
+            .. ' stroke-dasharray="%.3f %.3f" stroke-dashoffset="%.3f"'
+            .. ' transform="rotate(-90 %.2f %.2f)"/>',
+        cx, cy, radius, color, width, run, circumference - run,
+        -circumference * fromFraction, cx, cy
+    )
+end
+
+-- `size` is the CSS pixel box; the host rasterizes at 3× the element size.
+function usage.svg(slices, total, size, thickness, centerTop, centerBottom)
+    local dark = noctalia.isDarkMode()
+    local track = dark and "#2a2e3f" or "#e3e6ee"
+    local strong = dark and "#e6e9f0" or "#1c2030"
+    local dim = dark and "#9aa2b8" or "#5a627a"
+    local cx, cy = size / 2, size / 2
+    local radius = (size - thickness) / 2 - 1
+
+    local parts = {
+        string.format(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">',
+            size, size, size, size
+        ),
+        string.format(
+            '<circle cx="%.2f" cy="%.2f" r="%.2f" fill="none" stroke="%s" stroke-width="%.2f"/>',
+            cx, cy, radius, track, thickness
+        ),
+    }
+
+    local denominator = total > 0 and total or 1
+    local accumulated = 0.0
+    for _, slice in ipairs(slices) do
+        local fraction = slice.bytes / denominator
+        if fraction > 0 then
+            table.insert(parts, segment(cx, cy, radius, thickness, slice.color, accumulated, fraction))
+            accumulated += fraction
+        end
+    end
+
+    table.insert(parts, string.format(
+        '<text x="%.2f" y="%.2f" text-anchor="middle" font-family="sans-serif" font-size="%.1f"'
+            .. ' font-weight="600" fill="%s">%s</text>',
+        cx, cy - 1, size * 0.145, strong, escapeXml(centerTop)
+    ))
+    table.insert(parts, string.format(
+        '<text x="%.2f" y="%.2f" text-anchor="middle" font-family="sans-serif" font-size="%.1f"'
+            .. ' fill="%s">%s</text>',
+        cx, cy + size * 0.105, size * 0.10, dim, escapeXml(centerBottom)
+    ))
+    table.insert(parts, "</svg>")
+    return table.concat(parts, "")
+end
+
+-- Write the chart and point usage.imagePath at it, removing the other name.
+function usage.writeSvg(dataDir, size, thickness, centerTop, centerBottom)
+    if dataDir == nil then
+        return
+    end
+    svgSlot = (svgSlot % #SVG_NAMES) + 1
+    local previous = usage.imagePath or (dataDir .. "/" .. SVG_NAMES[(svgSlot % #SVG_NAMES) + 1])
+    local path = dataDir .. "/" .. SVG_NAMES[svgSlot]
+    local ok, err = noctalia.writeFile(path, usage.svg(usage.slices, usage.total, size, thickness, centerTop, centerBottom))
+    if not ok then
+        noctalia.log("file-search: could not write the usage chart: " .. tostring(err))
+        return
+    end
+    usage.imagePath = path
+    if previous ~= nil and previous ~= path then
+        noctalia.removeFile(previous)
+    end
+end
+
+-- ── persistence ──────────────────────────────────────────────────────────────
+
+-- The measurement outlives the process, so a restart (or a hot reload) does not
+-- pay a du walk for numbers that have not changed. Anything unreadable or from
+-- another version is discarded, not repaired: it is a cache.
+local STORE_VERSION = 1
+
+function usage.save(dataDir)
+    if dataDir == nil or usage.state ~= "ready" then
+        return
+    end
+    local plain = {}
+    for _, slice in ipairs(usage.slices) do
+        table.insert(plain, { label = slice.label, bytes = slice.bytes, kind = slice.kind })
+    end
+    local text = noctalia.json.encode({
+        version = STORE_VERSION,
+        root = usage.root,
+        total = usage.total,
+        at = usage.scannedAt,
+        slices = plain,
+        skipped = usage.skipped,
+    })
+    if type(text) ~= "string" then
+        return
+    end
+    local ok, err = noctalia.writeFile(dataDir .. "/usage.json", text)
+    if not ok then
+        noctalia.log("file-search: could not save the usage measurement: " .. tostring(err))
+    end
+end
+
+function usage.load(dataDir)
+    if dataDir == nil or usage.state == "ready" then
+        return false
+    end
+    local text = noctalia.readFile(dataDir .. "/usage.json")
+    if type(text) ~= "string" or text == "" then
+        return false
+    end
+    local ok, data = pcall(noctalia.json.decode, text)
+    if not ok or type(data) ~= "table" or data.version ~= STORE_VERSION then
+        return false
+    end
+    if type(data.root) ~= "string" or type(data.total) ~= "number" or type(data.slices) ~= "table" then
+        return false
+    end
+    local slices = {}
+    for _, slice in ipairs(data.slices) do
+        if type(slice) == "table" and type(slice.label) == "string" and type(slice.bytes) == "number" then
+            table.insert(slices, { label = slice.label, bytes = slice.bytes, kind = slice.kind or "folder" })
+        end
+    end
+    if #slices == 0 then
+        return false
+    end
+    usage.root = data.root
+    usage.total = data.total
+    usage.scannedAt = type(data.at) == "number" and data.at or 0
+    usage.slices = usage.paint(slices)
+    usage.skipped = type(data.skipped) == "table" and data.skipped or {}
+    usage.state = "ready"
+    usage.errText = nil
+    return true
+end
+
+-- ── measuring ────────────────────────────────────────────────────────────────
+
+function usage.fresh(root)
+    return usage.state == "ready" and usage.root == root
+        and (shared.now() - usage.scannedAt) < usage.TTL_SECONDS
+end
+
+-- Measure `root`, then call done() either way. `force` skips the TTL; a scan
+-- already in flight is never doubled.
+--
+-- -x keeps du inside one filesystem, so a mount below the root is not descended
+-- and cannot stall the panel. -d1 stops at the direct children, -B1 makes the
+-- first column plain bytes. The root goes after "--", so one starting with a
+-- dash is still a path.
+function usage.scan(root, dataDir, force, done)
+    if scanning then
+        return
+    end
+    if not force and usage.fresh(root) then
+        done()
+        return
+    end
+    if not noctalia.commandExists("du") then
+        usage.state = "error"
+        usage.errText = "du"
+        done()
+        return
+    end
+
+    local argv = { "du", "-x", "-d1", "-B1" }
+    for _, pattern in ipairs(usage.excludes()) do
+        table.insert(argv, "--exclude=" .. pattern)
+    end
+    table.insert(argv, "--")
+    table.insert(argv, root)
+
+    scanning = true
+    usage.state = "scanning"
+    local started = noctalia.runAsync(argv, function(result)
+        scanning = false
+        local entries, rootBytes = parseDu(result.stdout or "", root)
+        -- A non-zero exit is normal: one unreadable directory makes du exit 1
+        -- after printing everything else. The output decides, not the status.
+        if result.timedOut or rootBytes == nil then
+            usage.state = "error"
+            usage.errText = result.timedOut and "timeout" or "empty"
+            done()
+            return
+        end
+        usage.root = root
+        usage.total = rootBytes
+        usage.slices = toSlices(entries, rootBytes, usage.looseLabel, usage.otherLabel)
+        usage.skipped = usage.mountChildren(root)
+        usage.scannedAt = shared.now()
+        usage.state = "ready"
+        usage.errText = nil
+        usage.save(dataDir)
+        done()
+    end, usage.TIMEOUT_MS)
+
+    if not started then
+        scanning = false
+        usage.state = "error"
+        usage.errText = "spawn"
+        done()
+    end
+end
+
+return usage


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `nightwatch75/file-search`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Brings the merged 0.0.25 up to 0.2.0 (`plugin_api` 15 → 28). Changes, in order:

- Cached path eliding and a `nowMs` clock so the panel stops hitting the
  render CPU-budget timeout on a busy result list
- A disk free-space tooltip on the scope button, memoized off the render path
- `shared.luau`: the bar widget, panel and launcher now share one index
  module instead of three copies (`plugin_api` 22, relative imports)
- A disk-usage donut under the results: biggest direct children of the
  search folder, click a legend row to narrow the search to that folder
- A native right-click row menu — open, show in file manager, copy path,
  copy name (`panel.openContextMenu`, `plugin_api` 28)
- `xdg-open`, the file-manager reveal call and `du` now run as a direct
  argv, so none of them ever go through a shell

## External dependencies

Adds `du` (GNU coreutils) for the disk-usage chart — already declared in
`dependencies` and documented in the README's Requirements section.
Everything else was already required.

## Testing

- `noctalia plugins lint .` — clean.
- The community `validate-plugins.py` — clean.
- Compositor testing and screenshots to be added before this leaves Draft.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** 28

## Screenshots / Videos

<img width="653" height="902" alt="01-filesearch020" src="https://github.com/user-attachments/assets/77f66368-2d73-4ca9-9877-fb5e49507921" />
<img width="660" height="913" alt="02-filesearch020" src="https://github.com/user-attachments/assets/140f5f90-cd72-40e5-83c0-c7a4ee9f9918" />


## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [ ] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
