### PR TITLE
fix(claude-companion): fix settings snippet paths

### DIFF
--- a/claude-companion/hooks/settings.snippet.json
+++ b/claude-companion/hooks/settings.snippet.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py idle"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py idle"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py turn_start"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py turn_start"
           }
         ]
       }
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py tool_start"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py tool_start"
           }
         ]
       },
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/consent.py",
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/consent.py",
             "timeout": 120
           }
         ]
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py turn_start"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py turn_start"
           }
         ]
       }
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py needs_attention"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py needs_attention"
           }
         ]
       }
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py turn_end"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py turn_end"
           }
         ]
       }
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py session_end"
+            "command": "python3 $HOME/.local/state/noctalia/plugins/materialized/community/hooks/pulse.py session_end"
           }
         ]
       }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `lowcache/claude-companion`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [X] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->

So the instructions of claude-companion currently say:
> 3. Merge hooks/settings.snippet.json into ~/.claude/settings.json so Claude's lifecycle hooks actually drive the pulse.

In that json file, it basically tells claude code to run some python file included with this plugin so that the plugin can update its state. It points to files in `.local/share/noctalia/plugins/claude-companion/hooks/...`. I guess however, that in some update, Noctalia plugins were moved to `.local/state/noctalia/plugins/materialized/community/...` instead.

This means that when someone does try to copy that preset over and then use Claude code, it gives errors such as:
```
UserPromptSubmit operation blocked by hook:
  [python3 $HOME/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py turn_start]: /usr/bin/python3: can't open file '/home/atharv/.local/share/noctalia/plugins/claude-companion/hooks/pulse.py': [Errno 2] No such file or directory
```
This PR fixes that.

Because this does not touch any luau plugin code, I have decided not to bump the version number, it can of course be bumped if that is preferred.

## External dependencies

Same as before.

## Testing

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.1
- **Plugin API level:** 3

## Screenshots / Videos

N/A

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [X] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [X] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [X] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [X] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [X] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [X] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [X] I did not edit `catalog.toml`; CI generates it.
- [X] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [X] The code is readable and not obfuscated, minified, or generated.
- [X] It does not download and execute remote code.
- [X] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [X] I have the right to publish this code under the `license` declared in `plugin.toml`.

CC-ing @lowcache 