### PR TITLE
feat(k8s-status): context selector in the panel header

### DIFF
--- a/k8s-status/README.md
+++ b/k8s-status/README.md
@@ -29,6 +29,11 @@ Add the **status** bar widget (`davemhammer/k8s-status:status`). Click for the p
 
 Panel tabs: **Nodes**, **Pods**, **Deployments**, **Namespaces**. Select a row for describe / logs / shell / restart actions (where applicable).
 
+When the kubeconfig holds multiple contexts and the `context` setting is empty, the panel header shows a context
+selector. Picking one runs `kubectl config use-context` (the kubectx equivalent), so the choice is shared with your
+terminal and persists across restarts. With `context` set in the plugin settings, the selector stays a read-only
+label because the pinned setting overrides every kubectl call.
+
 Launcher examples:
 
 - `/kube` — categories (pods, problems, nodes, …)
@@ -59,11 +64,13 @@ noctalia msg panel-toggle davemhammer/k8s-status:manager
 ```sh
 noctalia msg panel-toggle davemhammer/k8s-status:manager
 noctalia msg plugin davemhammer/k8s-status:service all refresh
+noctalia msg plugin davemhammer/k8s-status:service all use_context <name>
 ```
 
 ## Notes
 
 - Shells out to `kubectl` and `less` (and optionally a terminal via `runInTerminal` for logs/shell/`k9s`).
 - Refresh: nodes, deployments, and namespaces use compact **jsonpath** queries; pods use `kubectl get pods` table output for ready/restart columns.
-- Does not modify cluster state unless you run restart/delete-style actions from the panel or launcher.
+- Modifies your kubeconfig's current-context when you pick a context in the panel selector; does not modify cluster
+  state unless you run restart/delete-style actions from the panel or launcher.
 - Network: only via `kubectl` to the API server from your kubeconfig. No cluster credentials are written into the plugin tree.

--- a/k8s-status/panel.luau
+++ b/k8s-status/panel.luau
@@ -10,6 +10,7 @@ local snapshot = noctalia.state.get(STATE_KEY) or {
   loading = true,
   busy = false,
   context = "",
+  contexts = {},
   nodes = {},
   pods = {},
   deployments = {},
@@ -455,6 +456,45 @@ local function filterPlaceholder()
   return tr("filter.placeholder_namespaces")
 end
 
+-- Context switcher: a select when the kubeconfig offers multiple contexts and the
+-- "context" setting does not pin one; otherwise the plain read-only label.
+local function contextControl()
+  local pinned = noctalia.string.trim(noctalia.getConfig("context") or "") ~= ""
+  local contexts = snapshot.contexts or {}
+  if pinned or #contexts < 2 then
+    return ui.label({
+      text = tr("panel.context", { name = snapshot.context ~= "" and snapshot.context or "—" }),
+      fontSize = 11,
+      color = "on_surface_variant",
+    })
+  end
+  local selected = 0
+  for i, name in ipairs(contexts) do
+    if name == snapshot.context then
+      selected = i
+      break
+    end
+  end
+  -- Fixed width inside a row + spacer: the title column stretches children to its
+  -- full width, so an unwrapped select would push the header buttons out of line.
+  return ui.row({ align = "center" }, {
+    ui.select({
+      options = contexts,
+      -- selectedIndex is 0-based on the host side; ipairs is 1-based.
+      selectedIndex = selected > 0 and (selected - 1) or nil,
+      placeholder = snapshot.context ~= "" and snapshot.context or "—",
+      controlSize = "sm",
+      width = 220,
+      onChange = function(_, text)
+        if type(text) == "string" and text ~= "" and text ~= snapshot.context then
+          sendCommand("use_context", { context = text })
+        end
+      end,
+    }),
+    ui.spacer({ flexGrow = 1 }),
+  })
+end
+
 render = function()
   dirty = false
   local statusRows = {}
@@ -491,11 +531,7 @@ render = function()
       }),
       ui.column({ flexGrow = 1, gap = 0 }, {
         ui.label({ text = tr("title"), fontSize = 18, fontWeight = "bold" }),
-        ui.label({
-          text = tr("panel.context", { name = snapshot.context ~= "" and snapshot.context or "—" }),
-          fontSize = 11,
-          color = "on_surface_variant",
-        }),
+        contextControl(),
       }),
       ui.button({
         text = tr("actions.open_k9s"),

--- a/k8s-status/plugin.toml
+++ b/k8s-status/plugin.toml
@@ -2,7 +2,7 @@
 
 id = "davemhammer/k8s-status"
 name = "K8s Status"
-version = "1.1.5"
+version = "1.2.0"
 plugin_api = 10
 author = "davemhammer"
 license = "MIT"

--- a/k8s-status/service.luau
+++ b/k8s-status/service.luau
@@ -10,6 +10,7 @@ local snapshot = {
   loading = true,
   busy = false,
   context = "",
+  contexts = {},
   nodes = {},
   pods = {},
   deployments = {},
@@ -417,6 +418,7 @@ refreshAll = function()
     snapshot.pods = {}
     snapshot.deployments = {}
     snapshot.namespaces = {}
+    snapshot.contexts = {}
     snapshot.readyNodes = 0
     snapshot.nodeCount = 0
     snapshot.problemPods = 0
@@ -454,12 +456,12 @@ refreshAll = function()
     snapshot.available = false
     snapshot.loading = false
     snapshot.error = trim(err) ~= "" and trim(err) or noctalia.tr("result.unreachable")
-    updateRevision("err:" .. snapshot.error)
+    updateRevision("err:" .. snapshot.error .. "|" .. snapshot.context)
     publishSnapshot()
     doneRefresh()
   end
 
-  local function applySuccess(ctx, nodes, pods, deploys, namespaces)
+  local function applySuccess(ctx, nodes, pods, deploys, namespaces, contexts)
     if generation ~= refreshGeneration then
       return
     end
@@ -485,6 +487,7 @@ refreshAll = function()
     snapshot.pods = pods
     snapshot.deployments = deploys
     snapshot.namespaces = namespaces
+    snapshot.contexts = contexts or {}
     snapshot.readyNodes = readyCount
     snapshot.nodeCount = #nodes
     snapshot.problemPods = problemCount
@@ -494,6 +497,7 @@ refreshAll = function()
 
     updateRevision(table.concat({
       snapshot.context,
+      table.concat(snapshot.contexts, ","),
       tostring(readyCount),
       tostring(#nodes),
       tostring(problemCount),
@@ -512,8 +516,9 @@ refreshAll = function()
     podsOut = "",
     deploysOut = "",
     nsOut = "",
+    contextsOut = "",
   }
-  local pending = 5
+  local pending = 6
   local finished = false
 
   local function finishOne()
@@ -527,6 +532,12 @@ refreshAll = function()
     finished = true
 
     if bag.nodesOut == nil then
+      -- Context data comes from the local kubeconfig, not the cluster: keep the
+      -- selector usable even when the current cluster is unreachable.
+      snapshot.context = bag.context
+      local contexts = splitLines(bag.contextsOut)
+      table.sort(contexts)
+      snapshot.contexts = contexts
       fail(bag.nodesErr or "nodes failed")
       return
     end
@@ -567,7 +578,10 @@ refreshAll = function()
       namespaces = nsOrErr
     end
 
-    applySuccess(bag.context, nodes, pods, deploys, namespaces)
+    local contexts = splitLines(bag.contextsOut)
+    table.sort(contexts)
+
+    applySuccess(bag.context, nodes, pods, deploys, namespaces, contexts)
   end
 
   -- context
@@ -664,6 +678,22 @@ refreshAll = function()
     end
     finishOne()
   end, 20000)
+
+  -- contexts (best-effort, feeds the panel selector)
+  local ctxsArgs = baseKubectlArgs()
+  table.insert(ctxsArgs, "config")
+  table.insert(ctxsArgs, "get-contexts")
+  table.insert(ctxsArgs, "-o")
+  table.insert(ctxsArgs, "name")
+  runKubectl(ctxsArgs, function(ctxsResult)
+    if generation ~= refreshGeneration then
+      return
+    end
+    if ctxsResult and ctxsResult.exitCode == 0 then
+      bag.contextsOut = ctxsResult.stdout or ""
+    end
+    finishOne()
+  end, 15000)
 end
 
 local function finishAction(command, ok, message)
@@ -787,6 +817,41 @@ local function restartDeploy(command)
       finishAction(command, false, noctalia.tr("result.failed", { error = err ~= "" and err or "restart failed" }))
     end
   end, 60000)
+end
+
+-- Switches the kubeconfig current-context (kubectx equivalent). Only meaningful
+-- when the "context" setting is empty; a pinned setting overrides every call.
+local function useContext(command)
+  if actionBusy then
+    actionResult(command, false, noctalia.tr("result.busy"))
+    return
+  end
+  local name = trim(command.context)
+  if name == "" then
+    actionResult(command, false, noctalia.tr("result.failed", { error = "missing context" }))
+    return
+  end
+  if trim(noctalia.getConfig("context")) ~= "" then
+    actionResult(command, false, noctalia.tr("result.context_pinned"))
+    return
+  end
+  -- The pinned-context case is rejected above, so baseKubectlArgs() adds no
+  -- --context here; reusing it keeps kubectl invocation consistent.
+  local args = baseKubectlArgs()
+  table.insert(args, "config")
+  table.insert(args, "use-context")
+  table.insert(args, name)
+  actionBusy = true
+  publishSnapshot()
+  runKubectl(args, function(result)
+    local ok = result ~= nil and result.exitCode == 0
+    if ok then
+      finishAction(command, true, noctalia.tr("result.context_switched", { name = name }))
+    else
+      local err = trim(result and result.stderr or "")
+      finishAction(command, false, noctalia.tr("result.failed", { error = err ~= "" and err or "context switch failed" }))
+    end
+  end, 30000)
 end
 
 local function openK9s(command)
@@ -931,6 +996,10 @@ local function executeAction(command)
     restartDeploy(command)
     return
   end
+  if command.action == "use_context" then
+    useContext(command)
+    return
+  end
   if command.action == "k9s" then
     openK9s(command)
     return
@@ -953,10 +1022,14 @@ function onConfigChanged()
   refreshAll()
 end
 
-function onIpc(event, _payload)
+function onIpc(event, payload)
   if event == "refresh" then
     refreshPending = false
     refreshStartedAt = 0
     refreshAll()
+    return
+  end
+  if event == "use_context" then
+    executeAction({ action = "use_context", context = trim(payload), requestId = "ipc" })
   end
 end

--- a/k8s-status/translations/en.json
+++ b/k8s-status/translations/en.json
@@ -103,6 +103,8 @@
   "result": {
     "busy": "Another operation is running.",
     "copied": "Copied {name}",
+    "context_pinned": "Context is pinned in the plugin settings.",
+    "context_switched": "Switched to context {name}",
     "deleted": "Deleted pod {name}",
     "describe_started": "Describing {name}…",
     "failed": "Failed: {error}",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `davemhammer/k8s-status`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds a context selector to the panel header (refs #630).

When the kubeconfig contains multiple contexts and the `context` setting is empty, the panel header shows a compact `ui.select` listing all contexts (`kubectl config get-contexts -o name`, current context pre-selected). Picking one runs `kubectl config use-context <name>` — the kubectx equivalent — so the choice is shared with the terminal/k9s and persists across restarts, and the snapshot refreshes immediately.

Details:

- With `context` pinned in the plugin settings, the header keeps the existing read-only label, because the pinned setting overrides every kubectl call.
- Context data comes from the local kubeconfig, so the selector stays usable even when the current cluster is unreachable — you can switch away from a dead cluster.
- Also exposed over IPC for scripting: `noctalia msg plugin davemhammer/k8s-status:service all use_context <name>` (documented in the README).

Note on #630: the issue asks for loading the plugin twice with different kubeconfigs (simultaneous multi-cluster). That needs multi-instance support in the Noctalia host (the service entry is a singleton per plugin id) and is out of plugin scope; this PR covers the underlying homelab need with fast, UI-native switching between clusters.

## External dependencies

Unchanged: `kubectl` and `less` (already declared). Two new kubectl invocations, both local kubeconfig operations: `config get-contexts -o name` (read-only, once per refresh) and `config use-context` (writes the kubeconfig's `current-context` when the user picks a context in the panel or via IPC — this is the feature). No new network calls.

## Testing

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** v5.0.1
- **Plugin API level:** 10

- Two real clusters/contexts (`torro`, `senti-k8s`): the selector lists both with the current one selected; picking the other flips `kubectl config current-context` and the panel refreshes to the new cluster's data (104 pods on torro, 205 on senti-k8s).
- Same flow via IPC: `noctalia msg plugin davemhammer/k8s-status:service all use_context senti-k8s` switches and refreshes.
- Pinned `context` setting: header falls back to the read-only label.
- `noctalia plugins lint k8s-status` clean.

## Screenshots / Videos

![k8s-status panel with the new context selector](https://files.catbox.moe/36r4p8.png)

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.


