### PR TITLE
fix(keybind-cheatsheet): stage the Hyprland Lua refresh across CPU budget windows

### DIFF
--- a/keybind-cheatsheet/plugin.toml
+++ b/keybind-cheatsheet/plugin.toml
@@ -1,6 +1,6 @@
 id = "kenn/keybind-cheatsheet"
 name = "Keybind Cheatsheet"
-version = "0.2.6"
+version = "0.2.7"
 plugin_api = 9
 author = "kenn"
 license = "MIT"

--- a/keybind-cheatsheet/service.luau
+++ b/keybind-cheatsheet/service.luau
@@ -1056,35 +1056,50 @@ local function modifiersFromMask(mask)
   return result
 end
 
-local function parseHyprJson(raw, rules)
+local function hyprBindingFromEntry(entry)
+  if type(entry) ~= "table" then return nil end
+  local description = entry.has_description == false and "" or (entry.description or "")
+  local key = entry.key or ""
+  if key == "" and tonumber(entry.keycode) ~= nil and tonumber(entry.keycode) ~= 0 then
+    key = "code:" .. tostring(entry.keycode)
+  end
+  local dispatcher = entry.dispatcher or ""
+  local argument = entry.arg or ""
+  if key == "" or dispatcher == "" then return nil end
+  local binding = {
+    compositor = "hyprland",
+    bindingType = entry.mouse == true and "bindm" or "bind",
+    modifiers = modifiersFromMask(entry.modmask),
+    key = key,
+    action = trim(dispatcher .. " " .. argument),
+    description = description,
+    category = "",
+    sourceFile = "hyprctl binds -j",
+    sourceLine = 0,
+    submap = entry.submap or "",
+  }
+  addBinding({}, binding)
+  return binding
+end
+
+local function parseHyprJsonEntries(raw)
   local decoded, err = noctalia.json.decode(raw)
   if type(decoded) ~= "table" then
     return nil, err or "Invalid hyprctl JSON"
   end
+  return decoded, nil
+end
+
+local function parseHyprJson(raw, rules)
+  local decoded, err = parseHyprJsonEntries(raw)
+  if decoded == nil then return nil, err end
   local result = {}
   for _, entry in ipairs(decoded) do
-    if type(entry) == "table" then
-      local description = entry.has_description == false and "" or (entry.description or "")
-      local key = entry.key or ""
-      if key == "" and tonumber(entry.keycode) ~= nil and tonumber(entry.keycode) ~= 0 then
-        key = "code:" .. tostring(entry.keycode)
-      end
-      local dispatcher = entry.dispatcher or ""
-      local argument = entry.arg or ""
-      if key ~= "" and dispatcher ~= "" then
-        addBinding(result, {
-          compositor = "hyprland",
-          bindingType = entry.mouse == true and "bindm" or "bind",
-          modifiers = modifiersFromMask(entry.modmask),
-          key = key,
-          action = trim(dispatcher .. " " .. argument),
-          description = description,
-          category = description ~= "" and categoryFromHyprRules(description, rules) or "",
-          sourceFile = "hyprctl binds -j",
-          sourceLine = 0,
-          submap = entry.submap or "",
-        })
-      end
+    local binding = hyprBindingFromEntry(entry)
+    if binding ~= nil then
+      binding.category = binding.description ~= "" and categoryFromHyprRules(binding.description, rules) or ""
+      binding.baseCategory = binding.category
+      table.insert(result, binding)
     end
   end
   return result, nil
@@ -1477,29 +1492,147 @@ noctalia.state.watch(PARSE_STEP_KEY, function(value)
   parseStep()
 end)
 
+-- The Hyprland Lua refresh is staged across several state-watch callbacks:
+-- one ~25 ms Luau CPU budget cannot cover decoding the full `hyprctl binds -j`
+-- payload, building every binding, running the Lua category scan, categorizing,
+-- and writing the cache in a single callback — on mid-size configs the callback
+-- is killed mid-flight and the panel is left on "Reading keybinds..." forever
+-- (#606, #663). scheduleHyprStep pings HYPR_STEP_KEY after each phase (decode,
+-- each HYPR_BINDING_SLICE-sized build/categorize slice, scan, finish), and each
+-- state-watch callback continues the job with a fresh budget window.
+local HYPR_STEP_KEY = "keybind-cheatsheet.hypr-step"
+local HYPR_BINDING_SLICE = 16
+local hyprJob = nil
+local hyprStepCounter = 0
+
+local function scheduleHyprStep(job, raw)
+  hyprStepCounter += 1
+  local value = { generation = job.generation, request = job.request, step = hyprStepCounter }
+  if raw ~= nil then value.raw = raw end
+  noctalia.state.set(HYPR_STEP_KEY, value)
+end
+
+local function finishHyprJob(job)
+  if job.generation ~= refreshGeneration or hyprJob ~= job then return end
+  local scan = job.scan
+  local warnings = scan ~= nil and scan.warnings or {}
+  local sourceSnapshot = scan
+  local result = job.bindings or {}
+  local err = job.error
+  hyprJob = nil
+  noctalia.state.set(HYPR_STEP_KEY, nil)
+  finishRefresh(job.generation, job.request, result, warnings, err, sourceSnapshot)
+end
+
+local function hyprStep(value)
+  local job = hyprJob
+  if job == nil or type(value) ~= "table"
+    or value.generation ~= refreshGeneration
+    or value.generation ~= job.generation
+    or value.step ~= hyprStepCounter
+    or not requestsMatch(value.request, job.request) then
+    return
+  end
+
+  if job.phase == "decode" then
+    job.raw = value.raw or ""
+    if job.result.exitCode ~= 0 or job.result.timedOut then
+      job.error = trim(job.result.stderr)
+      if job.error == "" then job.error = tr("hyprctl_failed") end
+      job.phase = "scan"
+      scheduleHyprStep(job)
+      return
+    end
+    local decoded, err = parseHyprJsonEntries(job.raw)
+    if decoded == nil then
+      job.error = err
+      job.phase = "scan"
+      scheduleHyprStep(job)
+      return
+    end
+    job.entries = decoded
+    job.raw = nil
+    job.index = 1
+    job.bindings = {}
+    job.phase = "build"
+  end
+
+  if job.phase == "build" then
+    local limit = math.min(#job.entries, job.index + HYPR_BINDING_SLICE - 1)
+    while job.index <= limit do
+      local binding = hyprBindingFromEntry(job.entries[job.index])
+      if binding ~= nil then table.insert(job.bindings, binding) end
+      job.index += 1
+    end
+    if job.index <= #job.entries then
+      scheduleHyprStep(job)
+      return
+    end
+    job.phase = "scan"
+    scheduleHyprStep(job)
+    return
+  end
+
+  if job.phase == "scan" then
+    -- Whole-config scan gets its own budget window (this is what
+    -- blew up on large Lua configs in #606).
+    job.scan = scanHyprLua(job.request.root)
+    if job.error ~= nil then
+      job.bindings = {}
+      job.phase = "finish"
+      scheduleHyprStep(job)
+      return
+    end
+    job.index = 1
+    job.phase = "categorize"
+    scheduleHyprStep(job)
+    return
+  end
+
+  if job.phase == "categorize" then
+    local bindings = job.bindings or {}
+    local limit = math.min(#bindings, job.index + HYPR_BINDING_SLICE - 1)
+    while job.index <= limit do
+      local binding = bindings[job.index]
+      if binding ~= nil and binding.description ~= "" then
+        binding.category = categoryFromHyprRules(binding.description, job.scan.rules)
+        binding.baseCategory = binding.category
+      end
+      job.index += 1
+    end
+    if job.index <= #bindings then
+      scheduleHyprStep(job)
+      return
+    end
+    job.phase = "finish"
+    scheduleHyprStep(job)
+    return
+  end
+
+  if job.phase == "finish" then
+    finishHyprJob(job)
+  end
+end
+
+noctalia.state.watch(HYPR_STEP_KEY, hyprStep)
+
 local function refreshHyprLua(generation, request)
   if not noctalia.commandExists("hyprctl") then
     finishRefresh(generation, request, {}, {}, tr("hyprctl_missing"), nil)
     return
   end
 
+  -- The completion callback only stashes the raw output; parsing continues
+  -- in the staged HYPR_STEP_KEY callbacks above (fresh budget per phase).
   local accepted = noctalia.runAsync("hyprctl binds -j", function(result)
     if generation ~= refreshGeneration then return end
-    local scan = scanHyprLua(request.root)
-    if result.exitCode ~= 0 or result.timedOut then
-      local message = trim(result.stderr)
-      finishRefresh(
-        generation,
-        request,
-        {},
-        scan.warnings,
-        message ~= "" and message or tr("hyprctl_failed"),
-        scan
-      )
-      return
-    end
-    local parsed, err = parseHyprJson(result.stdout, scan.rules)
-    finishRefresh(generation, request, parsed or {}, scan.warnings, err, scan)
+    hyprJob = {
+      generation = generation,
+      request = request,
+      result = result,
+      phase = "decode",
+    }
+    scheduleHyprStep(hyprJob, result.stdout or "")
   end, 10000)
 
   if not accepted then


### PR DESCRIPTION


<!-- noctalia-pr-template:v1 -->
## Plugin
- **Id:** `kenn/keybind-cheatsheet`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes the panel never loading on mid-size Hyprland **Lua** configs (#663).

Root cause: the completion callback of `noctalia.runAsync("hyprctl binds -j", ...)` performed the entire refresh inside one callback — JSON-decoding the full payload (~40 KB / 88 bindings on a real-world config), building the binding list, running
the Lua category scan (`scanHyprLua`), categorizing, and writing the cache. Noctalia's Luau host enforces a hard ~25 ms CPU budget per callback; when the chain exceeds it, the callback is killed before `finishRefresh` publishes anything, so the panel stays on "Reading keybinds…" forever, no error is ever shown (the abort is only in the host
log), and `bindings-cache.json` is never written, every shell start re-fails.

Fix: stage the work across multiple state-watch callbacks, reusing the same state-ping pattern the Niri parser and the self-test already use. The refresh now runs decode → build bindings in slices (`HYPR_BINDING_SLICE = 16`) → Lua category
scan → categorize in slices → publish + cache write, each in its own budget window. Stale pings are dropped via generation/request/step guards; all existing error paths (hyprctl missing/failed, invalid JSON, failed-refresh retention) are preserved.

This is the same CPU-budget failure class as #606; v0.2.6 (PR #639) fixed it by deferring the work *into* the async completion callback, this PR stages that callback itself.

**Authorship disclosure:** I am a software developer, but I have no prior experience with Luau. The initial implementation of this patch was produced with AI assistance, then debugged and iterated against real hardware. I reviewed the final diff block by block.

## External dependencies

None added. `hyprctl` remains the plugin's only dependency (already declared in `plugin.toml`), used only by the Hyprland Lua path. This PR adds no network calls, no new filesystem writes, and no new spawned processes, only additional `noctalia.state` keys used to stage the existing refresh.

## Testing

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.1-1.1 (Arch/CachyOS package)
- **Plugin API level:** 9

- Reproduction machine: CachyOS, Hyprland 0.56.2-2.1, AMD Ryzen 5 5600, native Lua config (`~/.config/hypr/hyprland.lua` requiring `config/*.lua`, no `hyprland.conf`), 88 bindings, `hyprctl binds -j` = 40,072 bytes.
- Before this patch: panel stuck on "Reading keybinds…" forever; host log showed  `script callback 'async command callback' exceeded its CPU budget` (and, with the scan stage alone, the same abort at the categorization loop); `bindings-cache.json` never written; IPC refresh returned `ok: dispatched 1` but the snapshot never landed.
- After this patch: panel populates; refresh works via IPC, panel toggle, and after a full shell restart (startup path); no budget errors across repeated refreshes and hot reloads; `bindings-cache.json` written.
- `noctalia msg plugin kenn/keybind-cheatsheet:data all self-test` → hypr_conf 5/5,  hypr_lua 4/4, mango 9/9, niri 5/5, `passed: true`.
- Two-machine differential from #663 (identical software, near-identical `binds.lua`): 88 binds / 40,072 B failed pre-patch on Ryzen 5 5600; 82 binds / 37,381 B worked on Ryzen 9 7900X3D.

## Screenshots / Videos

Before/after captures: (1) panel stuck on "Reading keybinds…" pre-patch, (2) panel
populated post-patch.
<img width="1733" height="877" alt="keybindings-before" src="https://github.com/user-attachments/assets/48330090-40ad-4b3c-9449-427b179e9f82" />
<img width="1731" height="882" alt="keybindings-after" src="https://github.com/user-attachments/assets/b94103b7-1c64-4832-93f0-26788b457f4c" />

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
  *(Unchanged in this PR — no visual identity change, so not regenerated.)*
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest
      API level this plugin requires. (0.2.6 → 0.2.7; `plugin_api` stays 9.)
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory. (`keybind-cheatsheet/`:
      `service.luau` + `plugin.toml` version bump only.)

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the
      description above accounts for.
- [x] I have the right to publish this code under the `license` declared in
      `plugin.toml`. (MIT, unchanged.)
