### PR TITLE
system-monitor: inherit bar presentation settings

### DIFF
--- a/system-monitor/plugin.toml
+++ b/system-monitor/plugin.toml
@@ -1,6 +1,6 @@
 id = "tmelik/system-monitor"
 name = "System Monitor"
-version = "1.5.1"
+version = "1.5.2"
 plugin_api = 26
 author = "TMelik"
 license = "GPL-3.0-only"

--- a/system-monitor/widget.luau
+++ b/system-monitor/widget.luau
@@ -135,10 +135,10 @@ local function thresholdPair(name)
 end
 
 local function metricColor(value, thresholds, colors)
-  if not colors.highlightValues or type(value) ~= "number" or thresholds[2] == 0 then return "on_surface" end
+  if not colors.highlightValues or type(value) ~= "number" or thresholds[2] == 0 then return nil end
   if value >= thresholds[2] then return colors.criticalColor end
   if value >= thresholds[1] then return colors.activityColor end
-  return "on_surface"
+  return nil
 end
 
 local function appendDivider(children, key)
@@ -155,8 +155,14 @@ end
 local function appendMetric(group, key, glyph, text, value, thresholds, colors, highlightValue)
   if value == nil and colors.hideUnavailable then return false end
   local color = metricColor(highlightValue, thresholds, colors)
-  table.insert(group, ui.glyph({ key = key .. ":glyph", name = glyph, size = 14, color = color }))
-  table.insert(group, ui.label({ key = key .. ":label", text = text, fontWeight = "medium", color = color }))
+  local glyphProps = { key = key .. ":glyph", name = glyph, size = 14 }
+  local labelProps = { key = key .. ":label", text = text }
+  if color ~= nil then
+    glyphProps.color = color
+    labelProps.color = color
+  end
+  table.insert(group, ui.glyph(glyphProps))
+  table.insert(group, ui.label(labelProps))
   return true
 end
 
@@ -164,7 +170,7 @@ local function renderFallback(glyph, label, tooltip, showTooltip)
   local container = barWidget.isVertical() and ui.column or ui.row
   barWidget.render(container({ gap = 4, align = "center" }, {
     ui.glyph({ name = glyph, size = 14 }),
-    ui.label({ text = label, fontWeight = "medium" }),
+    ui.label({ text = label }),
   }))
   if showTooltip then barWidget.setTooltip(tooltip) else barWidget.clearTooltip() end
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `tmelik/system-monitor`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Updates System Monitor to 1.5.2. The bar widget no longer hard-codes medium font weight or normal `on_surface` colors, so it inherits the standard widget Font weight, Color, and Icon color settings. Explicit activity and critical threshold colors still override the normal presentation.

The color inheritance depends on https://github.com/noctalia-dev/noctalia/pull/4318 and this plugin update should not be released before that host support is available. The host change was chosen instead of adding duplicate plugin-specific color controls or other compatibility workarounds.

## External dependencies

- `ps` (procps/procps-ng) for optional top-process tooltip rows.
- `cat` (coreutils) for the CPU-frequency fallback when Noctalia does not report it.

No dependencies or trust boundaries were added by this update.

## Testing

- `python3 .github/workflows/scripts/validate-plugins.py` (155 manifests validated)
- Lua 5.1 syntax check for `widget.luau`
- Manual Niri runtime check with the patched Noctalia host, using distinct fixed values for Color and Icon color, Bold font weight, and disabled value highlighting
- Verified activity and critical colors remain explicit overrides in the rendered tree

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `v5.0.1-28-g224da6dd4360` with https://github.com/noctalia-dev/noctalia/pull/4318 applied
- **Plugin API level:** 26

## Screenshots / Videos

The default visual identity is unchanged, so the existing [`thumbnail.webp`](https://github.com/noctalia-dev/community-plugins/blob/main/system-monitor/thumbnail.webp) remains representative. Runtime testing used deliberately distinct pink label and cyan glyph colors to confirm the two standard controls are independent.

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
