### PR TITLE
fix(k8s-status): don't flag finished pods over READY 0/1

### DIFF
--- a/k8s-status/plugin.toml
+++ b/k8s-status/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/k8s-status"
 name = "K8s Status"
-version = "1.1.5"
+version = "1.1.6"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"

--- a/k8s-status/service.luau
+++ b/k8s-status/service.luau
@@ -267,7 +267,10 @@ local function parsePodsWide(stdout)
       local node = fields[idx + 1] or ""
       local have, want = parseReady(ready)
       local restartsNum = tonumber((restarts:match("^(%d+)"))) or 0
-      local problem = isProblemPhase(status) or (want > 0 and have < want) or restartsNum > 5
+      -- Finished pods (Completed Jobs/CronJobs) report READY 0/1 because their
+      -- containers exited; the readiness ratio must not flag them (#596).
+      local finished = status == "Succeeded" or status == "Completed"
+      local problem = isProblemPhase(status) or (not finished and want > 0 and have < want) or restartsNum > 5
       table.insert(pods, {
         id = ns .. "/" .. name,
         namespace = ns,


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/k8s-status`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes #596. (Replaces the closed #597/#598.)

Completed Job/CronJob pods were counted as problems in the bar widget, the panel summary and the `/kube problems` launcher. Their containers have exited, so they report `READY 0/1` and the readiness-ratio part of the problem check flagged them despite `STATUS=Completed`.

The readiness-ratio check is now skipped for finished phases (`Succeeded`/`Completed`). The phase check (`Failed`, `CrashLoopBackOff`, …) and the restart-count check (> 5) are unchanged, so genuinely broken pods are still flagged.

## External dependencies

Unchanged: `kubectl` (cluster queries) and `less` (pager), both already declared in `plugin.toml`. No new spawned processes, network calls, or filesystem writes.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.1
- **Plugin API level:** 10

- Reproduced on a live k3s cluster: 104 pods, of which 6 `Completed` CronJob pods (`READY 0/1`) were all counted as problems before the fix.
- Ran the patched `parsePodsWide` over real `kubectl get pods -A --no-headers` output: problem count 6 → 0, and exactly those 6 finished pods flipped; no other pod changed state.
- In the running shell (plugin loaded from a path source): panel shows `6/6 nodes ready · 0 problem pods · 104 pods`; `/kube problems` is empty.
- `noctalia plugins lint k8s-status` clean.

## Screenshots / Videos

No visual change: the widget/panel problem counter simply no longer includes finished pods (evidence numbers above).

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.

