### PR TITLE
Add font size setting to widget in plugin jamesfeeder/special-workspaces

### DIFF
--- a/special-workspaces/README.md
+++ b/special-workspaces/README.md
@@ -29,6 +29,7 @@ can be hidden with `hide_inactive`.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
+| `font_size` | `int` | `11` | Workspace name font size. Set `0` to use system default. |
 | `max_label_chars` | `int` | `0` | Maximum Unicode characters shown from each workspace name. `0` shows the full name. |
 | `hide_inactive` | `bool` | `false` | Hide populated workspaces unless they are visible on a monitor. |
 | `capsule_radius` | `int` | `8` | Corner radius in logical pixels. Negative values are treated as `0`. |

--- a/special-workspaces/plugin.toml
+++ b/special-workspaces/plugin.toml
@@ -1,6 +1,6 @@
 id = "jamesfeeder/special-workspaces"
 name = "Special Workspaces"
-version = "1.4.0"
+version = "1.5.0"
 plugin_api = 3
 author = "jamesfeeder"
 license = "MIT"
@@ -16,6 +16,13 @@ entry = "service.luau"
 [[widget]]
 id = "special-workspaces"
 entry = "widget.luau"
+
+  [[widget.setting]]
+  key = "font_size"
+  type = "int"
+  label_key = "settings.font_size.label"
+  description_key = "settings.font_size.description"
+  default = 11
 
   [[widget.setting]]
   key = "max_label_chars"

--- a/special-workspaces/translations/en.json
+++ b/special-workspaces/translations/en.json
@@ -28,6 +28,10 @@
       "description": "Maximum characters shown from each workspace name. Use 0 to show the full name.",
       "label": "Maximum label characters"
     },
+    "font_size": {
+      "description": "Workspace name font size. Set 0 to use system default.",
+      "label": "Font size"
+    },
     "style": {
       "fill": "Fill",
       "ghost": "Ghost"

--- a/special-workspaces/widget.luau
+++ b/special-workspaces/widget.luau
@@ -1,7 +1,13 @@
+local function getFontSize()
+  local fontSize = tonumber(noctalia.getConfig("font_size"))
+  return (fontSize ~= 0) and fontSize or nil
+end
+
 local STATE_KEY = "special_workspaces"
 local PILL_HEIGHT = 16
 local PILL_GAP = 4
 local state = noctalia.state.get(STATE_KEY) or {}
+local fontSize = getFontSize()
 local maxLabelChars = tonumber(noctalia.getConfig("max_label_chars")) or 0
 local hideInactive = noctalia.getConfig("hide_inactive") == true
 local capsuleRadius = math.max(0, tonumber(noctalia.getConfig("capsule_radius")) or 8)
@@ -69,7 +75,7 @@ local function render(vertical)
       table.insert(chips, capsule(capsuleProps, {
         ui.label({
           text = vertical and verticalName(label) or label,
-          fontSize = 11,
+          fontSize = fontSize,
           color = textColor,
           textAlign = "center",
         }),
@@ -93,6 +99,7 @@ noctalia.state.watch(STATE_KEY, function(value)
 end)
 
 function onConfigChanged()
+  fontSize = getFontSize()
   maxLabelChars = tonumber(noctalia.getConfig("max_label_chars")) or 0
   hideInactive = noctalia.getConfig("hide_inactive") == true
   capsuleRadius = math.max(0, tonumber(noctalia.getConfig("capsule_radius")) or 8)


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `jamesfeeder/special-workspaces`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Hardcoded font size replaced with setting. Default configuration preserved.

## External dependencies

Not changed

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<img width="153" height="37" alt="satty-2026-09-04_21:03:53" src="https://github.com/user-attachments/assets/89bf4979-76f2-4af4-9137-95a6f0c65d9b" />
<img width="262" height="33" alt="satty-2026-09-04_21:04:18" src="https://github.com/user-attachments/assets/e4202e1f-e437-4218-998e-a66d66c00352" />

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
