### PR TITLE
feat(eyecare): complete the French translation

### DIFF
--- a/eyecare/plugin.toml
+++ b/eyecare/plugin.toml
@@ -1,6 +1,6 @@
 id = "apex077/eyecare"
 name = "Eye-Care Reminders"
-version = "1.0.2"
+version = "1.0.3"
 plugin_api = 3
 author = "Apex077"
 license = "MIT"

--- a/eyecare/translations/fr.json
+++ b/eyecare/translations/fr.json
@@ -1,10 +1,28 @@
 {
   "notifications": {
-    "eyecare-break-title": "Le temps d'une pause"
+    "eyecare-break-body": "Fixez un objet à six mètres pendant {seconds} secondes.",
+    "eyecare-break-finished-body": "Vos yeux sont reposés. Vous pouvez revenir à votre écran.",
+    "eyecare-break-finished-title": "Pause terminée",
+    "eyecare-break-title": "Le temps d'une pause",
+    "eyecare-reset-body": "Le minuteur a été réinitialisé.",
+    "eyecare-reset-title": "Eye-Care"
   },
   "settings": {
+    "eyecare-active-duration": {
+      "description": "Temps passé devant l'écran avant de déclencher une pause (minutes)",
+      "label": "Durée d'activité"
+    },
     "eyecare-break-duration": {
+      "description": "Durée imposée des pauses oculaires (secondes)",
       "label": "Durée de la pause"
+    },
+    "eyecare-notifications": {
+      "description": "Afficher des notifications système pour les rappels",
+      "label": "Activer les notifications"
+    },
+    "eyecare-sound": {
+      "description": "Jouer un son au début et à la fin des pauses",
+      "label": "Activer le retour sonore"
     }
   }
 }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `apex077/eyecare`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

`eyecare/translations/fr.json` carried 2 of the 14 keys the manifest and the entry scripts reference. With `lang = "fr"`, a French user got the break title translated and everything else in English, including the body of the reminder itself and all four setting labels.

This fills in the missing 12 keys. No code changes.

One translation choice worth flagging: the English body says "Focus on an object 20 feet away", which is the 20-20-20 rule. That mnemonic does not survive translation, and feet mean nothing to a French reader, so the distance is converted. The French reads "Fixez un objet à six mètres pendant {seconds} secondes."

## External dependencies

None. This PR only touches a JSON translation file and the `version` line in `plugin.toml`.

## Testing

Set `lang = "fr"` under `[shell]`, restarted the shell, then drove the service over IPC with `trigger-break` and `finish-break` to see both notifications. Verified the key set of `fr.json` matches `en.json` exactly, with no missing and no extra key, and that the file parses as valid JSON with its accents intact.

Worth knowing for anyone testing a translation: plugin translations are read once when the plugin loads. `config-reload` does not pick up an edited translation file, and toggling the plugin off and on re-exports it from the source cache, which overwrites local edits. A full shell restart is what makes an edited translation visible.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.1
- **Plugin API level:** 3

## Screenshots / Videos

Break start:

![Break start notification in French](https://raw.githubusercontent.com/stillsource/community-plugins/pr-638-assets/assets/eyecare-break-fr.png)

Break finished:

![Break finished notification in French](https://raw.githubusercontent.com/stillsource/community-plugins/pr-638-assets/assets/eyecare-finished-fr.png)

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

---

@Apex077 this touches your plugin, so it needs your sign-off.
