### PR TITLE
fix(sticky-notes): hide links while blurred

### DIFF
--- a/sticky-notes/panel.luau
+++ b/sticky-notes/panel.luau
@@ -277,7 +277,8 @@ local function notePreviewCard(note)
   local fontSize = noctalia.getConfig("font_size") or 13
   local dateText = formatDate(note.createdAt)
   local isPinned = note.pinned == true
-  local webLink = firstWebLink(note.content)
+  -- Do not expose a hidden note's URL through the action-row tooltip or link.
+  local webLink = not blurred and firstWebLink(note.content) or nil
   local tasks = checklistTasks(note.content)
   local completedTasks = 0
   for _, task in ipairs(tasks) do

--- a/sticky-notes/plugin.toml
+++ b/sticky-notes/plugin.toml
@@ -1,6 +1,6 @@
 id          = "ahmedhossamdev/sticky-notes"
 name        = "Sticky Notes"
-version     = "1.1.0"
+version     = "1.1.1"
 plugin_api  = 24
 author      = "ahmedhossamdev"
 license     = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `ahmedhossamdev/sticky-notes`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Prevents privacy-blurred notes from exposing or opening links. The normal,
unblurred note experience is unchanged.

## External dependencies

- `mkdir` — creates the selected storage folder when needed.
- `sh` — expands `~` in the configured storage path.
- `xdg-open` — opens user-provided, validated `http://`, `https://`, or `www.`
  links from notes only when notes are not blurred.

The plugin makes no network calls.

## Testing

Static regression check confirms that the final Markdown note is retained after
reload. Manual Noctalia testing of the blur/link behavior is pending.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** `noctalia v5.0.0 (5.0.0_beta.10-1-dirty)`
- **Plugin API level:** `24`

## Screenshots / Videos

No new screenshots. The normal, unblurred UI is unchanged; the existing link
action is intentionally hidden only while privacy blur is enabled.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
