### PR TITLE
fix(eyecare): use current theme for widget text color

### DIFF
--- a/eyecare/plugin.toml
+++ b/eyecare/plugin.toml
@@ -1,6 +1,6 @@
 id = "apex077/eyecare"
 name = "Eye-Care Reminders"
-version = "1.0.2"
+version = "1.0.3"
 plugin_api = 3
 author = "Apex077"
 license = "MIT"

--- a/eyecare/widget.luau
+++ b/eyecare/widget.luau
@@ -20,8 +20,8 @@ local function render()
         barWidget.setGlyph("coffee")
         barWidget.setText(string.format("Idle: %ds", idleTime))
         barWidget.setTooltip("System is idle. Resting eyes...")
-        barWidget.setGlyphColor("#26a69a") -- Teal
-        barWidget.setColor("#ffffff")
+        barWidget.setGlyphColor("on_surface_variant")
+        barWidget.setColor("on_surface")
         return
     end
 
@@ -30,16 +30,16 @@ local function render()
         local remaining = math.max(0, breakDurationSeconds - breakTimer)
         barWidget.setText(string.format("Break: %ds", remaining))
         barWidget.setTooltip(string.format("Break in progress! Look 20ft away.\nTime remaining: %ds\nClick to abort early\nRight-click to reset", remaining))
-        barWidget.setGlyphColor("#ff5252") -- Soft Red
-        barWidget.setColor("#ff5252")
+        barWidget.setGlyphColor("error")
+        barWidget.setColor("error")
     else
         barWidget.setGlyph("eye")
         local activeLimit = activeDurationMinutes * 60
         local remaining = math.max(0, activeLimit - activeTime)
         barWidget.setText(formatTime(remaining))
         barWidget.setTooltip(string.format("Eye-Care timer active.\nTime remaining: %s\nClick to start break manually\nRight-click to reset", formatTime(remaining)))
-        barWidget.setGlyphColor("#00e676") -- Vibrant Green
-        barWidget.setColor("#ffffff")
+        barWidget.setGlyphColor("primary")
+        barWidget.setColor("on_surface")
     end
 end
 


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `apex077/eyecare`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

This updates the eyecare plugin to use the user theme color instead of hardcoded color

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.1
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos
Before it looks like that in my environment:
<img width="96" height="49" alt="image" src="https://github.com/user-attachments/assets/f51d4685-5d74-4020-8488-4e4cbb9d28fd" />


And now like that:
<img width="112" height="55" alt="image" src="https://github.com/user-attachments/assets/f53686db-27d4-4900-990c-33e17843ac1d" />

(also the break one looks pretty similar as before for me:)
<img width="150" height="51" alt="image" src="https://github.com/user-attachments/assets/3c81fc5a-0ada-4c9c-b6f5-976f108d60ae" />

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
