### PR TITLE
feat!(Config Swap): add custom path support

### DIFF
--- a/config-swap/config-swap-panel.luau
+++ b/config-swap/config-swap-panel.luau
@@ -2,9 +2,6 @@
 -- Config Swap panel
 
 -- Local variables
-
-local configBox = "~/Config-Swap" 			
-
 local listConfig = nil
 
 local pickSlots = {}
@@ -52,6 +49,34 @@ function isDetect(target: string)
 		return false
 	end
 end
+
+-- Function for data save accross  reset
+
+local function getDataPath()
+	return noctalia.pluginDataDir() .. "/data.json"
+end
+
+local function loadValue()
+	local raw = noctalia.readFile(getDataPath())
+	if not raw then
+		return nil
+	end
+	local ok, decoded = pcall(function()
+		return noctalia.json.decode(raw)
+	end)
+	if not ok or type(decoded) ~= "table" then
+		return nil
+	end
+	return decoded.value
+end
+
+local function saveValue(value)
+	local content = noctalia.json.encode({ value = value })
+	return noctalia.writeFile(getDataPath(), content)
+end
+
+local configBox = loadValue() or "~/Config-Swap"
+local configBoxSave = "~/Config-Swap"
 
 -- Store listing cache
 
@@ -283,6 +308,7 @@ local noctaliaStateDir = resolveStateDir()
 local settingsTomlPath = noctaliaStateDir .. "/settings.toml"	-- Active settings file path
 
 local saveNameInput = "save"
+local customPath = configBox
 
 local function saveConfig()
 	local name = saveNameInput ~= "" and saveNameInput or "save"
@@ -322,7 +348,27 @@ function onSaveNameChange(value)
 	saveNameInput = value
 end
 
-local function renderSetting()
+function onCustomPathChange(value)
+	customPath = value 
+end
+
+function saveCustomPath(value)
+	if value == "" or value == nil then
+		noctalia.notify(tr("title"), tr("error_path"))
+		return
+	end
+	local start = string.sub(value, 1, 2)
+	if start ~= "~/" then
+		noctalia.notify(tr("title"), tr("error_path"))
+		return
+	end
+	configBox = customPath
+	configBox = noctalia.expandPath(value)
+	noctalia.notify(tr("title"), tr("success_path"))
+	saveValue(configBox)
+end
+
+local function renderSetting()				-- Render for setting panel 
 	local rowsSettings = {
 		ui.column({ gap = 8 }, {
 			ui.label({
@@ -336,6 +382,7 @@ local function renderSetting()
 					value = saveNameInput,
 					placeholder = "Save name",
 					onChange = "onSaveNameChange",
+
 					flexGrow = 1,
 				}),
 				ui.button({ text = tr("save"), onClick = function()
@@ -343,6 +390,26 @@ local function renderSetting()
 				end
 				}),
 			}),
+			ui.label({
+				text = "Custom path: enter your custom path following this example: ~/{your path}",
+				fontSize = 12,
+				color = "on_surface_variant",
+			}),
+			ui.row({ flexGrow = 1, gap = 16, align = "center"}, {
+				ui.input({
+					key = "save-name-input",
+					value = customPath,
+					placeholder = "Custom Path",
+					onChange = "onCustomPathChange",
+					flexGrow = 1,
+				}),
+				ui.button({
+					text = "Change path",
+					onClick = function()
+						saveCustomPath(customPath)
+					end
+				})
+			})
 		}),
 	}
 	panel.render(ui.column({ flexGrow = 1, gap = 16 }, {
@@ -494,6 +561,9 @@ end
 
 function getListInstall()
 	local localPath = configBox
+	if not noctalia.fileExists(localPath) then
+		noctalia.mkdirAll(localPath)
+	end
 	local list = noctalia.listDir(localPath)
 	local listShow: { infoConfig } = {}
 

--- a/config-swap/config-swap-service.luau
+++ b/config-swap/config-swap-service.luau
@@ -1,1 +1,17 @@
 noctalia.mkdirAll("~/Config-Swap")
+local configBox = "~/Config-Swap" 	
+
+type saveCustomPath = {
+    value: string
+}
+
+local save: saveCustomPath = {
+    value = configBox
+}
+
+
+local dir = noctalia.pluginDataDir()
+local path = dir .. "/data.json"
+if not noctalia.fileExists(path) then
+    noctalia.writeFile(path, noctalia.json.encode(save))
+end

--- a/config-swap/plugin.toml
+++ b/config-swap/plugin.toml
@@ -1,6 +1,6 @@
 id = "tadomika_ari/config-swap"
 name = "Config Swap"
-version = "1.1.0"
+version = "1.2.0"
 plugin_api = 4
 author = "TadomiKa-Ari"
 license = "MIT"

--- a/config-swap/translations/en.json
+++ b/config-swap/translations/en.json
@@ -41,7 +41,9 @@
     "store_title": "Config Store",
     "title": "Config Swap",
     "welcome_message1": "Please read this carefully before you continue.",
-    "welcome_message2": "This plugin can replace your current Noctalia configuration. We recommend backing up your current settings first — use the Save button in the Installed section. Backups are stored in ~/Config-Swap.",
-    "welcome_message_title": "Welcome to Config Swap!"
+    "welcome_message2": "This plugin can replace your current Noctalia configuration. We recommend backing up your current settings first — use the Save button in the Installed section. Backups are stored in ~/Config-Swap or your custom path",
+    "welcome_message_title": "Welcome to Config Swap!",
+    "error_path": "Incorrect path. Need a path like: ~/{your path}",
+    "success_path": "New Path Set"
   }
 }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `<author>/<plugin>`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

The plugin did not have a custom path system and now the feature is available.
A check is run after try to apply path and accepte only path with ~/ at the begining for prevent bad path.
If folder not exist, the plugin create this.


Mention: https://github.com/noctalia-dev/community-plugins/issues/621#issue-5346892368
<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:**
- **Plugin API level:** <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
