### PR TITLE
Add shortcut functionality to wayland-screen-mirror

### DIFF
--- a/wl-screen-mirror/README.md
+++ b/wl-screen-mirror/README.md
@@ -7,7 +7,7 @@ This plugin allows you to easily toggle screen mirroring in Wayland via `wl-mirr
 | Field | Value |
 | --- | --- |
 | ID | `elijaharch/wl-screen-mirror` |
-| Entries | Bar widget: `mirror`; panel: `controls`; service: `mirror-service` |
+| Entries | Bar widget: `mirror`; panel: `controls`; service: `mirror-service`; shortcut: `toggle` |
 
 ## Requirements
 

--- a/wl-screen-mirror/plugin.toml
+++ b/wl-screen-mirror/plugin.toml
@@ -1,11 +1,11 @@
 id = "elijaharch/wl-screen-mirror"
 name = "Wayland Screen Mirror"
-version = "1.0.0"
+version = "1.1.0"
 plugin_api = 3
 author = "elijaharch"
 license = "MIT"
 dependencies = ["wl-mirror"]
-tags = ["bar", "panel", "service", "utility", "video"]
+tags = ["bar", "panel", "service", "shortcut", "utility", "video"]
 icon = "screen-share"
 description = "Mirror one Wayland output to another with wl-mirror."
 

--- a/wl-screen-mirror/plugin.toml
+++ b/wl-screen-mirror/plugin.toml
@@ -25,3 +25,7 @@ open_near_click = true
 [[service]]
 id = "mirror-service"
 entry = "service.luau"
+
+[[shortcut]]
+id = "toggle"
+entry = "shortcut.luau"

--- a/wl-screen-mirror/shortcut.luau
+++ b/wl-screen-mirror/shortcut.luau
@@ -1,0 +1,47 @@
+--!nonstrict
+
+local PANEL_ID = "elijaharch/wl-screen-mirror:controls"
+
+local status = noctalia.state.get("mirror_status") or {
+	phase = "stopped",
+	running = false,
+}
+local requestSerial = 0
+
+local function tr(key, values)
+	return noctalia.tr(key, values)
+end
+
+local function render()
+	local phase = status.phase or "stopped"
+	local active = phase == "running" or phase == "starting"
+
+	shortcut.setLabel(active and tr("shortcut.active") or tr("shortcut.inactive"))
+	shortcut.setIcon("screen-share")
+	shortcut.setActive(active)
+	shortcut.setEnabled(status.available ~= false and phase ~= "stopping")
+end
+
+noctalia.state.watch("mirror_status", function(value)
+	if type(value) == "table" then
+		status = value
+		render()
+	end
+end)
+
+function onClick()
+	local phase = status.phase or "stopped"
+
+	if phase == "running" or phase == "starting" then
+		requestSerial += 1
+		noctalia.state.set("mirror_request", {
+			action = "stop",
+			serial = requestSerial,
+		})
+		return
+	end
+
+	noctalia.togglePanel(PANEL_ID)
+end
+
+render()

--- a/wl-screen-mirror/translations/en.json
+++ b/wl-screen-mirror/translations/en.json
@@ -46,6 +46,10 @@
     "stopping": "Stopping wl-mirror…",
     "wl_mirror_missing": "wl-mirror was not found in PATH."
   },
+  "shortcut": {
+    "active": "Screen Mirror On",
+    "inactive": "Screen Mirror Off"
+  },
   "title": "Screen Mirror",
   "widget": {
     "error": "Screen mirror error",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `elijaharch/wl-screen-mirror`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a Control Center shortcut tile (`toggle`) for the screen mirror. The
tile reflects the mirror service's running state (on/off) via the shared
`mirror_status` plugin state. Clicking it while mirroring is active (or
starting) stops the mirror directly. Clicking it while stopped opens the
existing `controls` panel so the user can pick source/destination displays
and start mirroring — starting always requires a monitor pair, so there's
no state to toggle straight to "on" from the tile alone.

## External dependencies

None beyond the existing `wl-mirror` dependency, already declared in
`plugin.toml`. No new dependency was added for the shortcut.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.1
- **Plugin API level:** 3

## Screenshots / Videos

<img width="247" height="308" alt="image" src="https://github.com/user-attachments/assets/0869917b-9b74-41a5-b137-142767d416d8" />

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
