### PR TITLE
media-lyrics: update to v0.9.3 (plugin_api 30, overlay layer panels)

### DIFF
--- a/media-lyrics/CHANGELOG.md
+++ b/media-lyrics/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **plugin_api 24 → 30** — the plugin now declares the full Noctalia 5.0.1
   plugin API (context menus, graph pointer tracking, panel layer). Requires
   Noctalia 5.0.1+.
-- **Lyrics panel floats above fullscreen content** — all three panel presets
-  (`panel`, `panel-compact`, `panel-large`) declare `layer = "overlay"`, so
-  the lyrics window stays visible over fullscreen video (karaoke over a
-  film/YouTube). A per-entry **Layer** dropdown in Settings → Plugins can
-  switch any preset back to `top` without editing the manifest.
+- **Overlay layer above fullscreen content** — on Noctalia 5.0.1 the host
+  injects a per-entry **Layer** setting (Settings → Plugins) for every panel:
+  choose `overlay` on any preset (`panel`, `panel-compact`, `panel-large`) so
+  the lyrics window floats above fullscreen video (karaoke over a film /
+  YouTube). (This store copy does not declare `layer` in the manifest — the
+  store validator does not know the field yet; the canonical repo ships it.)
 
 ## [0.9.2] — 2026-09-06
 

--- a/media-lyrics/CHANGELOG.md
+++ b/media-lyrics/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to **Media Lyrics** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] — 2026-09-06
+
+### Changed
+
+- **plugin_api 24 → 30** — the plugin now declares the full Noctalia 5.0.1
+  plugin API (context menus, graph pointer tracking, panel layer). Requires
+  Noctalia 5.0.1+.
+- **Lyrics panel floats above fullscreen content** — all three panel presets
+  (`panel`, `panel-compact`, `panel-large`) declare `layer = "overlay"`, so
+  the lyrics window stays visible over fullscreen video (karaoke over a
+  film/YouTube). A per-entry **Layer** dropdown in Settings → Plugins can
+  switch any preset back to `top` without editing the manifest.
+
+## [0.9.2] — 2026-09-06
+
+### Added
+
+- **Current lyric line in the bar chip** — new widget setting
+  `show_lyric_line` (off by default; widget settings popup, visible when the
+  chip shows text). When on and synced lyrics are ready, the chip shows
+  `Title · <current line>` instead of `Title - Artist`; the line steps with
+  the playback position (snapshot polls every 150 ms) and long lines scroll
+  with the existing marquee. Falls back to the artist line while lyrics are
+  not ready or unsynced.
+- **Embedded MPRIS lyrics (`xesam:asText`)** — a zero-network source: players
+  that embed lyrics in their own `Metadata` (the Noctalia aggregator does not
+  forward the field, so the service asks the player bus directly, once per
+  track change) feed the chain at position 2:
+  local `.lrc` → **embedded** → cache → LRCLIB exact → LRCLIB search →
+  NetEase. Footer provider label: "Embedded". Placeholders are filtered like
+  any other source. (Few players ship `xesam:asText` today; LRCLIB remains
+  the workhorse.)
+
+## [0.9.1] — 2026-09-05
+
+### Added
+
+- **NetEase Cloud Music fallback source** — when LRCLIB finds nothing (or a
+  transport error occurs), the service queries NetEase's public
+  cloudsearch/lyric endpoints (no API key; browser User-Agent + Referer only)
+  and accepts the best-ranked candidate. Synced LRC wins over plain text;
+  candidates are ranked by title/artist match plus a duration bonus against
+  the playing track; NetEase LRC metadata lines (作词/作曲/Artist: …) are
+  stripped before parsing. The chain is: local `.lrc` → cache → LRCLIB exact
+  → LRCLIB search → NetEase fallback.
+- **Instrumental / placeholder guard** — NetEase's placeholder "lyrics" for
+  instrumentals and missing words (纯音乐/暂无歌词) are filtered both at fetch
+  time and at cache-read time, so a cached placeholder cannot short-circuit
+  the chain into a fake "no lyrics".
+
+### Changed
+
+- `service.lyrics-unreachable` copy: "LRCLIB unreachable" → "Lyrics services
+  unreachable" (LRCLIB is no longer the only network source).
+
 ## [0.9.0] — 2026-09-03
 
 ### Added

--- a/media-lyrics/README.md
+++ b/media-lyrics/README.md
@@ -1,6 +1,6 @@
 # Media Lyrics
 
-A full-featured media player panel with **time-synced lyrics** for the Noctalia desktop shell. Karaoke-style lyric carousel (10/14/16 visible lines per size preset), album cover, transport controls, and a progress bar — all in one floating panel. **Pure Luau implementation**: no playerctl, no python daemons, no GTK overlays — runtime needs `busctl` (MPRIS) and `curl` (LRCLIB HTTPS).
+A full-featured media player panel with **time-synced lyrics** for the Noctalia desktop shell. Karaoke-style lyric carousel (10/14/16 visible lines per size preset), album cover, transport controls, and a progress bar — all in one floating panel. **Pure Luau implementation**: no playerctl, no python daemons, no GTK overlays — runtime needs `busctl` (MPRIS) and `curl` (LRCLIB HTTPS + NetEase fallback).
 
 | Light theme | Dark theme |
 | --- | --- |
@@ -17,8 +17,11 @@ A full-featured media player panel with **time-synced lyrics** for the Noctalia 
 
 - Noctalia v5 (plugin API 24+)
 - `busctl` (systemd, present on every Arch install)
-- `curl` — used for the LRCLIB HTTPS fetch (spawned as `curl -sSf -m 8 -4 <url>`, argv-only, no shell; LRCLIB resolves IPv4 faster than the built-in HTTP client on some setups)
-- Outbound HTTPS access to `https://lrclib.net` for synced lyrics
+- `curl` — used for the HTTPS lyric fetches: LRCLIB primary + NetEase Cloud
+  Music fallback (spawned as `curl -sSf -m 8 -4 <url>`, argv-only, no shell;
+  LRCLIB resolves IPv4 faster than the built-in HTTP client on some setups)
+- Outbound HTTPS access to `https://lrclib.net` (primary) and
+  `https://music.163.com` (NetEase fallback) for lyrics
 
 No player-specific software. Any MPRIS-capable player works: Spotify, MPD, Cider, web players, VLC, and anything else that exposes MPRIS over D-Bus. `sleep` (coreutils) is used for a short refresh delay after transport commands.
 
@@ -64,6 +67,7 @@ Display options are edited in the widget's own settings popup (middle click):
 | `art_size` | 16 | Artwork size (px) |
 | `title_scroll` | none | Scroll long titles: `none`, `always`, or `on hover` |
 | `hide_when_no_media` | off | Hide the chip when no MPRIS player is active |
+| `show_lyric_line` | off | Show `Title · current line` in the chip instead of `Title - Artist` while synced lyrics are ready (long lines scroll with the marquee; falls back to the artist line otherwise) |
 
 A `toggle` shortcut (control-center tile) is also available. Bind it to a hotkey in Noctalia's shortcut settings, or from your compositor:
 
@@ -79,9 +83,11 @@ The panel shows the active MPRIS player automatically; when nothing is playing i
 - **Clickable lyric lines** — click a synced line to seek the player to that timestamp.
 - **Manual lyric scroll** — Up/Down step a line (the host's chord validator accepts only basic key names; PageUp/PageDown/Home/End are rejected).
 - **LRCLIB integration** — exact `/api/get` lookup first, `/api/search` fallback, LRC parsed in pure Luau.
+- **NetEase Cloud Music fallback** — no-auth second source for LRCLIB misses (public endpoints, browser headers only): synced LRC wins, candidates ranked by title/artist + duration, metadata lines stripped; instrumental placeholders are filtered.
 - **Local `.lrc` files** — drop `Artist - Title.lrc` into the local lyrics folder; they take priority over the network.
 - **Marquee titles** — long track/artist names hold for 2 s, then scroll slowly instead of wrapping or clipping. Overlap-free (per-slice node recreation).
 - **Album cover + progress bar** — interpolated progress between polls, transport controls (prev / play-pause / next), shuffle and repeat state.
+- **Live lyric line in the chip** — optional `show_lyric_line` widget setting: while synced lyrics are ready the chip shows `Title · current line` instead of the artist (steps with playback, marquee for long lines).
 - **Settings** — lyric timing offset in ms, on-disk cache, local lyrics folder. Translatable UI: strings go through Noctalia's i18n (`noctalia.tr`, English ships in the plugin; other locales via Noctalia Translate).
 
 ## Advantages over alternative lyric plugins
@@ -123,8 +129,10 @@ Upcoming work, roughly in priority order:
 
 - [ ] Album cover inside a capsule shape (panel info row — the bar-widget
       chip already shows the artwork since 0.9.0)
-- [ ] Additional lyric sources (NetEase, Musixmatch, embedded MPRIS metadata, …)
-      — most need API keys/tokens; LRCLIB is the no-auth source (see Notes)
+- [x] Additional lyric sources — **NetEase fallback DONE in 0.9.1** (no-auth,
+      last in the chain); **embedded MPRIS `xesam:asText` DONE in 0.9.2**
+      (zero-network, position 2 in the chain). Remaining: Musixmatch,
+      Spotify — most need API keys/tokens (see Notes)
 - [x] Clickable lyric lines — click a line to seek the track to that moment (DONE in 0.8.5: click + Return/Space)
 - [ ] Seek on progress-bar click — **BLOCKED by host**: click handlers do not
       report coordinates, so a click position cannot be mapped to a timestamp
@@ -139,6 +147,8 @@ Upcoming work, roughly in priority order:
 ## Notes
 
 - The service polls MPRIS via `busctl` (150 ms cadence) and publishes a snapshot to `noctalia.state`; the panel animates from those publishes.
-- Lyrics are fetched from the public LRCLIB API with `curl`; nothing is uploaded. Cache and local lyrics live under the plugin data directory and `local_lyrics_dir`.
-- Spawned processes (all argv-form, no shell): `busctl` (MPRIS poll), `curl` (LRCLIB fetch, IPv4, 8 s timeout), `sleep` (coreutils, 0.35 s refresh delay after transport commands).
+- Lyrics are fetched from public services with `curl` — LRCLIB API primary,
+  NetEase Cloud Music fallback on misses; nothing is uploaded. Cache and
+  local lyrics live under the plugin data directory and `local_lyrics_dir`.
+- Spawned processes (all argv-form, no shell): `busctl` (MPRIS poll), `curl` (LRCLIB + NetEase lyric fetches, IPv4, 8 s timeout), `sleep` (coreutils, 0.35 s refresh delay after transport commands).
 - Adapted from the Clavis shell media player text layer (karaoke render + LRCLIB provider), ported to pure Luau for Noctalia v5.

--- a/media-lyrics/plugin.toml
+++ b/media-lyrics/plugin.toml
@@ -180,10 +180,6 @@ width = 520
 height = 520
 placement = "floating"
 position = "center"
-# Overlay layer keeps the lyrics above fullscreen windows (karaoke over
-# video). Per-entry Layer dropdown in Settings -> Plugins can switch any
-# preset back to "top" without editing the manifest.
-layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 
@@ -192,7 +188,6 @@ id = "panel-compact"
 entry = "panel.luau"
 width = 440
 height = 440
-layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 
@@ -201,7 +196,6 @@ id = "panel-large"
 entry = "panel.luau"
 width = 640
 height = 640
-layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 

--- a/media-lyrics/plugin.toml
+++ b/media-lyrics/plugin.toml
@@ -10,8 +10,8 @@
 
 id = "tranzem/media-lyrics"
 name = "Media Lyrics"
-version = "0.9.0"
-plugin_api = 24
+version = "0.9.3"
+plugin_api = 30
 author = "tranzem"
 license = "MIT"
 tags = ["media", "music", "panel", "service"]
@@ -153,6 +153,16 @@ entry = "widget.luau"
   description_key = "settings.hide_when_no_media.description"
   default = false
 
+  # Extra (beyond the built-in media widget): show the current synced lyric
+  # line in the chip instead of the artist while lyrics are ready.
+  [[widget.setting]]
+  key = "show_lyric_line"
+  type = "bool"
+  label_key = "settings.show_lyric_line.label"
+  description_key = "settings.show_lyric_line.description"
+  default = false
+  visible_when = { key = "album_art_only", values = ["false"] }
+
 # Background service: polls D-Bus for player state, fetches + parses lyrics,
 # and publishes a snapshot to noctalia.state for the panel.
 [[service]]
@@ -170,6 +180,10 @@ width = 520
 height = 520
 placement = "floating"
 position = "center"
+# Overlay layer keeps the lyrics above fullscreen windows (karaoke over
+# video). Per-entry Layer dropdown in Settings -> Plugins can switch any
+# preset back to "top" without editing the manifest.
+layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 
@@ -178,6 +192,7 @@ id = "panel-compact"
 entry = "panel.luau"
 width = 440
 height = 440
+layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 
@@ -186,6 +201,7 @@ id = "panel-large"
 entry = "panel.luau"
 width = 640
 height = 640
+layer = "overlay"
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
 

--- a/media-lyrics/service.luau
+++ b/media-lyrics/service.luau
@@ -18,6 +18,12 @@
 local POLL_MS = 150
 local LRCLIB_UA = "media-lyrics/0.1 (Noctalia v5 plugin)"
 
+-- NetEase Cloud Music fallback source (public endpoints, no auth): the
+-- cloudsearch and song-lyric APIs need a browser User-Agent and a
+-- music.163.com Referer — plain requests return an encrypted blob instead.
+local NETEASE_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+local NETEASE_REF = "https://music.163.com/"
+
 -- ============================= utility =============================
 
 local function trim(s)
@@ -212,6 +218,11 @@ end
 
 local currentTrackKey = ""
 local fetchGeneration = 0
+-- Lyrics embedded in the player's own MPRIS metadata (xesam:asText), cached
+-- per track key: the aggregator does not forward the field, so we fetch it
+-- directly from the player bus once per track change.
+local embeddedCache = ""
+local embeddedCacheKey = ""
 
 local function publish()
   noctalia.state.set("media", snapshot)
@@ -258,8 +269,33 @@ local function finishError(msg)
   publish()
 end
 
--- chain: local dir -> cache -> LRCLIB exact -> LRCLIB search
-local function loadLyricsForTrack(artist, title, album, durationSec, key)
+-- NetEase keeps placeholder "lyrics" for instrumentals / missing words
+-- (e.g. "[00:00.000] 纯音乐，请欣赏" = "instrumental music, enjoy", or
+-- "暂无歌词" = "no lyrics yet"). Those are NOT lyrics: treat the text as
+-- empty so the chain keeps hunting / ends with a clean "no lyrics".
+local NETEASE_PLACEHOLDERS = { "纯音乐请欣赏", "纯音乐版", "暂无歌词",
+  "此歌曲为没有填词的纯音乐", "此歌曲为纯音乐请欣赏", "纯音乐" }
+local function isPlaceholderLyrics(raw)
+  -- Byte-safe sanitize: multibyte chars must NOT live inside a Lua character
+  -- class together with ASCII punctuation — it corrupts UTF-8 bytes. Strip
+  -- timestamps + ASCII punctuation first, then full-width chars literally.
+  local cleaned = (raw or ""):gsub("%[%d+:%d+%.?%d*%]", "")
+  cleaned = cleaned:gsub("[%s,.!?]", "")
+  cleaned = cleaned:gsub("，", ""):gsub("。", ""):gsub("．", "")
+  cleaned = cleaned:gsub("！", ""):gsub("？", "")
+  if cleaned == "" then return false end
+  for _, p in ipairs(NETEASE_PLACEHOLDERS) do
+    if cleaned == p then return true end
+  end
+  -- variant lines appended after the phrase (e.g. "...请欣赏，谢谢");
+  -- compare CHARACTER length (utf8), not bytes
+  local clen = utf8.len(cleaned) or #cleaned
+  return clen <= 16 and cleaned:find("纯音乐", 1, true) ~= nil
+end
+
+-- chain: local dir -> embedded (xesam:asText) -> cache -> LRCLIB exact ->
+-- LRCLIB search -> NetEase fallback
+local function loadLyricsForTrack(artist, title, album, durationSec, key, embeddedText)
   fetchGeneration = fetchGeneration + 1
   local gen = fetchGeneration
   -- claim the track key up front: while the fetch is in flight, subsequent
@@ -281,9 +317,19 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key)
     return
   end
 
-  -- 2) cache
+  -- 1.5) lyrics embedded in the player's own metadata (xesam:asText):
+  -- exact-track and zero-network; only when the player provides them.
+  -- Placeholders are filtered like any other source.
+  if embeddedText and trim(embeddedText) ~= "" and not isPlaceholderLyrics(embeddedText) then
+    if acceptLyrics(noctalia.tr("provider.embedded"), embeddedText, "", key) then
+      return
+    end
+  end
+
+  -- 2) cache (skip entries that are NetEase-style placeholder text cached
+  --    before the placeholder filter existed)
   local cached = loadCachedLyrics(title == "" and "" or artist, title)
-  if cached then
+  if cached and not isPlaceholderLyrics(cached) then
     acceptLyrics(noctalia.tr("provider.cache"), cached, "", key)
     return
   end
@@ -299,15 +345,220 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key)
   -- fetch via external curl: the built-in noctalia.http hangs against lrclib.net
   -- on this setup (curl=28 timeout, 30s, 0 bytes) while the curl CLI resolves
   -- IPv4 happily (~50ms). Force IPv4 and a short timeout.
-  local function httpGet(url, cb)
+  local function httpGetH(url, headers, cb)
     -- -f: 4xx/5xx -> non-zero exit (treated as fetch failure, not parse error).
     -- exitCode is passed through so callers can tell "HTTP miss" (curl -f
     -- exit 22) from a transport/network failure (DNS, timeout, conn reset).
-    noctalia.runAsync({ "curl", "-sSf", "-m", "8", "-4",
-      "-H", "User-Agent: " .. LRCLIB_UA, url }, function(result)
+    local argv = { "curl", "-sSf", "-m", "8", "-4" }
+    for _, h in ipairs(headers) do
+      argv[#argv + 1] = "-H"
+      argv[#argv + 1] = h
+    end
+    argv[#argv + 1] = url
+    noctalia.runAsync(argv, function(result)
       cb({ ok = result.exitCode == 0, status = result.exitCode == 0 and 200 or 0,
         body = result.stdout or "", exit = result.exitCode })
     end)
+  end
+
+  local function httpGet(url, cb)
+    httpGetH(url, { "User-Agent: " .. LRCLIB_UA }, cb)
+  end
+
+  -- ── NetEase Cloud Music fallback (last resort, no auth) ──────────────────
+  -- NetEase LRCs open with metadata credit lines (作词/作曲/编曲/Artist: …)
+  -- that would render as lyric rows; drop them before parsing.
+  local NETEASE_META = {
+    "^%s*作词%s*[:：]", "^%s*作曲%s*[:：]", "^%s*编曲%s*[:：]",
+    "^%s*制作人%s*[:：]", "^%s*混音%s*[:：]", "^%s*母带%s*[:：]",
+    "^%s*录音%s*[:：]", "^%s*监制%s*[:：]", "^%s*和声%s*[:：]",
+    "^%s*出品%s*[:：]", "^%s*发行%s*[:：]", "^%s*企划%s*[:：]",
+    "^%s*统筹%s*[:：]", "^%s*OP%s*[:：]", "^%s*SP%s*[:：]",
+    "^%s*Artist%s*[:：]", "^%s*Album%s*[:：]", "^%s*Producer%s*[:：]",
+    "^%s*Composer%s*[:：]", "^%s*Lyricist%s*[:：]",
+  }
+  local function stripNetEaseMeta(raw)
+    local out = {}
+    for line in (raw .. "\n"):gmatch("(.-)\n") do
+      local text = trim(line)
+      if text ~= "" then
+        local body = text:gsub("^%[%d+:%d+%.?%d*%]%s*", "")
+        local isMeta = false
+        for _, p in ipairs(NETEASE_META) do
+          if body:match(p) then isMeta = true break end
+        end
+        if not isMeta then out[#out + 1] = text end
+      end
+    end
+    return table.concat(out, "\n")
+  end
+
+  local function ciEq(a, b)
+    return trim(a or ""):lower() == trim(b or ""):lower()
+  end
+  local function ciHas(hay, needle)
+    return trim(hay or ""):lower():find(trim(needle or ""):lower(), 1, true) ~= nil
+  end
+
+  -- Rank cloudsearch hits: exact/contains matches on title (3/1) and artist
+  -- (2/1), plus a duration bonus (2/1) when cloudsearch `dt` (ms) matches the
+  -- playing track's length — the timed version of a song is the one whose
+  -- timestamps line up. Returns score>0 candidates sorted desc {id, score}.
+  local function rankNetEaseSongs(songs, artist, title, durSec)
+    local ranked = {}
+    for _, s in ipairs(songs) do
+      local sname = trim(s.name or "")
+      local artists = ""
+      local arr = type(s.ar) == "table" and s.ar or type(s.artists) == "table" and s.artists or nil
+      if arr then
+        local names = {}
+        for _, a in ipairs(arr) do names[#names + 1] = a.name or "" end
+        artists = table.concat(names, ", ")
+      end
+      -- Eligibility: when we know the artist, the candidate MUST overlap on
+      -- the artist too — a title-only hit for "DNA" happily returns some
+      -- Chinese song with the same name (wrong-language lyrics, 2026-09-03).
+      -- An empty metadata artist (dirty sources) keeps title-based matching.
+      local artistKnown = trim(artist or "") ~= ""
+      local titleOk = ciEq(sname, title) or ciHas(sname, title)
+      local artistOk = (not artistKnown) or ciEq(artists, artist) or ciHas(artists, artist)
+      if titleOk and artistOk then
+        local score = 0
+      if ciEq(sname, title) then score = score + 3 end
+      if ciHas(sname, title) then score = score + 1 end
+      if ciEq(artists, artist) then score = score + 2 end
+      if ciHas(artists, artist) then score = score + 1 end
+      if type(s.dt) == "number" and durSec and durSec > 0 then
+        local d = math.abs(s.dt / 1000 - durSec)
+        if d < 2 then score = score + 2
+        elseif d < 6 then score = score + 1 end
+      end
+        if score > 0 and type(s.id) == "number" then
+          ranked[#ranked + 1] = { id = s.id, score = score }
+        end
+      end
+    end
+    table.sort(ranked, function(a, b) return a.score > b.score end)
+    return ranked
+  end
+
+  -- True when the text carries [mm:ss.xx] timestamps (karaoke-capable).
+  local function lrcIsSynced(text)
+    return text:match("%[%d+:%d+%.?%d*%]") ~= nil
+  end
+
+  -- Accept a candidate and cache it on success. Returns success.
+  local function acceptAndCache(provider, synced, plain)
+    if acceptLyrics(provider, synced, plain, key) then
+      cacheLyrics(artist, title, synced, plain)
+      return true
+    end
+    return false
+  end
+
+  local neteaseHeaders = {
+    "User-Agent: " .. NETEASE_UA,
+    "Referer: " .. NETEASE_REF,
+  }
+
+  -- Pick the closest cloudsearch hit, then fetch lyrics for up to 3
+  -- candidates. SYNCHRONIZED LRC wins: a plain (untimed) NetEase text is
+  -- kept as a fallback while better candidates are still hunted, and an
+  -- LRCLIB plain-only hit stashed by the caller is used only when NetEase
+  -- produced nothing at all.
+  local function fetchNetEaseFallback(artist, title, key, stash)
+    if gen ~= fetchGeneration then return end
+    -- stash = { provider, synced, plain } (e.g. an LRCLIB plain-only hit).
+    local function settle(isError)
+      if gen ~= fetchGeneration then return end
+      if stash then
+        acceptAndCache(stash.provider, stash.synced, stash.plain)
+      elseif isError then
+        finishError(noctalia.tr("service.lyrics-unreachable"))
+      else
+        finishEmpty()
+      end
+    end
+    local searchAttempt = 0
+    local function trySearch(query)
+      if gen ~= fetchGeneration then return end
+      local searchUrl = "https://music.163.com/api/cloudsearch/pc?s="
+        .. noctalia.string.urlEncode(query) .. "&type=1&offset=0&limit=10"
+      httpGetH(searchUrl, neteaseHeaders, function(resp)
+        if gen ~= fetchGeneration then return end
+        if not resp.ok then
+          settle(true)
+          return
+        end
+        local data = type(resp.body) == "string" and noctalia.json.decode(resp.body) or nil
+        local songs = data and data.result and type(data.result.songs) == "table"
+          and data.result.songs or nil
+        if not songs or #songs == 0 then
+          -- title-only missed: retry once with "artist title"
+          if searchAttempt == 0 and artist ~= "" then
+            searchAttempt = 1
+            trySearch(artist .. " " .. title)
+          else
+            settle(false)
+          end
+          return
+        end
+        local ranked = rankNetEaseSongs(songs, artist, title, durationSec)
+        local tried = 0
+        local firstPlain = nil
+        local anyNetworkError = false
+        local function tryLyric(i)
+          if gen ~= fetchGeneration then return end
+          if i > #ranked or tried >= 3 then
+            if firstPlain then
+              acceptAndCache("NetEase", firstPlain, "")
+            else
+              settle(anyNetworkError)
+            end
+            return
+          end
+          tried = tried + 1
+          local lyricUrl = "https://music.163.com/api/song/lyric?os=pc&id="
+            .. tostring(ranked[i].id) .. "&lv=-1&kv=-1&tv=-1"
+          httpGetH(lyricUrl, neteaseHeaders, function(resp)
+            if gen ~= fetchGeneration then return end
+            if resp.ok and type(resp.body) == "string" then
+              local d = noctalia.json.decode(resp.body)
+              local lrc = type(d) == "table" and d.lrc and type(d.lrc.lyric) == "string"
+                and trim(d.lrc.lyric) or ""
+              if lrc ~= "" then
+                lrc = stripNetEaseMeta(lrc)
+                if trim(lrc) ~= "" then
+                  if isPlaceholderLyrics(lrc) then
+                    -- instrumental placeholder (纯音乐/暂无歌词): next candidate
+                    tryLyric(i + 1)
+                    return
+                  end
+                  if lrcIsSynced(lrc) then
+                    if not acceptAndCache("NetEase", lrc, "") then
+                      tryLyric(i + 1)  -- parsed but unusable: next candidate
+                    end
+                    return
+                  end
+                  -- plain (untimed) LRC: keep as the fallback, keep hunting
+                  -- for a synced copy in the remaining candidates
+                  if not firstPlain then firstPlain = lrc end
+                end
+              end
+            else
+              anyNetworkError = true
+            end
+            tryLyric(i + 1)
+          end)
+        end
+        tryLyric(1)
+      end)
+    end
+    if title ~= "" then
+      trySearch(title)
+    else
+      settle(false)
+    end
   end
 
   httpGet(getUrl, function(resp)
@@ -321,20 +572,28 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key)
     end
 
     if okData then
-      if acceptLyrics("LRCLIB", okData.synced, okData.plain, key) then
-        cacheLyrics(artist, title, okData.synced, okData.plain)
+      local synced = trim(okData.synced or "")
+      local plain = trim(okData.plain or "")
+      if synced ~= "" then
+        -- synced LRCLIB hit: done
+        acceptAndCache("LRCLIB", synced, plain)
+      elseif plain ~= "" then
+        -- LRCLIB has only untimed text: hunt for a synced copy on NetEase
+        -- first; the plain text is the fallback if NetEase has nothing.
+        fetchNetEaseFallback(artist, title, key,
+          { provider = "LRCLIB", synced = "", plain = plain })
+      else
+        fetchNetEaseFallback(artist, title, key)
       end
       return
     end
 
     -- Transport failure (DNS / timeout / connection), not an HTTP miss:
     -- curl -f exits 22 for 4xx/5xx; anything else means the request never
-    -- completed, so a search against the same host would fail the same way.
-    -- Surface a real error instead of the misleading "no lyrics found".
+    -- completed. music.163.com is a different host, so try the NetEase
+    -- fallback before giving up.
     if not resp.ok and resp.exit ~= 22 then
-      if gen == fetchGeneration then
-        finishError(noctalia.tr("service.lyrics-unreachable"))
-      end
+      fetchNetEaseFallback(artist, title, key)
       return
     end
 
@@ -357,24 +616,26 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key)
           if best then
             local synced = trim(best.syncedLyrics or "")
             local plain = trim(best.plainLyrics or "")
-            -- accept may fail on an instrumental hit (empty lyrics): end the
-            -- pipeline with "empty", otherwise the status sticks at "loading"
-            if acceptLyrics("LRCLIB", synced, plain, key) then
-              cacheLyrics(artist, title, synced, plain)
+            if synced ~= "" then
+              if not acceptAndCache("LRCLIB", synced, plain) then
+                -- parsed but unusable (instrumental): try NetEase
+                fetchNetEaseFallback(artist, title, key, plain ~= "" and
+                  { provider = "LRCLIB", synced = "", plain = plain } or nil)
+              end
+            elseif plain ~= "" then
+              -- plain-only LRCLIB hit: prefer a synced NetEase copy
+              fetchNetEaseFallback(artist, title, key,
+                { provider = "LRCLIB", synced = "", plain = plain })
             else
-              finishEmpty()
+              fetchNetEaseFallback(artist, title, key)
             end
             return
           end
         end
       end
-      if not resp2.ok and resp2.exit ~= 22 then
-        if gen == fetchGeneration then
-          finishError(noctalia.tr("service.lyrics-unreachable"))
-        end
-        return
-      end
-      finishEmpty()
+      -- LRCLIB had no usable hit (or its own transport failed): NetEase is
+      -- the last resort.
+      fetchNetEaseFallback(artist, title, key)
     end)
   end)
 end
@@ -392,6 +653,29 @@ end
 
 local GET_ACTIVE = { "busctl", "--user", "--json=short", "call", "dev.noctalia.Mpris",
   "/dev/noctalia/Mpris", "dev.noctalia.Mpris", "GetActivePlayer" }
+
+-- Some MPRIS players expose lyrics via xesam:asText in their own Metadata;
+-- the Noctalia aggregator does not forward that field, so ask the player bus
+-- directly (argv-only busctl, once per track change). The reply is a
+-- Properties.Get variant: {type="v", data=[{type="a{sv}", data={...}}]}.
+local function fetchEmbeddedLyrics(busName, cb)
+  if busName == "" then cb("") return end
+  local argv = { "busctl", "--user", "--json=short", "call", busName,
+    "/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Properties", "Get", "ss",
+    "org.mpris.MediaPlayer2.Player", "Metadata" }
+  noctalia.runAsync(argv, function(r)
+    if r.exitCode ~= 0 then cb("") return end
+    local payload = noctalia.json.decode(r.stdout or "")
+    local outer = payload and payload.data
+    if type(outer) ~= "table" then cb("") return end
+    local inner = outer[1]
+    local fields = (type(inner) == "table" and type(inner.data) == "table") and inner.data or nil
+    if type(fields) ~= "table" then cb("") return end
+    local v = fields["xesam:asText"]
+    if type(v) ~= "table" or v.type ~= "s" then cb("") return end
+    cb(tostring(v.data or ""))
+  end)
+end
 
 local function parseBusctlVariant(v)
   if type(v) ~= "table" or v.type == nil then return nil end
@@ -445,6 +729,7 @@ local function refreshPlayer()
     local lengthUs = tonumber(parseBusctlVariant(f.length_us)) or 0
     local posUs = tonumber(parseBusctlVariant(f.position_us)) or 0
     local ident = parseBusctlVariant(f.identity) or parseBusctlVariant(f.bus_name) or ""
+    local busName = parseBusctlVariant(f.bus_name) or ""
     local canSeek = parseBusctlVariant(f.can_seek) == true
     local canNext = parseBusctlVariant(f.can_go_next) == true
     local canPrev = parseBusctlVariant(f.can_go_previous) == true
@@ -471,9 +756,18 @@ local function refreshPlayer()
     snapshot.posAtMs = nowMs()
 
     if trackChanged then
+      -- claim the key up front: the embedded-metadata fetch below is async,
+      -- and without the claim the next 150 ms poll would see a "new" track
+      -- and restart the whole load forever.
+      currentTrackKey = key
       invalidateLyrics()
+      snapshot.lyricsStatus = "loading"
       publish()
-      loadLyricsForTrack(artist, title, album, snapshot.lengthSec, key)
+      fetchEmbeddedLyrics(busName, function(raw)
+        embeddedCache = raw or ""
+        embeddedCacheKey = key
+        loadLyricsForTrack(artist, title, album, snapshot.lengthSec, key, raw or "")
+      end)
     else
       publish()
     end
@@ -532,7 +826,8 @@ noctalia.state.watch("panel_req", function(value)
     -- same track key format as refreshPlayer (lengthUs integer, not float)
     local key = snapshot.playerName .. "|" .. snapshot.title .. "|" .. snapshot.artist
       .. "|" .. tostring(math.floor(snapshot.lengthSec * 1e6 + 0.5))
-    loadLyricsForTrack(snapshot.artist, snapshot.title, snapshot.album, snapshot.lengthSec, key)
+    loadLyricsForTrack(snapshot.artist, snapshot.title, snapshot.album, snapshot.lengthSec, key,
+      (embeddedCacheKey == key) and embeddedCache or "")
   end
 end)
 
@@ -545,7 +840,8 @@ function onConfigChanged()
   refreshPlayer()
   if title ~= "" then
     local key = snapshot.playerName .. "|" .. title .. "|" .. artist .. "|" .. tostring(snapshot.lengthSec * 1e6)
-    loadLyricsForTrack(artist, title, snapshot.album, snapshot.lengthSec, key)
+    loadLyricsForTrack(artist, title, snapshot.album, snapshot.lengthSec, key,
+      (embeddedCacheKey == key) and embeddedCache or "")
   end
 end
 

--- a/media-lyrics/translations/en.json
+++ b/media-lyrics/translations/en.json
@@ -3,6 +3,14 @@
     "no-title": "(no title)",
     "unknown-artist": "Unknown artist"
   },
+  "provider": {
+    "local": "Local",
+    "cache": "Cache",
+    "embedded": "Embedded"
+  },
+  "service": {
+    "lyrics-unreachable": "Lyrics services unreachable (network error)"
+  },
   "panel": {
     "loading-lyrics": "Loading lyrics…",
     "lyrics-error": "Lyrics error: ",
@@ -13,75 +21,72 @@
     "synced": "synced",
     "unsynced": "unsynced"
   },
-  "provider": {
-    "cache": "Cache",
-    "local": "Local"
-  },
-  "service": {
-    "lyrics-unreachable": "LRCLIB unreachable (network error)"
-  },
   "settings": {
     "album_art_only": {
-      "description": "Show only the album artwork (no text).",
-      "label": "Album art only"
-    },
-    "art_size": {
-      "description": "Album artwork size in pixels.",
-      "label": "Art size"
-    },
-    "artist_first": {
-      "description": "Show \"Artist - Title\" instead of \"Title - Artist\".",
-      "label": "Artist first"
+      "label": "Album art only",
+      "description": "Show only the album artwork (no text)."
     },
     "hide_album_art": {
-      "description": "Hide the artwork and its fallback icon.",
-      "label": "Hide album art"
+      "label": "Hide album art",
+      "description": "Hide the artwork and its fallback icon."
     },
     "hide_artist": {
-      "description": "Show only the track title.",
-      "label": "Hide artist"
+      "label": "Hide artist",
+      "description": "Show only the track title."
     },
-    "hide_when_no_media": {
-      "description": "Hide the widget when no MPRIS player is active.",
-      "label": "Hide when no media"
-    },
-    "local_lyrics_dir": {
-      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB.",
-      "label": "Local lyrics folder"
-    },
-    "max_length": {
-      "description": "Maximum widget length in pixels — the text area width (long titles scroll or truncate to fit it).",
-      "label": "Max length"
+    "artist_first": {
+      "label": "Artist first",
+      "description": "Show \"Artist - Title\" instead of \"Title - Artist\"."
     },
     "min_length": {
-      "description": "Minimum widget length in pixels.",
-      "label": "Min length"
+      "label": "Min length",
+      "description": "Minimum widget length in pixels."
     },
-    "offset_ms": {
-      "description": "Shift lyric timing: positive values show lines earlier, negative later.",
-      "label": "Lyrics offset (ms)"
+    "max_length": {
+      "label": "Max length",
+      "description": "Maximum widget length in pixels — the text area width (long titles scroll or truncate to fit it)."
     },
-    "panel_size": {
-      "description": "Size preset of the lyrics panel: compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
-      "label": "Panel size",
-      "options": {
-        "compact": "Compact (440)",
-        "large": "Large (640)",
-        "medium": "Medium (520)"
-      }
+    "art_size": {
+      "label": "Art size",
+      "description": "Album artwork size in pixels."
     },
     "title_scroll": {
-      "description": "Scroll long titles that exceed the max length.",
       "label": "Title scroll",
+      "description": "Scroll long titles that exceed the max length.",
       "options": {
-        "always": "Always",
         "none": "None",
+        "always": "Always",
         "on_hover": "On hover"
       }
     },
+    "hide_when_no_media": {
+      "label": "Hide when no media",
+      "description": "Hide the widget when no MPRIS player is active."
+    },
+    "offset_ms": {
+      "label": "Lyrics offset (ms)",
+      "description": "Shift lyric timing: positive values show lines earlier, negative later."
+    },
+    "panel_size": {
+      "label": "Panel size",
+      "description": "Size preset of the lyrics panel: compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
+      "options": {
+        "compact": "Compact (440)",
+        "medium": "Medium (520)",
+        "large": "Large (640)"
+      }
+    },
     "use_cache": {
-      "description": "Store fetched lyrics in the plugin data directory for offline reuse.",
-      "label": "Cache lyrics"
+      "label": "Cache lyrics",
+      "description": "Store fetched lyrics in the plugin data directory for offline reuse."
+    },
+    "local_lyrics_dir": {
+      "label": "Local lyrics folder",
+      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB."
+    },
+    "show_lyric_line": {
+      "label": "Show current lyric line",
+      "description": "Show the current synced lyric line in the chip instead of the artist (title stays)."
     }
   }
 }

--- a/media-lyrics/widget.luau
+++ b/media-lyrics/widget.luau
@@ -61,6 +61,7 @@ local function widgetOptions()
     hideArt = hideArt,
     hideArtist = cfgBool("hide_artist", false),
     artistFirst = cfgBool("artist_first", false),
+    showLine = cfgBool("show_lyric_line", false),
     maxLength = cfgInt("max_length", 220),
     artSize = math.max(8, math.min(96, cfgInt("art_size", 16))),
     scroll = scroll,
@@ -119,11 +120,37 @@ local scrollTick = 0
 local hovered = false
 local lastFull = ""
 
+local function activeLyricLine(m)
+  -- Current synced line for the chip (show_lyric_line): last line whose
+  -- timestamp <= posSec. Falls back to the first line before the first
+  -- timestamp (karaoke convention). posSec in the snapshot is ≤150 ms stale
+  -- (service polls), fine for a subtitle.
+  if m == nil or m.lyricsStatus ~= "ready" or not m.synced then return nil end
+  local lines = m.lyrics
+  if type(lines) ~= "table" or #lines == 0 then return nil end
+  local pos = tonumber(m.posSec) or 0
+  local idx = nil
+  for i, l in ipairs(lines) do
+    local t = tonumber(l.time) or -1
+    if t >= 0 and t <= pos then idx = i end
+  end
+  if idx == nil then idx = 1 end
+  local text = lines[idx] and lines[idx].text or ""
+  text = text:gsub("^%s+", ""):gsub("%s+$", "")
+  if text == "" then return nil end
+  return text
+end
+
 local function buildFull(m, o)
   local title = m.title or ""
   local artist = (not o.hideArtist) and (m.artist or "") or ""
+  local line = o.showLine and activeLyricLine(m) or nil
   local text
-  if title ~= "" and artist ~= "" then
+  if line then
+    -- The chip shows the live lyric line instead of the artist while synced
+    -- lyrics are ready; title stays for context.
+    if title ~= "" then text = title .. " · " .. line else text = line end
+  elseif title ~= "" and artist ~= "" then
     text = o.artistFirst and (artist .. " - " .. title) or (title .. " - " .. artist)
   else
     text = title ~= "" and title or artist


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `tranzem/media-lyrics`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Update to v0.9.3, synced from the canonical TraNZeM/media-lyrics repo. Since the store copy is v0.9.0, this PR carries three increments:

- **v0.9.3 — plugin_api 24 → 30.** The manifest now declares API level 30 (full
  Noctalia 5.0.1 plugin API: context menus, graph pointer tracking, panel layer), which
  unlocks the host-injected per-entry **Layer** setting (Settings → Plugins) on 5.0.1:
  choosing `overlay` on any preset floats the lyrics panel above fullscreen windows
  (karaoke over a film / YouTube in fullscreen). Note: this store copy does **not**
  declare the `layer` manifest field — the store validator does not know it yet — so
  the default stays `top` and overlay is one GUI click away; the canonical
  TraNZeM/media-lyrics repo (v0.9.3 release) declares `layer = "overlay"` in the
  manifest for all three presets. `capture_keys`, `keyboard_focus = "exclusive"` and
  the entry script are unchanged.
- **v0.9.2 — current lyric line in the bar chip + embedded lyrics.** New widget setting `show_lyric_line` (off by default; settings popup): when on and synced lyrics are ready, the chip shows `Title · <current line>` instead of `Title - Artist`, stepping with playback position, long lines scroll via the existing marquee. Plus an embedded source at chain position 2: players that ship `xesam:asText` in their own MPRIS Metadata feed the chain (local → embedded → cache → LRCLIB exact → LRCLIB search → NetEase); the Noctalia aggregator does not forward the field, so the service asks the player bus directly once per track change. Footer provider label "Embedded".
- **v0.9.1 — NetEase Cloud Music no-auth fallback.** When LRCLIB finds nothing (common for Chinese/niche music), the chain continues to NetEase (`/api/cloudsearch/pc` + `/api/song/lyric`, browser UA + Referer, no API key): candidate scoring (title/artist match, duration bonus against the playing track), synced-over-plain preference, service-line stripping, and an instrumental-placeholder guard (纯音乐/暂无歌词 filtered on fetch and cache read). Eligibility requires an artist cross-match when artist metadata exists (prevents wrong-language false positives). Network failures surface as a distinct "lyrics services unreachable" error instead of a fake "no lyrics".

## External dependencies

Unchanged from the reviewed in-store version: `busctl` (MPRIS poll, embedded-lyrics read), `curl` (LRCLIB + NetEase HTTPS, argv-only) and `sleep` (coreutils) — all argv-form, no shell. `dependencies = ["busctl", "curl"]`.

## Testing

- Live on Umbriel (Wayland), Noctalia **5.0.1 stable**: plugin re-enabled from the updated manifest → `0.9.3 enabled`; the catalog scan accepts `plugin_api = 30` with zero warnings; service starts cleanly. `layer = "overlay"` was exercised on the canonical copy (same host code path).
- Lyrics panel (`panel`, medium preset) opens, renders and closes cleanly on 5.0.1 — render confirmed pixel-wise (dark surface present at the panel geometry); no `luau_load failed` / `ui tree node is not a table` warnings in the host log after the reload.
- Embedded/NetEase paths were exercised live on earlier 5.0.1 sessions: embedded chain hop non-regression (a track with no lyrics on any source honestly ends as "No lyrics found"), NetEase hits for tracks LRCLIB misses, instrumental tracks short-circuit without a fake miss.
- `luac -p` passes on every entry script; `translations/en.json` parses and covers every `label_key`/`description_key`.
- No visual surface changed (panel/widget render the same outside fullscreen), so the in-store screenshots stay current; `thumbnail.webp` was not regenerated (visual identity unchanged).
- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Umbriel (Wayland)
- **Noctalia version tested against:** 5.0.1 (stable)
- **Plugin API level:** 30

## Screenshots / Videos

Visual surfaces are unchanged from v0.9.0 (the overlay layer only affects stacking above fullscreen windows, not the rendered UI); existing `media-lyrics/screenshots/` (panel light/dark, settings) still apply.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
      (This PR ships English only — `translations/en.json`.)
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
