### PR TITLE
feat: update media-lyrics to v0.9.0 (bar widget cover + display settings + panel presets)

### DIFF
--- a/media-lyrics/CHANGELOG.md
+++ b/media-lyrics/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to **Media Lyrics** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] — 2026-09-03
+
+### Added
+
+- **Bar widget album cover** — the `now-playing` chip shows the artwork
+  (squircle, ~0.62 em glyph budget for text, `noctalia.fileExists` guard with
+  a state-glyph fallback when the art is missing; render deduped by a content
+  key so the 150 ms service publishes never flicker the chip). Paused
+  playback dims the chip like the built-in media widget.
+- **Widget display settings** — the same knobs as the shell's built-in media
+  widget, edited in the widget's own settings popup (middle click):
+  `album_art_only`, `hide_album_art`, `hide_artist`, `artist_first`,
+  `min_length`, `max_length`, `art_size`, `title_scroll` (none/always/on
+  hover), `hide_when_no_media` (chip hides via `barWidget.setVisible`).
+- **Gesture parity with the built-in media widget** — right click toggles
+  play/pause, mouse back/forward and the wheel skip tracks (declared in
+  `[widget.actions]` so they show up in the settings editor); middle click is
+  left to the host default `settings-open-widget`. Vertical bars show the
+  artwork only (like `media_widget.cpp`: `artOnly = isVertical`).
+
+### Fixed
+
+- **Chip stayed dimmed after resume** — the paused-dim `opacity` was sent as
+  `nil` on resume, and the host reads a nil prop as "unchanged", leaving the
+  0.65 dim applied forever. Opacity is now always an explicit number
+  (`m.playing and 1 or 0.65`); verified live (play → pause → resume pixel
+  luminance returns to baseline).
+- Bar widget now shows the artist too (default `Title - Artist`), matching
+  the built-in widget, instead of the title alone.
+
 ## [0.8.13] — 2026-09-02
 
 ### Fixed

--- a/media-lyrics/README.md
+++ b/media-lyrics/README.md
@@ -41,7 +41,31 @@ noctalia msg panel-toggle tranzem/media-lyrics:panel-compact
 noctalia msg panel-toggle tranzem/media-lyrics:panel-large
 ```
 
-Add the `now-playing` widget to your bar to get a compact indicator that opens the panel on click. A `toggle` shortcut (control-center tile) is also available. Bind it to a hotkey in Noctalia's shortcut settings, or from your compositor:
+Add the `now-playing` widget to your bar: a compact chip with the album
+cover and **Title - Artist** of the active MPRIS player. Its gestures mirror
+the shell's built-in media widget:
+
+- **Left click** — open the lyrics panel.
+- **Right click** — play/pause.
+- **Middle click** — this widget's display settings.
+- **Wheel / mouse back / forward** — previous / next track.
+- On a **vertical bar** the chip collapses to the artwork only.
+
+Display options are edited in the widget's own settings popup (middle click):
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `album_art_only` | off | Show only the artwork, no text |
+| `hide_album_art` | off | Hide the artwork and its fallback icon |
+| `hide_artist` | off | Show only the track title |
+| `artist_first` | off | Show `Artist - Title` instead of `Title - Artist` |
+| `min_length` | 80 | Minimum widget length (px) — accepted for parity; plugin chips are sized by the host to their content |
+| `max_length` | 220 | Text area width (px); long titles truncate or scroll to fit |
+| `art_size` | 16 | Artwork size (px) |
+| `title_scroll` | none | Scroll long titles: `none`, `always`, or `on hover` |
+| `hide_when_no_media` | off | Hide the chip when no MPRIS player is active |
+
+A `toggle` shortcut (control-center tile) is also available. Bind it to a hotkey in Noctalia's shortcut settings, or from your compositor:
 
 ```toml
 "Ctrl+Alt+M" = "spawn:noctalia msg panel-toggle tranzem/media-lyrics:panel"
@@ -97,13 +121,20 @@ noctalia msg config-reload
 
 Upcoming work, roughly in priority order:
 
-- [ ] Album cover inside a capsule shape
+- [ ] Album cover inside a capsule shape (panel info row — the bar-widget
+      chip already shows the artwork since 0.9.0)
 - [ ] Additional lyric sources (NetEase, Musixmatch, embedded MPRIS metadata, …)
+      — most need API keys/tokens; LRCLIB is the no-auth source (see Notes)
 - [x] Clickable lyric lines — click a line to seek the track to that moment (DONE in 0.8.5: click + Return/Space)
-- [ ] Seek on progress-bar click
-- [ ] Compact mode with a pinnable widget
-- [x] Preconfigured widget actions — default gestures declared in the manifest (middle click → play/pause, scroll → track switching) work out of the box (DONE in 0.8.1: `[widget.actions] middle = "none"`)
-- [x] Widget size setting — panel size presets (DONE in 0.8.7: `panel_size` select — compact 440 / medium 520 / large 640; the bar widget itself keeps its hard-coded look)
+- [ ] Seek on progress-bar click — **BLOCKED by host**: click handlers do not
+      report coordinates, so a click position cannot be mapped to a timestamp
+      (only lyric-line clicks and the keyboard cursor can seek)
+- [ ] Compact mode with a pinnable widget — the bar chip + panel presets
+      cover the compact surface; a desktop-pinned view would need a new
+      `[[desktop_widget]]` entry (open question)
+- [x] Preconfigured widget actions — default gestures declared in the manifest (DONE in 0.8.1 and reworked in 0.9.0: now mirrors the built-in media widget — right click = play/pause, back/forward + wheel = prev/next; middle click = widget settings)
+- [x] Widget size setting — panel size presets (DONE in 0.8.7: `panel_size` select — compact 440 / medium 520 / large 640)
+- [x] Bar widget album cover + display settings (DONE in 0.9.0: artwork chip, `album_art_only` / `hide_album_art` / `hide_artist` / `artist_first` / `min_length` / `max_length` / `art_size` / `title_scroll` / `hide_when_no_media`; vertical bars show the artwork only)
 
 ## Notes
 

--- a/media-lyrics/plugin.toml
+++ b/media-lyrics/plugin.toml
@@ -10,7 +10,7 @@
 
 id = "tranzem/media-lyrics"
 name = "Media Lyrics"
-version = "0.8.13"
+version = "0.9.0"
 plugin_api = 24
 author = "tranzem"
 license = "MIT"
@@ -52,15 +52,106 @@ label_key = "settings.local_lyrics_dir.label"
 description_key = "settings.local_lyrics_dir.description"
 default = "~/.local/share/media-lyrics"
 
-# Bar widget: compact now-playing indicator; opens the panel on click.
+# Bar widget: compact now-playing chip; opens the panel on click.
 [[widget]]
 id = "now-playing"
 entry = "widget.luau"
 
-  # Free the middle button for play/pause — the host default opens the
-  # widget's settings instead. Declared so onMiddleClick works out of the box.
+  # Gestures mirror the shell's built-in media widget (noctalia-dev/noctalia
+  # src/shell/bar/widget_gesture_defaults.cpp): right toggles playback, thumb
+  # buttons and the scroll wheel skip tracks. Middle is deliberately NOT
+  # bound here — every widget gets the host default `settings-open-widget`,
+  # so middle click opens this widget's settings like any other bar app.
   [widget.actions]
-  middle = "none"
+  right       = "media toggle"
+  back        = "media previous"
+  forward     = "media next"
+  scroll_up   = "media next"
+  scroll_down = "media previous"
+
+  # Display settings — same knobs as the shell's built-in media widget
+  # (media_widget_definition.cpp). Edited in the widget's own settings popup
+  # (middle click) and read with noctalia.getConfig(key) in widget.luau.
+  [[widget.setting]]
+  key = "album_art_only"
+  type = "bool"
+  label_key = "settings.album_art_only.label"
+  description_key = "settings.album_art_only.description"
+  default = false
+
+  [[widget.setting]]
+  key = "hide_album_art"
+  type = "bool"
+  label_key = "settings.hide_album_art.label"
+  description_key = "settings.hide_album_art.description"
+  default = false
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "hide_artist"
+  type = "bool"
+  label_key = "settings.hide_artist.label"
+  description_key = "settings.hide_artist.description"
+  default = false
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "artist_first"
+  type = "bool"
+  label_key = "settings.artist_first.label"
+  description_key = "settings.artist_first.description"
+  default = false
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "min_length"
+  type = "int"
+  label_key = "settings.min_length.label"
+  description_key = "settings.min_length.description"
+  default = 80
+  min = 0
+  max = 800
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "max_length"
+  type = "int"
+  label_key = "settings.max_length.label"
+  description_key = "settings.max_length.description"
+  default = 220
+  min = 40
+  max = 800
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "art_size"
+  type = "int"
+  label_key = "settings.art_size.label"
+  description_key = "settings.art_size.description"
+  default = 16
+  min = 8
+  max = 96
+  visible_when = { key = "hide_album_art", values = ["false"] }
+
+  [[widget.setting]]
+  key = "title_scroll"
+  type = "select"
+  label_key = "settings.title_scroll.label"
+  description_key = "settings.title_scroll.description"
+  default = "none"
+  options = [
+    { value = "none", label_key = "settings.title_scroll.options.none" },
+    { value = "always", label_key = "settings.title_scroll.options.always" },
+    { value = "on_hover", label_key = "settings.title_scroll.options.on_hover" },
+  ]
+  visible_when = { key = "album_art_only", values = ["false"] }
+
+  [[widget.setting]]
+  key = "hide_when_no_media"
+  type = "bool"
+  label_key = "settings.hide_when_no_media.label"
+  description_key = "settings.hide_when_no_media.description"
+  default = false
 
 # Background service: polls D-Bus for player state, fetches + parses lyrics,
 # and publishes a snapshot to noctalia.state for the panel.

--- a/media-lyrics/translations/en.json
+++ b/media-lyrics/translations/en.json
@@ -3,6 +3,13 @@
     "no-title": "(no title)",
     "unknown-artist": "Unknown artist"
   },
+  "provider": {
+    "local": "Local",
+    "cache": "Cache"
+  },
+  "service": {
+    "lyrics-unreachable": "LRCLIB unreachable (network error)"
+  },
   "panel": {
     "loading-lyrics": "Loading lyrics…",
     "lyrics-error": "Lyrics error: ",
@@ -13,34 +20,68 @@
     "synced": "synced",
     "unsynced": "unsynced"
   },
-  "provider": {
-    "cache": "Cache",
-    "local": "Local"
-  },
-  "service": {
-    "lyrics-unreachable": "LRCLIB unreachable (network error)"
-  },
   "settings": {
-    "local_lyrics_dir": {
-      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB.",
-      "label": "Local lyrics folder"
+    "album_art_only": {
+      "label": "Album art only",
+      "description": "Show only the album artwork (no text)."
+    },
+    "hide_album_art": {
+      "label": "Hide album art",
+      "description": "Hide the artwork and its fallback icon."
+    },
+    "hide_artist": {
+      "label": "Hide artist",
+      "description": "Show only the track title."
+    },
+    "artist_first": {
+      "label": "Artist first",
+      "description": "Show \"Artist - Title\" instead of \"Title - Artist\"."
+    },
+    "min_length": {
+      "label": "Min length",
+      "description": "Minimum widget length in pixels."
+    },
+    "max_length": {
+      "label": "Max length",
+      "description": "Maximum widget length in pixels — the text area width (long titles scroll or truncate to fit it)."
+    },
+    "art_size": {
+      "label": "Art size",
+      "description": "Album artwork size in pixels."
+    },
+    "title_scroll": {
+      "label": "Title scroll",
+      "description": "Scroll long titles that exceed the max length.",
+      "options": {
+        "none": "None",
+        "always": "Always",
+        "on_hover": "On hover"
+      }
+    },
+    "hide_when_no_media": {
+      "label": "Hide when no media",
+      "description": "Hide the widget when no MPRIS player is active."
     },
     "offset_ms": {
-      "description": "Shift lyric timing: positive values show lines earlier, negative later.",
-      "label": "Lyrics offset (ms)"
+      "label": "Lyrics offset (ms)",
+      "description": "Shift lyric timing: positive values show lines earlier, negative later."
     },
     "panel_size": {
-      "description": "Size preset of the lyrics panel: compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
       "label": "Panel size",
+      "description": "Size preset of the lyrics panel: compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
       "options": {
         "compact": "Compact (440)",
-        "large": "Large (640)",
-        "medium": "Medium (520)"
+        "medium": "Medium (520)",
+        "large": "Large (640)"
       }
     },
     "use_cache": {
-      "description": "Store fetched lyrics in the plugin data directory for offline reuse.",
-      "label": "Cache lyrics"
+      "label": "Cache lyrics",
+      "description": "Store fetched lyrics in the plugin data directory for offline reuse."
+    },
+    "local_lyrics_dir": {
+      "label": "Local lyrics folder",
+      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB."
     }
   }
 }

--- a/media-lyrics/widget.luau
+++ b/media-lyrics/widget.luau
@@ -1,16 +1,35 @@
 --!nonstrict
--- Bar widget: compact now-playing indicator; click opens the lyrics panel.
+-- Bar widget: now-playing chip with the same display settings as the shell's
+-- built-in media widget (media_widget_definition.cpp):
+--   album_art_only / hide_album_art / hide_artist / artist_first /
+--   min_length / max_length / art_size / title_scroll / hide_when_no_media.
+-- Settings are [[widget.setting]] entries — edited in this widget's own
+-- settings popup (middle click) and read via noctalia.getConfig(key).
 --
--- Reads the snapshot published by the service (noctalia.state "media") and
--- renders glyph + truncated title. Left click toggles the panel, middle click
--- toggles play/pause, scroll switches tracks.
+-- Interactions mirror the built-in media widget 1:1
+-- (src/shell/bar/widget_gesture_defaults.cpp): left = lyrics panel (our
+-- equivalent of control-center media), right = media toggle, back/forward &
+-- scroll = prev/next, middle = settings (host default, unbound here).
+--
+-- Vertical bars: icon only (art, or the state glyph) like media_widget.cpp
+-- (artOnly = isVertical || albumArtOnly).
+--
+-- Notes:
+--   * No explicit color roles — the instance Color/Icon Color settings apply.
+--   * `min_length` is accepted for parity but inert: plugins cannot fix a
+--     widget width; the host sizes the chip to its content.
+--   * Text width budget is estimated (no measure API): ~0.62 em per char at
+--     fontSize 12 -> ~7.5 px/char, calibrated against the built-in widget.
 
 local glyphPlay = "player-play"
 local glyphPause = "player-pause"
 
--- Which panel preset to open: the plugin setting panel_size selects among
--- compact (440), medium (520, default) and large (640) presets declared in
--- plugin.toml. Medium keeps the historical `panel` id for IPC compatibility.
+local GAP = 6
+local FONT_PX = 12
+local CHAR_PX = FONT_PX * 0.62     -- ~7.4 px per char (est., see above)
+local SCROLL_TICKS = 2             -- advance one char every N update ticks
+
+-- Which panel preset to open (panel_size plugin setting).
 local function panelIdForSize()
   local sz = noctalia.getConfig("panel_size")
   if sz == "compact" then return "panel-compact" end
@@ -18,11 +37,39 @@ local function panelIdForSize()
   return "panel"
 end
 
-local TITLE_MAX = 26
+-- ── settings ────────────────────────────────────────────────────────────────
 
--- UTF-8 helpers: a byte >= 0xC0 starts a character (2–4 bytes), a byte in
--- 0x80..0xBF is a continuation. charCount walks whole characters so titles
--- in any script truncate on char boundaries, never mid-sequence.
+local function cfgBool(key, fallback)
+  local v = noctalia.getConfig(key)
+  if type(v) == "boolean" then return v end
+  return fallback
+end
+
+local function cfgInt(key, fallback)
+  local v = noctalia.getConfig(key)
+  if type(v) == "number" then return math.floor(v) end
+  return fallback
+end
+
+local function widgetOptions()
+  local artOnly = cfgBool("album_art_only", false)
+  local hideArt = cfgBool("hide_album_art", false)
+  local scroll = noctalia.getConfig("title_scroll") or "none"
+  if scroll ~= "always" and scroll ~= "on_hover" then scroll = "none" end
+  return {
+    artOnly = artOnly,
+    hideArt = hideArt,
+    hideArtist = cfgBool("hide_artist", false),
+    artistFirst = cfgBool("artist_first", false),
+    maxLength = cfgInt("max_length", 220),
+    artSize = math.max(8, math.min(96, cfgInt("art_size", 16))),
+    scroll = scroll,
+    hideWhenNoMedia = cfgBool("hide_when_no_media", false),
+  }
+end
+
+-- ── utf-8 helpers (char boundaries, never split a sequence) ─────────────────
+
 local function charCount(s)
   local i, n = 1, 0
   while i <= #s do
@@ -36,6 +83,22 @@ local function charCount(s)
   return n
 end
 
+local function toChars(s)
+  local out = {}
+  local i = 1
+  while i <= #s do
+    local b = s:byte(i)
+    local len = 1
+    if b >= 0xF0 then len = 4
+    elseif b >= 0xE0 then len = 3
+    elseif b >= 0xC0 then len = 2 end
+    out[#out + 1] = s:sub(i, i + len - 1)
+    i = i + len
+  end
+  return out
+end
+
+-- First maxChars characters (UTF-8 safe).
 local function charPrefix(s, maxChars)
   local i, n = 1, 0
   while i <= #s and n < maxChars do
@@ -49,11 +112,40 @@ local function charPrefix(s, maxChars)
   return s:sub(1, i - 1)
 end
 
-local function truncate(s)
-  s = tostring(s or "")
-  if charCount(s) <= TITLE_MAX then return s end
-  return charPrefix(s, TITLE_MAX - 1) .. "…"
+-- ── text (build + scroll) ───────────────────────────────────────────────────
+
+local scrollOffset = 0
+local scrollTick = 0
+local hovered = false
+local lastFull = ""
+
+local function buildFull(m, o)
+  local title = m.title or ""
+  local artist = (not o.hideArtist) and (m.artist or "") or ""
+  local text
+  if title ~= "" and artist ~= "" then
+    text = o.artistFirst and (artist .. " - " .. title) or (title .. " - " .. artist)
+  else
+    text = title ~= "" and title or artist
+  end
+  if text == "" then text = noctalia.tr("common.no-title") end
+  return text
 end
+
+-- Rolling window of `budget` chars over padded text; wraps forever.
+local function rolling(text, budget, offset)
+  local chars = toChars(text .. "   ")
+  local n = #chars
+  local start = (offset % n) + 1
+  local out = {}
+  for k = 0, budget - 1 do
+    local idx = ((start + k - 1) % n) + 1
+    out[#out + 1] = chars[idx]
+  end
+  return table.concat(out)
+end
+
+-- ── state / snapshot ────────────────────────────────────────────────────────
 
 local function media()
   local ok, v = pcall(function() return noctalia.state.get("media") end)
@@ -61,50 +153,200 @@ local function media()
   return nil
 end
 
-local function renderFrom(m)
-  if not m or not m.hasPlayer then
-    -- Empty state is ALSO a render() tree: the host warns that
-    -- setGlyph/setText have no visible effect once a render() tree is
-    -- active (verified live), so a plain disc glyph is rendered instead.
-    -- No explicit color roles — the widget instance's Color/Icon Color
-    -- settings apply.
-    barWidget.render(ui.row({ gap = 6, align = "center" }, {
+local visible = true
+local function setChipVisible(want)
+  want = want == true
+  if want ~= visible then
+    visible = want
+    barWidget.setVisible(want)
+  end
+end
+
+-- ── render ──────────────────────────────────────────────────────────────────
+
+local lastKey = ""
+local function renderKey(m, o, shown)
+  return table.concat({
+    m.hasPlayer and "1" or "0",
+    tostring(m.playing),
+    shown,
+    m.artUrl or "",
+    (type(m.artUrl) == "string" and m.artUrl ~= "" and noctalia.fileExists(m.artUrl)) and "1" or "0",
+    tostring(o.artOnly),
+    tostring(o.hideArt),
+    tostring(o.hideArtist),
+    tostring(o.artistFirst),
+    tostring(o.artSize),
+    barWidget.isVertical() and "V" or "H",
+  }, "|")
+end
+
+local function renderFrom(m, force)
+  if not m then m = media() end
+  if not m then return end
+  local o = widgetOptions()
+
+  -- Hide-when-no-media
+  if not m.hasPlayer then
+    if o.hideWhenNoMedia then
+      setChipVisible(false)
+      return
+    end
+    setChipVisible(true)
+    local key = "empty"
+    if not force and key == lastKey then return end
+    lastKey = key
+    -- Empty state is ALSO a render() tree (setGlyph/setText are dead once a
+    -- tree is active — verified live); no explicit color roles.
+    barWidget.render(ui.row({ gap = GAP, align = "center" }, {
       ui.glyph({ name = "disc", size = 14 }),
     }))
     return
   end
-  local g = m.playing and glyphPause or glyphPlay
-  local title = truncate(m.title ~= "" and m.title or noctalia.tr("common.no-title"))
-  -- No explicit color roles: the host applies the widget instance's Color /
-  -- Icon Color settings (Default = theme role). Explicit roles here would
-  -- silently ignore the user's per-widget color configuration.
-  barWidget.render(ui.row({ gap = 6, align = "center" }, {
-    ui.glyph({ name = g, size = 14 }),
-    ui.label({ text = title, fontSize = 12 }),
-  }))
+  setChipVisible(true)
+
+  local vertical = barWidget.isVertical()
+  -- Paused = stable dim; playing = full opacity. The prop must ALWAYS be an
+  -- explicit number — a nil opacity is read by the host as "unchanged", so
+  -- resuming playback would leave the chip stuck dimmed (bug 2026-09-03).
+  local dim = m.playing and 1 or 0.65
+  local artOk = type(m.artUrl) == "string" and m.artUrl ~= ""
+    and noctalia.fileExists(m.artUrl)
+
+  -- Icon part: art, or the state glyph when no art; suppressed entirely by
+  -- hide_album_art on horizontal bars (vertical always shows art, mirroring
+  -- the built-in: hideAlbumArt is a horizontal-only option).
+  local function iconChild()
+    if (not vertical) and o.hideArt then return nil end
+    if artOk then
+      return ui.image({
+        key = "cover",
+        path = m.artUrl,
+        width = o.artSize,
+        height = o.artSize,
+        radius = math.floor(o.artSize / 4),
+        fit = "cover",
+        opacity = dim,
+      })
+    end
+    return ui.glyph({
+      key = "state",
+      name = m.playing and glyphPause or glyphPlay,
+      size = math.max(10, o.artSize - 4),
+      opacity = dim,
+    })
+  end
+
+  -- Text part (horizontal only; suppressed by album_art_only).
+  if vertical or o.artOnly then
+    local children = { iconChild() }
+    local key = renderKey(m, o, "icon-only")
+    if not force and key == lastKey then return end
+    lastKey = key
+    barWidget.render(ui.row({ align = "center" }, children))
+    return
+  end
+
+  local full = buildFull(m, o)
+  if full ~= lastFull then
+    lastFull = full
+    scrollOffset = 0
+    scrollTick = 0
+  end
+
+  -- Text area = max_length minus the icon slot (art or fallback glyph both
+  -- occupy artSize + gap).
+  local iconW = (not o.hideArt) and (o.artSize + GAP) or 0
+  local budget = math.max(8, math.floor((o.maxLength - iconW) / CHAR_PX))
+
+  local overBudget = charCount(full) > budget
+  local scrolling = overBudget and
+    (o.scroll == "always" or (o.scroll == "on_hover" and hovered))
+
+  local shown
+  if overBudget then
+    if o.scroll == "none" then
+      shown = charPrefix(full, budget - 1) .. "…"
+    else
+      shown = rolling(full, budget, scrollOffset)
+    end
+  else
+    shown = full
+  end
+
+  local key = renderKey(m, o, shown)
+  if not force and key == lastKey then return end
+  lastKey = key
+
+  local children = {}
+  local icon = iconChild()
+  if icon then children[#children + 1] = icon end
+  -- Wrap the label in a row owning onHover (ui.label takes no hover handler);
+  -- the row passes clicks through to the widget-level onClick.
+  children[#children + 1] = ui.row({
+    key = "textwrap",
+    align = "center",
+    onHover = function(state)
+      local h = (state == "true")
+      if h ~= hovered then
+        hovered = h
+        renderFrom(media(), true)
+      end
+    end,
+  }, {
+    ui.label({
+      key = "title",
+      text = shown,
+      fontSize = FONT_PX,
+      opacity = dim,
+      maxLines = 1,
+    }),
+  })
+
+  barWidget.render(ui.row({ gap = GAP, align = "center" }, children))
 end
 
+-- ── loop ────────────────────────────────────────────────────────────────────
+
 function update()
-  renderFrom(media())
+  local m = media()
+  if not m then return end
+  if not m.hasPlayer then
+    renderFrom(m, false)
+    return
+  end
+  local o = widgetOptions()
+  local vertical = barWidget.isVertical()
+  if vertical or o.artOnly or o.scroll == "none" then
+    renderFrom(m, false)
+    return
+  end
+  -- advance the rolling text
+  local full = buildFull(m, o)
+  local iconW = (not o.hideArt) and (o.artSize + GAP) or 0
+  local budget = math.max(8, math.floor((o.maxLength - iconW) / CHAR_PX))
+  local active = charCount(full) > budget and
+    (o.scroll == "always" or (o.scroll == "on_hover" and hovered))
+  if not active then
+    renderFrom(m, false)
+    return
+  end
+  scrollTick = scrollTick + 1
+  if scrollTick % SCROLL_TICKS == 0 then
+    scrollOffset = scrollOffset + 1
+    renderFrom(m, true)
+  end
 end
 
 noctalia.state.watch("media", function(value)
-  renderFrom(value)
+  renderFrom(value, false)
 end)
 
-noctalia.setUpdateInterval(2000)
+noctalia.setUpdateInterval(120)
 
+-- Left click opens the lyrics panel (the built-in media widget opens the
+-- control-center media tab instead). All other gestures live in
+-- [widget.actions] (plugin.toml).
 function onClick()
   noctalia.togglePanel("tranzem/media-lyrics:" .. panelIdForSize())
-end
-
-function onMiddleClick()
-  noctalia.state.set("panel_cmd", { action = "toggle" })
-end
-
--- scroll up = next, down = previous (mirrors the built-in media widget)
-function onScroll(axis, steps, startsGesture)
-  if axis ~= "vertical" or startsGesture then return end
-  local dir = (steps or 0) > 0 and "next" or "prev"
-  noctalia.state.set("panel_cmd", { action = dir })
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `tranzem/media-lyrics`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Update to v0.9.0 — the `now-playing` bar widget now mirrors the shell's built-in media widget, and the manifest gains the panel size presets that the panel has supported since v0.8.7:

- **Album cover in the chip** — squircle artwork (`radius = size/4`) with a `noctalia.fileExists` guard and a state-glyph fallback when art is missing; render is deduped by a content key (no flicker from the 150 ms service publishes). Paused playback dims the chip.
- **Display settings** (edited in the widget's own settings popup via middle click): `album_art_only`, `hide_album_art`, `hide_artist`, `artist_first`, `min_length`, `max_length`, `art_size`, `title_scroll` (`none`/`always`/`on hover`), `hide_when_no_media` — the same knobs as the built-in media widget.
- **Gesture parity**: right click = `media toggle`, mouse back/forward and the wheel skip tracks (declared in `[widget.actions]`); middle click is left to the host default `settings-open-widget`; left click still opens the lyrics panel. Vertical bars show the artwork only.
- **Panel size presets** (since v0.8.7, missing from the store copy): `panel` (medium 520×520/14 lines), `panel-compact` (440×440/10), `panel-large` (640×640/16) — three `[[panel]]` entries share `panel.luau`, selected via the `panel_size` setting; README documents every entry id.
- Fixed: the paused-dim `opacity` was sent as `nil` on resume (a nil prop is read as "unchanged" by the host) — the chip stayed dimmed forever; opacity is now always an explicit number.

## External dependencies

Unchanged from the reviewed in-store version: `busctl` (MPRIS poll), `curl` (LRCLIB HTTPS fetch, argv-only) and `sleep` (coreutils) — all argv-form, no shell. `dependencies = ["busctl", "curl"]`.

## Testing

- Live on Umbriel (Wayland): chip renders cover + "Title - Artist"; middle click opens the widget settings popup with the nine display settings; right click toggles play/pause; wheel skips tracks.
- All three panel presets (`panel` / `panel-compact` / `panel-large`) open cleanly on Noctalia **5.0.1 stable**; panel toggle semantics verified (`panel-toggle` opens, second `panel-toggle` closes); zero `ui tree node is not a table` warnings in the host log.
- Pause → resume verified by pixel luminance (returns to baseline; previously stayed dim).
- Display options exercised: `album_art_only`, `hide_artist`, `artist_first`, `title_scroll = always`, vertical-bar branch (`artOnly = isVertical`).
- `luac -p` passes on every entry script.
- `min_length` is accepted for parity but inert (plugins cannot fix widget width; the host sizes the chip to content) — noted in widget.luau.
- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel (Wayland)
- **Noctalia version tested against:** 5.0.1 (stable)
- **Plugin API level:** 24

## Screenshots / Videos

The main visual surface (lyrics panel) is unchanged; existing `media-lyrics/screenshots/` (panel light/dark) still apply. The bar-widget chip behaves like the built-in media widget and is described above.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
