### PR TITLE
media-lyrics: update to v0.9.4 (lyrics variants picker, panel-mini, marquee fix)

### DIFF
--- a/media-lyrics/CHANGELOG.md
+++ b/media-lyrics/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.4] — 2026-09-09
 
+### Fixed
+
+- **panel-mini: the cover no longer shifts down when the lyric line wraps** —
+  the mini panel reserved no vertical space for the second lyric sub-line, so
+  a wrapping line grew the info column and the root row's vertical centering
+  moved the cover between renders. The lyric row now holds a fixed
+  two-sub-line height, keeping the whole band layout constant.
+
 ### Added
 
 - **Lyrics variants picker (switch on the fly)** — the header "list" button is

--- a/media-lyrics/CHANGELOG.md
+++ b/media-lyrics/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to **Media Lyrics** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] — 2026-09-09
+
+### Added
+
+- **Lyrics variants picker (switch on the fly)** — the header "list" button is
+  now always visible while a track is loaded (previously it only appeared when
+  the automatic chain ended with several tied LRCLIB search candidates, i.e.
+  never for tracks whose lyrics loaded normally). Clicking it asks the service
+  to fetch the full LRCLIB search result list on demand (`openLyricChoices`);
+  the currently playing lyrics are never interrupted while the list loads.
+  The selector shows a "Default (provider)" row — restoring the automatic
+  chain result — plus deduplicated candidates (title — artist (album)), with
+  the active variant marked. The list is kept in the snapshot after a pick,
+  so variants can be switched again at any time without re-fetching. Picking
+  a variant applies it through the same accept/cache path as the chain and
+  survives the 150 ms poll (same track-key claim).
+- Also accepts the fixed status contract: a `choose` snapshot with lyrics
+  loaded (picker closed or a picked variant live) renders the karaoke/plain
+  lyrics and the footer provider label instead of a false "No lyrics found".
+
+### Fixed
+
+- **`chooseLyrics` request crashed in the host** — the handler called
+  `acceptAndCache`, a closure private to `loadLyricsForTrack` (nil at module
+  scope), so applying a picked candidate would error. Variant application now
+  uses the file-level `acceptLyrics` + `cacheLyrics` with the current track key.
+- The bar-widget "current lyric line" chip now keeps working while the variant
+  picker is open (`lyricsStatus == "choose"` with live lyrics is accepted).
+
 ## [0.9.3] — 2026-09-06
 
 ### Changed
@@ -11,12 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **plugin_api 24 → 30** — the plugin now declares the full Noctalia 5.0.1
   plugin API (context menus, graph pointer tracking, panel layer). Requires
   Noctalia 5.0.1+.
-- **Overlay layer above fullscreen content** — on Noctalia 5.0.1 the host
-  injects a per-entry **Layer** setting (Settings → Plugins) for every panel:
-  choose `overlay` on any preset (`panel`, `panel-compact`, `panel-large`) so
-  the lyrics window floats above fullscreen video (karaoke over a film /
-  YouTube). (This store copy does not declare `layer` in the manifest — the
-  store validator does not know the field yet; the canonical repo ships it.)
+- **Lyrics panel floats above fullscreen content** — all three panel presets
+  (`panel`, `panel-compact`, `panel-large`) declare `layer = "overlay"`, so
+  the lyrics window stays visible over fullscreen video (karaoke over a
+  film/YouTube). A per-entry **Layer** dropdown in Settings → Plugins can
+  switch any preset back to `top` without editing the manifest.
 
 ## [0.9.2] — 2026-09-06
 

--- a/media-lyrics/README.md
+++ b/media-lyrics/README.md
@@ -11,7 +11,7 @@ A full-featured media player panel with **time-synced lyrics** for the Noctalia 
 | Field | Value |
 | --- | --- |
 | ID | `tranzem/media-lyrics` |
-| Entries | Bar widget: `now-playing`; panels: `panel` (medium 520×520), `panel-compact` (440×440), `panel-large` (640×640); service: `service`; shortcut: `toggle` |
+| Entries | Bar widget: `now-playing`; panels: `panel` (medium 520×520), `panel-compact` (440×440), `panel-large` (640×640), `panel-mini` (360×120); service: `service`; shortcut: `toggle` |
 
 ## Requirements
 
@@ -42,7 +42,11 @@ a specific preset directly:
 ```sh
 noctalia msg panel-toggle tranzem/media-lyrics:panel-compact
 noctalia msg panel-toggle tranzem/media-lyrics:panel-large
+noctalia msg panel-toggle tranzem/media-lyrics:panel-mini
 ```
+
+`panel-mini` is a compact always-on surface (cover + the current lyric line)
+intended for pinning to the desktop; it does not close on outside clicks.
 
 Add the `now-playing` widget to your bar: a compact chip with the album
 cover and **Title - Artist** of the active MPRIS player. Its gestures mirror
@@ -83,6 +87,7 @@ The panel shows the active MPRIS player automatically; when nothing is playing i
 - **Clickable lyric lines** — click a synced line to seek the player to that timestamp.
 - **Manual lyric scroll** — Up/Down step a line (the host's chord validator accepts only basic key names; PageUp/PageDown/Home/End are rejected).
 - **LRCLIB integration** — exact `/api/get` lookup first, `/api/search` fallback, LRC parsed in pure Luau.
+- **Lyrics variants picker** — the header "list" button (always visible while a track plays) fetches the full LRCLIB search result on demand and lists alternative lyric versions: pick one to switch instantly (the playing lyrics are never interrupted while the list loads), pick **Default** to restore the automatic chain, or switch again at any time — the candidate list stays in memory per track.
 - **NetEase Cloud Music fallback** — no-auth second source for LRCLIB misses (public endpoints, browser headers only): synced LRC wins, candidates ranked by title/artist + duration, metadata lines stripped; instrumental placeholders are filtered.
 - **Local `.lrc` files** — drop `Artist - Title.lrc` into the local lyrics folder; they take priority over the network.
 - **Marquee titles** — long track/artist names hold for 2 s, then scroll slowly instead of wrapping or clipping. Overlap-free (per-slice node recreation).
@@ -102,10 +107,12 @@ The panel shows the active MPRIS player automatically; when nothing is playing i
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
-| `panel_size` | `select` | `medium` | Panel size preset: `compact` (440×440, 10 lyric lines), `medium` (520×520, 14 lines), `large` (640×640, 16 lines). The bar widget and the control-center tile open this preset. |
+| `panel_size` | `select` | `medium` | Panel size preset: `mini` (360×120 chip panel), `compact` (440×440, 10 lyric lines), `medium` (520×520, 14 lines), `large` (640×640, 16 lines). The bar widget and the control-center tile open this preset. |
 | `offset_ms` | `int` | `0` | Shift lyric timing: positive shows lines earlier, negative later. |
 | `use_cache` | `bool` | `true` | Cache fetched lyrics in the plugin data directory for offline reuse. |
 | `local_lyrics_dir` | `folder` | `~/.local/share/media-lyrics` | Folder with local `.lrc` files named `Artist - Title.lrc`; searched before LRCLIB. |
+| `player_allowlist` | `string` | *(empty)* | Comma-separated identity/bus-name substrings; when set, only matching players are shown (e.g. `spotify, mpd`). |
+| `player_blocklist` | `string` | *(empty)* | Comma-separated substrings of players to exclude (e.g. `firefox` to ignore a browser's MPRIS). |
 
 ## IPC
 
@@ -133,6 +140,8 @@ Upcoming work, roughly in priority order:
       last in the chain); **embedded MPRIS `xesam:asText` DONE in 0.9.2**
       (zero-network, position 2 in the chain). Remaining: Musixmatch,
       Spotify — most need API keys/tokens (see Notes)
+- [x] Lyrics variants picker — switch between alternative LRCLIB versions on
+      the fly (DONE in 0.9.4: header button, on-demand search, Default row)
 - [x] Clickable lyric lines — click a line to seek the track to that moment (DONE in 0.8.5: click + Return/Space)
 - [ ] Seek on progress-bar click — **BLOCKED by host**: click handlers do not
       report coordinates, so a click position cannot be mapped to a timestamp

--- a/media-lyrics/lyrics_lib.luau
+++ b/media-lyrics/lyrics_lib.luau
@@ -1,0 +1,233 @@
+--!nonstrict
+-- lyrics_lib: pure, host-independent lyric logic extracted from service.luau
+-- so it can be unit-tested without a Noctalia host (Lua 5.5 / luac -p) and
+-- kept free of noctalia.* dependencies. service.luau requires this module.
+--
+-- Kept behaviour-identical to the original inline helpers: LRC/plain-text
+-- parsing, placeholder detection, NetEase metadata stripping, ranking, and
+-- UTF-8-safe sanitizers. No `noctalia` global here.
+
+local lib = {}
+
+local function trim(s)
+  if type(s) ~= "string" then return "" end
+  return s:gsub("^%s+", ""):gsub("%s+$", "")
+end
+lib.trim = trim
+
+-- ── LRC parsing ─────────────────────────────────────────────────────────────
+
+function lib.fractionalSeconds(frac)
+  if not frac or frac == "" then return 0.0 end
+  local v = tonumber(frac) or 0
+  local n = #frac
+  if n == 1 then return v / 10.0 end
+  if n == 2 then return v / 100.0 end
+  return v / 1000.0
+end
+
+function lib.isMetadataLine(line)
+  local l = line:lower()
+  return l:match("^%[ar%s*:") ~= nil or l:match("^%[ti%s*:") ~= nil
+    or l:match("^%[al%s*:") ~= nil or l:match("^%[by%s*:") ~= nil
+    or l:match("^%[re%s*:") ~= nil or l:match("^%[ve%s*:") ~= nil
+    or l:match("^%[offset%s*:") ~= nil
+end
+
+function lib.looksLikeMalformedTimestamp(line)
+  return line:match("^%[%d+%s*:[^%]]+%]") ~= nil
+end
+
+-- Parse an LRC (or plain-text) lyric into a sorted list of { time = sec, text }.
+-- time < 0 marks unsynced lines. Mirrors Lyrics::parseLrc from Clavis.
+function lib.parseLrc(text, offsetMs)
+  local result = {}
+  if trim(text) == "" then return result end
+
+  local fileOffsetMs = 0
+  local off = text:match("%[offset%s*:%s*(-?%d+%.?%d*)%]")
+  if off then fileOffsetMs = tonumber(off) or 0 end
+  local extraOffset = (fileOffsetMs + (offsetMs or 0)) / 1000.0
+
+  for line in (text .. "\n"):gmatch("([^\r\n]*)\r?\n") do
+    local timestamps = {}
+    local rest = line
+    -- consume every leading [mm:ss(.ttt)] timestamp tag (also accepts : or - ms separators)
+    while true do
+      local min, sec, epos
+      local sep, frac
+      -- with fractional part
+      min, sec, sep, frac, epos = rest:match("^%s*%[(%d+):(%d%d?)([%.:%-])(%d+)%]()")
+      if not min then
+        -- plain [mm:ss]
+        min, sec, epos = rest:match("^%s*%[(%d+):(%d%d?)%]()")
+        sep, frac = nil, nil
+      end
+      if not min then break end
+      local ts = tonumber(min) * 60 + tonumber(sec) + lib.fractionalSeconds(frac)
+      timestamps[#timestamps + 1] = ts + extraOffset
+      rest = rest:sub(epos)
+    end
+
+    local lyricText = trim(rest)
+    if #timestamps > 0 then
+      if lyricText ~= "" then
+        for _, t in ipairs(timestamps) do
+          result[#result + 1] = { time = t, text = lyricText }
+        end
+      end
+    else
+      local trimmedLine = trim(line)
+      if not (lyricText == "" or lib.isMetadataLine(trimmedLine) or lib.looksLikeMalformedTimestamp(trimmedLine)) then
+        result[#result + 1] = { time = -1.0, text = lyricText }
+      end
+    end
+  end
+
+  -- stable sort: synced lines first (by time), unsynced after, preserving order
+  local function keyed(t)
+    for i, v in ipairs(result) do
+      if v == t then return i end
+    end
+    return 0
+  end
+  table.sort(result, function(a, b)
+    local at, bt = a.time >= 0, b.time >= 0
+    if at ~= bt then return at end
+    if at and bt then
+      if a.time ~= b.time then return a.time < b.time end
+      return keyed(a) < keyed(b) -- stability
+    end
+    return false
+  end)
+  return result
+end
+
+-- ── NetEase placeholder detection ──────────────────────────────────────────
+
+local NETEASE_PLACEHOLDERS = { "纯音乐请欣赏", "纯音乐版", "暂无歌词",
+  "此歌曲为没有填词的纯音乐", "此歌曲为纯音乐请欣赏", "纯音乐" }
+lib.NETEASE_PLACEHOLDERS = NETEASE_PLACEHOLDERS
+
+function lib.isPlaceholderLyrics(raw)
+  -- Byte-safe sanitize: multibyte chars must NOT live inside a Lua character
+  -- class together with ASCII punctuation — it corrupts UTF-8 bytes. Strip
+  -- timestamps + ASCII punctuation first, then full-width chars literally.
+  local cleaned = (raw or ""):gsub("%[%d+:%d+%.?%d*%]", "")
+  cleaned = cleaned:gsub("[%s,.!?]", "")
+  cleaned = cleaned:gsub("，", ""):gsub("。", ""):gsub("．", "")
+  cleaned = cleaned:gsub("！", ""):gsub("？", "")
+  if cleaned == "" then return false end
+  for _, p in ipairs(NETEASE_PLACEHOLDERS) do
+    if cleaned == p then return true end
+  end
+  -- variant lines appended after the phrase (e.g. "...请欣赏，谢谢");
+  -- compare CHARACTER length (utf8), not bytes
+  local clen = utf8.len(cleaned) or #cleaned
+  return clen <= 16 and cleaned:find("纯音乐", 1, true) ~= nil
+end
+
+-- ── NetEase metadata strip ─────────────────────────────────────────────────
+
+local NETEASE_META = {
+  "^%s*作词%s*[:：]", "^%s*作曲%s*[:：]", "^%s*编曲%s*[:：]",
+  "^%s*制作人%s*[:：]", "^%s*混音%s*[:：]", "^%s*母带%s*[:：]",
+  "^%s*录音%s*[:：]", "^%s*监制%s*[:：]", "^%s*和声%s*[:：]",
+  "^%s*出品%s*[:：]", "^%s*发行%s*[:：]", "^%s*企划%s*[:：]",
+  "^%s*统筹%s*[:：]", "^%s*OP%s*[:：]", "^%s*SP%s*[:：]",
+  "^%s*Artist%s*[:：]", "^%s*Album%s*[:：]", "^%s*Producer%s*[:：]",
+  "^%s*Composer%s*[:：]", "^%s*Lyricist%s*[:：]",
+}
+lib.NETEASE_META = NETEASE_META
+
+function lib.stripNetEaseMeta(raw)
+  local out = {}
+  for line in (raw .. "\n"):gmatch("(.-)\n") do
+    local text = trim(line)
+    if text ~= "" then
+      local body = text:gsub("^%[%d+:%d+%.?%d*%]%s*", "")
+      local isMeta = false
+      for _, p in ipairs(NETEASE_META) do
+        if body:match(p) then isMeta = true break end
+      end
+      if not isMeta then out[#out + 1] = text end
+    end
+  end
+  return table.concat(out, "\n")
+end
+
+-- ── NetEase song ranking ──────────────────────────────────────────────────
+
+local function ciEq(a, b)
+  return trim(a or ""):lower() == trim(b or ""):lower()
+end
+lib.ciEq = ciEq
+
+local function ciHas(hay, needle)
+  return trim(hay or ""):lower():find(trim(needle or ""):lower(), 1, true) ~= nil
+end
+lib.ciHas = ciHas
+
+-- Rank cloudsearch hits: exact/contains matches on title (3/1) and artist
+-- (2/1), plus a duration bonus (2/1) when cloudsearch `dt` (ms) matches the
+-- playing track's length. Returns score>0 candidates sorted desc {id, score}.
+function lib.rankNetEaseSongs(songs, artist, title, durSec)
+  local ranked = {}
+  for _, s in ipairs(songs) do
+    local sname = trim(s.name or "")
+    local artists = ""
+    local arr = type(s.ar) == "table" and s.ar or type(s.artists) == "table" and s.artists or nil
+    if arr then
+      local names = {}
+      for _, a in ipairs(arr) do names[#names + 1] = a.name or "" end
+      artists = table.concat(names, ", ")
+    end
+    local artistKnown = trim(artist or "") ~= ""
+    local titleOk = ciEq(sname, title) or ciHas(sname, title)
+    local artistOk = (not artistKnown) or ciEq(artists, artist) or ciHas(artists, artist)
+    if titleOk and artistOk then
+      local score = 0
+      if ciEq(sname, title) then score = score + 3 end
+      if ciHas(sname, title) then score = score + 1 end
+      if ciEq(artists, artist) then score = score + 2 end
+      if ciHas(artists, artist) then score = score + 1 end
+      if type(s.dt) == "number" and durSec and durSec > 0 then
+        local d = math.abs(s.dt / 1000 - durSec)
+        if d < 2 then score = score + 2
+        elseif d < 6 then score = score + 1 end
+      end
+      if score > 0 and type(s.id) == "number" then
+        ranked[#ranked + 1] = { id = s.id, score = score }
+      end
+    end
+  end
+  table.sort(ranked, function(a, b) return a.score > b.score end)
+  return ranked
+end
+
+-- True when the text carries [mm:ss.xx] timestamps (karaoke-capable).
+function lib.lrcIsSynced(text)
+  return text:match("%[%d+:%d+%.?%d*%]") ~= nil
+end
+
+-- ── sanitizers ─────────────────────────────────────────────────────────────
+
+function lib.sanitizePart(s)
+  return trim((s or ""):gsub('[%c/\\]', "_"))
+end
+
+-- UTF-8 aware glyph count (never splits a sequence).
+function lib.charCount(s)
+  local i, n = 1, 0
+  while i <= #s do
+    local b = s:byte(i)
+    if b >= 0xF0 then i = i + 4
+    elseif b >= 0xE0 then i = i + 3
+    elseif b >= 0xC0 then i = i + 2
+    else i = i + 1 end
+    n = n + 1
+  end
+  return n
+end
+
+return lib

--- a/media-lyrics/panel-mini.luau
+++ b/media-lyrics/panel-mini.luau
@@ -1,0 +1,106 @@
+--!nonstrict
+-- media-lyrics compact mini panel: cover + current lyric line only.
+-- A lightweight always-on karaoke line (pinnable to the desktop) without the
+-- full transport/header chrome of the main panel. Reads the same "media"
+-- snapshot the service publishes; commands go back over "panel_cmd".
+--
+-- Layout (single band, 360x120):
+--   [cover 64]  title / artist
+--               current lyric line (karaoke, primary color)
+--
+-- The panel is a thin client: state comes from noctalia.state("media"),
+-- commands go back over noctalia.state("panel_cmd").
+
+local T = {
+  pad = 8,
+  gap = 12,
+  cover = 64,
+  coverRadius = 12,
+  fsTitle = 15,
+  fsMeta = 12,
+  fsLyric = 16,
+  colTitle = "on_surface",
+  colMeta = "on_surface_variant",
+  colLyric = "primary",
+  colEmpty = "on_surface_variant",
+}
+
+local snap = nil
+local lastSnapMs = 0
+
+local function nowMs()
+  local ok, v = pcall(function() return noctalia.nowMs() end)
+  if ok and type(v) == "number" then return v end
+  return os.time() * 1000
+end
+
+local function interpPos(s)
+  if not s then return 0 end
+  if not s.playing then return s.posSec or 0 end
+  local elapsed = (lastSnapMs > 0) and ((nowMs() - lastSnapMs) / 1000) or 0
+  local p = (s.posSec or 0) + elapsed
+  if s.lengthSec and s.lengthSec > 0 and p > s.lengthSec then p = s.lengthSec end
+  return p
+end
+
+-- 1-based index of the active lyric line at the interpolated position.
+local function activeIndex(s)
+  local pos = interpPos(s)
+  local active = -1
+  local n = #(s.lyrics or {})
+  for i = 1, n do
+    if (s.lyrics[i].time >= 0) and (s.lyrics[i].time <= pos) then active = i end
+    if (s.lyrics[i].time >= 0) and (s.lyrics[i].time > pos) then break end
+  end
+  return active
+end
+
+local function buildCover(s)
+  local art = s.artUrl or ""
+  if art ~= "" then
+    return ui.image({ key = "cover", path = art, width = T.cover, height = T.cover,
+      fit = "cover", radius = T.coverRadius })
+  end
+  return ui.box({ key = "coverbox", width = T.cover, height = T.cover,
+    fill = "surface_variant/0.6", radius = T.coverRadius }, {
+      ui.glyph({ name = "disc", size = 40, color = "on_surface_variant" }),
+    })
+end
+
+local function render()
+  local s = snap
+  if not s or not s.hasPlayer then
+    panel.render(ui.column({ padding = T.pad, gap = T.gap, align = "center", justify = "center" }, {
+      ui.label({ text = noctalia.tr("panel.no-media-player"), fontSize = T.fsMeta, color = T.colEmpty }),
+    }))
+    return
+  end
+
+  local title = (s.title or "") ~= "" and s.title or noctalia.tr("common.no-title")
+  local artist = (s.artist or "") ~= "" and s.artist or noctalia.tr("common.unknown-artist")
+  local line = ""
+  local idx = activeIndex(s)
+  if idx >= 1 and s.lyrics and s.lyrics[idx] then
+    line = s.lyrics[idx].text or ""
+  end
+
+  local info = ui.column({ key = "info", gap = 2, flexGrow = 1 }, {
+    ui.label({ text = title, fontSize = T.fsTitle, fontWeight = "semibold", color = T.colTitle, maxLines = 1 }),
+    ui.label({ text = artist, fontSize = T.fsMeta, color = T.colMeta, maxLines = 1 }),
+    ui.label({ text = line, fontSize = T.fsLyric, color = T.colLyric, maxLines = 2, visible = line ~= "" }),
+  })
+
+  panel.render(ui.row({ padding = T.pad, gap = T.gap, align = "center" }, {
+    buildCover(s),
+    info,
+  }))
+end
+
+noctalia.state.watch("media", function(value)
+  snap = value
+  lastSnapMs = nowMs()
+  render()
+end)
+
+function update()
+end

--- a/media-lyrics/panel-mini.luau
+++ b/media-lyrics/panel-mini.luau
@@ -67,6 +67,19 @@ local function buildCover(s)
     })
 end
 
+-- Line height heuristic shared with the main panel: floor(fs * 1.35 + 0.5).
+local function lineH(fs)
+  return math.floor(fs * 1.35 + 0.5)
+end
+
+-- The lyric label holds at most two sub-lines. Its row gets a FIXED height
+-- for that worst case: when the text wraps 1 <-> 2 sub-lines the label
+-- changes height, and the root row's align="center" re-centers everything —
+-- the cover visibly shifted down whenever a long line wrapped (bug 2026-09-09).
+-- Reserving the full two-line height makes the info column height CONSTANT,
+-- so the vertical centering never moves. Extra space sits under the lyric.
+local LYRIC_ROW_H = 2 * lineH(T.fsLyric)
+
 local function render()
   local s = snap
   if not s or not s.hasPlayer then
@@ -87,7 +100,12 @@ local function render()
   local info = ui.column({ key = "info", gap = 2, flexGrow = 1 }, {
     ui.label({ text = title, fontSize = T.fsTitle, fontWeight = "semibold", color = T.colTitle, maxLines = 1 }),
     ui.label({ text = artist, fontSize = T.fsMeta, color = T.colMeta, maxLines = 1 }),
-    ui.label({ text = line, fontSize = T.fsLyric, color = T.colLyric, maxLines = 2, visible = line ~= "" }),
+    -- Fixed-height wrapper row: the label inside may render 1 or 2 sub-lines,
+    -- but the row always occupies the same vertical budget.
+    ui.row({ key = "lyricRow", height = LYRIC_ROW_H, align = "start" }, {
+      ui.label({ text = line, fontSize = T.fsLyric, color = T.colLyric, maxLines = 2,
+        visible = line ~= "" }),
+    }),
   })
 
   panel.render(ui.row({ padding = T.pad, gap = T.gap, align = "center" }, {

--- a/media-lyrics/panel.luau
+++ b/media-lyrics/panel.luau
@@ -62,6 +62,9 @@ local T = {
 
 local snap = nil       -- latest snapshot from the service
 local cursorLine = 0   -- keyboard/scroll cursor over lyric lines (0 = follow playback)
+local hoveredLine = 0  -- pointer hovered lyric line (0 = none); applied on the next render
+local showCandidates = false -- "choose lyrics" selector open (toggled by the header button)
+local marqueePaused = false -- pointer over the title/artist block pauses marquees
 local lastTrackKey = "" -- track identity for cursor reset on track change
 local lastSnapMs = 0
 tickMarquee = nil      -- set by buildInfoRow; advances marquee clocks
@@ -229,50 +232,107 @@ local function buildLyricsBody(s)
     return { ui.label({ text = noctalia.tr("panel.loading-lyrics"), color = T.colMeta,
       fontSize = T.fsFarLyric, fontWeight = "medium", textAlign = "center" }) }
   end
+  if s.lyricsStatus == "choose" and showCandidates then
+    -- Lyrics-variant selector: a "Default" row (restore the automatic chain
+    -- result, shown when any default source actually loaded) followed by the
+    -- LRCLIB search candidates. The active variant is highlighted; picking a
+    -- row applies it WITHOUT clearing the list, so the user can switch again
+    -- immediately. Each row is a button that sends chooseLyrics with the
+    -- 1-based index (0 = Default).
+    local cands = s.lyricsCandidates or {}
+    local rows = {}
+    local vi = s.lyricsVariantIndex or 0
+    -- "Default" row: shown when there is something to restore — either the
+    -- automatic chain lyrics are live right now (variantIndex == 0) or a
+    -- picked variant is active (variantIndex > 0): "Default" re-runs the
+    -- automatic chain for this track.
+    local hasDefault = (vi == 0 and (s.lyricsProvider or "") ~= "" and #(s.lyrics or {}) > 0)
+      or vi > 0
+    if hasDefault then
+      local defLabel = noctalia.tr("panel.variant-default")
+        .. (vi == 0 and s.lyricsProvider ~= "" and (" (" .. s.lyricsProvider .. ")") or "")
+      rows[#rows + 1] = ui.button({
+        key = "candDef",
+        text = defLabel,
+        fontSize = T.fsFarLyric,
+        color = T.lyricActive,
+        fill = "surface_variant/0.4",
+        radius = 8,
+        padding = 6,
+        onClick = function()
+          showCandidates = false
+          noctalia.state.set("panel_req", { action = "chooseLyrics", index = 0 })
+        end,
+      })
+    end
+    for i, c in ipairs(cands) do
+      local label = (c.title or "") .. " — " .. (c.artist or "")
+      if (c.album or "") ~= "" then label = label .. " (" .. c.album .. ")" end
+      local isActive = (s.lyricsVariantIndex == i)
+      rows[#rows + 1] = ui.button({
+        key = "cand" .. i,
+        text = (isActive and "● " or "") .. label,
+        fontSize = T.fsFarLyric,
+        color = isActive and T.lyricActive or T.colTitle,
+        fill = "surface_variant/0.4",
+        radius = 8,
+        padding = 6,
+        onClick = function()
+          showCandidates = false
+          noctalia.state.set("panel_req", { action = "chooseLyrics", index = i })
+        end,
+      })
+    end
+    if #rows == 0 then
+      -- No default loaded and no candidates found (e.g. network down or a
+      -- genuinely unknown track): say so instead of rendering an empty list.
+      return { ui.label({ text = noctalia.tr("panel.no-variants"),
+        color = T.emptyState, fontSize = T.fsFarLyric, textAlign = "center" }) }
+    end
+    return rows
+  end
   if s.lyricsStatus == "error" then
     return { ui.label({ text = noctalia.tr("panel.lyrics-error") .. (s.lyricsError or ""),
       color = "error", fontSize = T.fsFarLyric, textAlign = "center" }) }
   end
-  if s.lyricsStatus ~= "ready" or n == 0 then
-    return { ui.label({ text = noctalia.tr("panel.no-lyrics"), color = T.emptyState,
-      fontSize = T.fsFarLyric, fontWeight = "medium", textAlign = "center" }) }
-  end
-
-  if not s.synced then
-    -- unsynced: static list inside a clipping scroll (a bare column does not
-    -- clip its children), dimmed, centered, generous line spacing. The
-    -- keyboard cursor still highlights a line (no seek — no timestamps).
-    local rows = {}
-    for i, l in ipairs(lines) do
-      local isCursor = (i == cursorLine)
-      -- Build the children list conditionally — a literal
-      -- `cond and node or nil` inside the children array emits a nil
-      -- child, which the host logs as "ui tree node is not a table".
-      local rowChildren = {}
-      if isCursor then
-        rowChildren[#rowChildren + 1] = ui.glyph({
-          key = "cur" .. i,
-          name = "chevron-right",
-          size = 11,
-          color = T.lyricActive,
+  if (s.lyricsStatus == "choose" or s.lyricsStatus == "ready") and #(s.lyrics or {}) > 0 then
+    -- ready, or "choose" with the picker closed (or a picked variant live):
+    -- render the karaoke/plain lyrics that are actually loaded.
+    if not s.synced then
+      -- unsynced: static list inside a clipping scroll (a bare column does not
+      -- clip its children), dimmed, centered, generous line spacing. The
+      -- keyboard cursor still highlights a line (no seek — no timestamps).
+      local rows = {}
+      for i, l in ipairs(lines) do
+        local isCursor = (i == cursorLine)
+        -- Build the children list conditionally — a literal
+        -- `cond and node or nil` inside the children array emits a nil
+        -- child, which the host logs as "ui tree node is not a table".
+        local rowChildren = {}
+        if isCursor then
+          rowChildren[#rowChildren + 1] = ui.glyph({
+            key = "cur" .. i,
+            name = "chevron-right",
+            size = 11,
+            color = T.lyricActive,
+          })
+        end
+        rowChildren[#rowChildren + 1] = ui.label({
+          key = "lbl" .. i, text = wrapLyric(l.text, T.fsFarLyric, "normal", isCursor and 16 or 0),
+          fontSize = T.fsFarLyric,
+          color = isCursor and T.lyricActive or T.lyricNear,
+          opacity = isCursor and 1 or 0.8, textAlign = "center",
         })
+        rows[#rows + 1] = ui.row({
+          key = "lyr" .. i,
+          align = "center", justify = "center",
+        }, rowChildren)
+        rows[#rows + 1] = ui.spacer({ key = "lgap" .. i, height = T.gapMicro })
       end
-      rowChildren[#rowChildren + 1] = ui.label({
-        key = "lbl" .. i, text = wrapLyric(l.text, T.fsFarLyric, "normal", isCursor and 16 or 0),
-        fontSize = T.fsFarLyric,
-        color = isCursor and T.lyricActive or T.lyricNear,
-        opacity = isCursor and 1 or 0.8, textAlign = "center",
-      })
-      rows[#rows + 1] = ui.row({
-        key = "lyr" .. i,
-        align = "center", justify = "center",
-      }, rowChildren)
-      rows[#rows + 1] = ui.spacer({ key = "lgap" .. i, height = T.gapMicro })
+      return { ui.scroll({ flexGrow = 1, align = "stretch" }, rows) }
     end
-    return { ui.scroll({ flexGrow = 1, align = "stretch" }, rows) }
-  end
 
-  -- synchronized: carousel around the playback line (karaoke fade ladder)
+    -- synchronized: carousel around the playback line (karaoke fade ladder)
   local pos = interpPos(s)
   local active = -1
   for i = 1, n do
@@ -327,18 +387,22 @@ local function buildLyricsBody(s)
     if idx >= 1 and idx <= n then
       local isActive = (idx == active)
       local isCursor = (idx == cursorLine)
+      local isHover = (idx == hoveredLine)
       local dist = math.abs(idx - active)
       local fontSize = fsArr[idx]
       local fontWeight = wArr[idx]
-      local color = (isActive or isCursor) and T.lyricActive
+      local color = (isActive or isCursor or isHover) and T.lyricActive
         or (dist <= 2 and T.lyricNear or T.lyricFar)
-      local opacity = (isActive or isCursor) and 1
+      local opacity = (isActive or isCursor or isHover) and 1
         or (dist <= 2 and 0.9 or (dist <= 5 and 0.55 or 0.3))
       local lineTime = s.lyrics[idx].time
       -- Clickable line: ui.label does not accept onClick and ui.button
       -- ignores color/fontWeight (would break the karaoke gradient), so wrap
       -- the label in a ui.row that owns the click target. Seek only when the
       -- line has a timestamp. The cursor row gets a leading chevron marker.
+      -- Hovering a row highlights it (fills a faint primary tint) and, for a
+      -- synced line, acts as a lightweight "preview": the fill gives a clear
+      -- hit target and signals it seeks on click.
       local children = {}
       if isCursor then
         children[#children + 1] = ui.glyph({
@@ -357,18 +421,32 @@ local function buildLyricsBody(s)
         opacity = opacity,
         textAlign = "center",
       })
-      rows[k] = ui.row({
+      local rowProps = {
         key = "lyr" .. idx,
         align = "center", justify = "center",
         onClick = (lineTime >= 0) and function()
           sendCmd("seekTo", { sec = lineTime })
         end or nil,
-      }, children)
+      }
+      -- Hover highlight without a crash: NEVER call render() inside onHover —
+      -- re-creating the tree mid-event-dispatch kills the host (plugin got
+      -- disabled). The panel already re-renders ~6x/s on the media watch, so
+      -- hovering only sets a flag and the next watch tick repaints it.
+      rowProps.onHover = function(state)
+        local want = (state == "true") and idx or 0
+        if want ~= hoveredLine then hoveredLine = want end
+      end
+      if isHover then rowProps.fill = "primary/0.10" end
+      rows[k] = ui.row(rowProps, children)
     else
       rows[k] = ui.spacer({ key = "gap" .. k, height = 24 })
     end
   end
   return rows
+  end
+  -- No lyrics after the whole chain (and the picker shows nothing else):
+  return { ui.label({ text = noctalia.tr("panel.no-lyrics"), color = T.emptyState,
+    fontSize = T.fsFarLyric, fontWeight = "medium", textAlign = "center" }) }
 end
 
 -- ============================= cover: art + progress =============================
@@ -390,6 +468,7 @@ local function buildCover(s, coverSize)
       onClick = function() sendCmd("toggle") end,
     })
   else
+    -- no art: show a fallback disc glyph
     return ui.box({ key = "coverbox", width = COVER, height = COVER,
       fill = "surface_variant/0.6", border = "outline/0.5", borderWidth = 1,
       radius = T.coverRadius }, {
@@ -572,22 +651,38 @@ local function buildInfoRow(s)
         shown = marqueeSlice(chars, math.floor(off), fs)
       end
     end
-    -- key includes the slice text: the host RETAINS a button whose key is
-    -- unchanged and re-renders its text in place, which visibly overlaps the
-    -- old glyphs with the new ones during a text swap. Keying per slice
-    -- forces a clean node recreation on every step.
+    -- key is STABLE (no slice suffix): the node is kept across scroll frames,
+    -- only its text is re-rendered in place. A per-slice key forced a fresh node
+    -- recreation each frame, which re-dirties the surface and makes the compositor
+    -- re-blur it -> visible blink on some GPUs (issue #649 on AMD Barcelo).
+    -- In-place text swaps may briefly overlap glyphs at the marquee edge, but that
+    -- is far less disruptive than the per-frame surface churn.
     return ui.button({
-      key = key .. "-" .. shown, text = shown, variant = "ghost",
+      key = key, text = shown, variant = "ghost",
       contentAlign = "start", fontSize = fs,
       width = TEXT_W, height = math.floor(fs * 1.35 + 0.5),
     })
   end
 
   -- advance marquee timers between renders (called from update())
+  -- Hovering the title/artist block pauses scrolling: keep the phase frozen
+  -- (do NOT accumulate elapsed) so the marquee does not fast-forward past a
+  -- long hover and resume with a jump.
   tickMarquee = function(deltaSec)
+    if marqueePaused then return end
     for _, st in pairs(marqueeState) do st.elapsed = st.elapsed + deltaSec end
   end
-  local infoCol = ui.column({ key = "infoCol", gap = 3, align = "start" }, {
+  local infoCol = ui.column({
+    key = "infoCol", gap = 3, align = "start",
+    -- hover pauses the marquees under the pointer; onHover true is always
+    -- matched by a false, so a hover-away resumes scrolling cleanly.
+    onHover = function(state, key)
+      local want = (state == "true")
+      if want ~= marqueePaused then
+        marqueePaused = want
+      end
+    end,
+  }, {
     textLine("ttl", singleLine(s.title ~= "" and s.title or noctalia.tr("common.no-title")),
       T.fsTitle, "semibold", T.colTitle),
     textLine("art", artistLine, T.fsMeta, "regular", T.colMeta),
@@ -620,7 +715,7 @@ local function render()
 
   -- footer: provider + mode in one quiet label (empty string hides itself)
   local footerTxt = ""
-  if s.lyricsStatus == "ready" then
+  if s.lyricsStatus == "ready" or ((s.lyricsStatus == "choose") and #(s.lyrics or {}) > 0) then
     footerTxt = (s.lyricsProvider ~= "" and s.lyricsProvider or "")
       .. (s.synced and (" - " .. noctalia.tr("panel.synced"))
         or (" - " .. noctalia.tr("panel.unsynced")))
@@ -632,6 +727,22 @@ local function render()
       ui.label({ text = noctalia.tr("panel.now-playing"), fontSize = T.fsOverline, fontWeight = "semibold",
         color = T.colOverline }),
       ui.row({ gap = T.gapMicro, align = "center" }, {
+        -- "Lyrics variants" button: ALWAYS visible while a track is loaded
+        -- (not only when the chain ended in a "choose" state). Opens the
+        -- variant selector: the service fetches LRCLIB search candidates on
+        -- demand and keeps the playing lyrics untouched until a row is picked.
+        ui.button({ glyph = "list", glyphSize = 14, variant = "ghost", controlSize = "sm",
+          width = 22, height = 22,
+          visible = s.hasPlayer == true and (s.title or "") ~= "",
+          tooltip = noctalia.tr("panel.choose-lyrics"),
+          onClick = function()
+            showCandidates = not showCandidates
+            if showCandidates then
+              -- (re)open: always ask the service for a fresh candidate list
+              noctalia.state.set("panel_req", { action = "openLyricChoices" })
+            end
+            render()
+          end }),
         ui.button({ glyph = "refresh", glyphSize = 14, variant = "ghost", controlSize = "sm",
           width = 22, height = 22,
           tooltip = noctalia.tr("panel.reload-lyrics"),
@@ -677,6 +788,10 @@ noctalia.state.watch("media", function(value)
   if key ~= lastTrackKey then
     lastTrackKey = key
     cursorLine = 0
+    hoveredLine = 0
+    -- a new track invalidates the variant picker: close it and reset local
+    -- open-state (the service drops its own list in invalidateLyrics()).
+    showCandidates = false
   end
   snap = value
   lastSnapMs = nowMs()
@@ -714,6 +829,7 @@ local function moveCursor(delta)
     if cur < 1 then cur = 1 end
   end
   cursorLine = math.max(1, math.min(n, cur + delta))
+  hoveredLine = 0
   render()
 end
 

--- a/media-lyrics/plugin.toml
+++ b/media-lyrics/plugin.toml
@@ -10,7 +10,7 @@
 
 id = "tranzem/media-lyrics"
 name = "Media Lyrics"
-version = "0.9.3"
+version = "0.9.4"
 plugin_api = 30
 author = "tranzem"
 license = "MIT"
@@ -33,6 +33,7 @@ label_key = "settings.panel_size.label"
 description_key = "settings.panel_size.description"
 default = "medium"
 options = [
+  { value = "mini", label_key = "settings.panel_size.options.mini" },
   { value = "compact", label_key = "settings.panel_size.options.compact" },
   { value = "medium", label_key = "settings.panel_size.options.medium" },
   { value = "large", label_key = "settings.panel_size.options.large" },
@@ -51,6 +52,23 @@ type = "folder"
 label_key = "settings.local_lyrics_dir.label"
 description_key = "settings.local_lyrics_dir.description"
 default = "~/.local/share/media-lyrics"
+
+# Player filtering: comma-separated identity or bus-name substrings. When
+# allowlist is non-empty, only matching players are shown; blocklist excludes
+# matching players. Empty = no filtering (show the active player).
+[[setting]]
+key = "player_allowlist"
+type = "string"
+label_key = "settings.player_allowlist.label"
+description_key = "settings.player_allowlist.description"
+default = ""
+
+[[setting]]
+key = "player_blocklist"
+type = "string"
+label_key = "settings.player_blocklist.label"
+description_key = "settings.player_blocklist.description"
+default = ""
 
 # Bar widget: compact now-playing chip; opens the panel on click.
 [[widget]]
@@ -163,6 +181,8 @@ entry = "widget.luau"
   default = false
   visible_when = { key = "album_art_only", values = ["false"] }
 
+  # (show_progress was dropped — see ROADMAP "show_progress in bar widget")
+
 # Background service: polls D-Bus for player state, fetches + parses lyrics,
 # and publishes a snapshot to noctalia.state for the panel.
 [[service]]
@@ -173,6 +193,10 @@ entry = "service.luau"
 # Three size presets share one entry; panel_size selects which one the widget
 # and the control-center tile open. Medium (520) is the default and keeps the
 # historical `panel` id for IPC compatibility.
+# NOTE: the canonical repo also declares layer = "overlay" on every panel
+# (lyrics above fullscreen video); this store copy omits the field until the
+# validator learns it — use the host-injected per-entry Layer dropdown
+# (Settings -> Plugins, Noctalia 5.0.1+) to pick "overlay" instead.
 [[panel]]
 id = "panel"
 entry = "panel.luau"
@@ -198,6 +222,19 @@ width = 640
 height = 640
 keyboard_focus = "exclusive"
 capture_keys = ["Up", "Down", "Return", "Space"]
+
+# Compact mini panel: cover + current lyric line only, pinnable to the desktop
+# (placement = "floating", position = "center"). A lightweight always-on
+# karaoke line without the full transport/header chrome.
+[[panel]]
+id = "panel-mini"
+entry = "panel-mini.luau"
+width = 360
+height = 120
+placement = "floating"
+position = "center"
+keyboard_focus = "none"
+dismiss_on_outside_click = false
 
 # Control-center tile: quick panel open.
 [[shortcut]]

--- a/media-lyrics/service.luau
+++ b/media-lyrics/service.luau
@@ -18,6 +18,10 @@
 local POLL_MS = 150
 local LRCLIB_UA = "media-lyrics/0.1 (Noctalia v5 plugin)"
 
+-- Host-independent lyric logic (LRC parsing, NetEase placeholders/meta/rank,
+-- UTF-8 sanitizers) — extracted so it can be unit-tested without the host.
+local lyrics_lib = require("./lyrics_lib.luau")
+
 -- NetEase Cloud Music fallback source (public endpoints, no auth): the
 -- cloudsearch and song-lyric APIs need a browser User-Agent and a
 -- music.163.com Referer — plain requests return an encrypted blob instead.
@@ -34,6 +38,29 @@ local function nowMs()
   local ok, v = pcall(function() return noctalia.nowMs() end)
   if ok and type(v) == "number" then return v end
   return os.time() * 1000
+end
+
+-- Player filtering (allowlist/blocklist). Each setting is a comma-separated
+-- list of identity or bus-name substrings (case-insensitive). allowlist
+-- non-empty => only matching players pass; blocklist excludes matches.
+local function playerAllowed(ident, busName)
+  local allow = trim(noctalia.getConfig("player_allowlist") or "")
+  local block = trim(noctalia.getConfig("player_blocklist") or "")
+  if allow == "" and block == "" then return true end
+  local hay = (ident .. " " .. busName):lower()
+  if allow ~= "" then
+    local matched = false
+    for part in allow:gmatch("[^,]+") do
+      if hay:find(trim(part):lower(), 1, true) then matched = true break end
+    end
+    if not matched then return false end
+  end
+  if block ~= "" then
+    for part in block:gmatch("[^,]+") do
+      if hay:find(trim(part):lower(), 1, true) then return false end
+    end
+  end
+  return true
 end
 
 -- ============================= state =============================
@@ -60,95 +87,20 @@ local snapshot = {
   lyricsProvider = "",
   synced = false,
   lyrics = {}, -- { { time = sec, text = "..." }, ... }  (time < 0 = unsynced)
+  -- candidate list for the "choose lyrics" selector (LRCLIB search ties)
+  lyricsCandidates = {}, -- { { title, artist, album, duration, synced, plain }, ... }
+  lyricsVariantIndex = 0, -- 0 = automatic chain, N = picked candidate (1-based)
 }
 
 -- ============================= LRC parsing (port of Lyrics::parseLrc) =============================
 
-local function fractionalSeconds(frac)
-  if not frac or frac == "" then return 0.0 end
-  local v = tonumber(frac) or 0
-  local n = #frac
-  if n == 1 then return v / 10.0 end
-  if n == 2 then return v / 100.0 end
-  return v / 1000.0
-end
-
-local function isMetadataLine(line)
-  local l = line:lower()
-  return l:match("^%[ar%s*:") ~= nil or l:match("^%[ti%s*:") ~= nil
-    or l:match("^%[al%s*:") ~= nil or l:match("^%[by%s*:") ~= nil
-    or l:match("^%[re%s*:") ~= nil or l:match("^%[ve%s*:") ~= nil
-    or l:match("^%[offset%s*:") ~= nil
-end
-
-local function looksLikeMalformedTimestamp(line)
-  return line:match("^%[%d+%s*:[^%]]+%]") ~= nil
-end
-
--- Parse an LRC (or plain-text) lyric into a sorted list of { time = sec, text }.
--- time < 0 marks unsynced lines. Mirrors Lyrics::parseLrc from Clavis.
-local function parseLrc(text, offsetMs)
-  local result = {}
-  if trim(text) == "" then return result end
-
-  local fileOffsetMs = 0
-  local off = text:match("%[offset%s*:%s*(-?%d+%.?%d*)%]")
-  if off then fileOffsetMs = tonumber(off) or 0 end
-  local extraOffset = (fileOffsetMs + (offsetMs or 0)) / 1000.0
-
-  for line in (text .. "\n"):gmatch("([^\r\n]*)\r?\n") do
-    local timestamps = {}
-    local rest = line
-    -- consume every leading [mm:ss(.ttt)] timestamp tag (also accepts : or - ms separators)
-    while true do
-      local min, sec, epos
-      local sep, frac
-      -- with fractional part
-      min, sec, sep, frac, epos = rest:match("^%s*%[(%d+):(%d%d?)([%.:%-])(%d+)%]()")
-      if not min then
-        -- plain [mm:ss]
-        min, sec, epos = rest:match("^%s*%[(%d+):(%d%d?)%]()")
-        sep, frac = nil, nil
-      end
-      if not min then break end
-      local ts = tonumber(min) * 60 + tonumber(sec) + fractionalSeconds(frac)
-      timestamps[#timestamps + 1] = ts + extraOffset
-      rest = rest:sub(epos)
-    end
-
-    local lyricText = trim(rest)
-    if #timestamps > 0 then
-      if lyricText ~= "" then
-        for _, t in ipairs(timestamps) do
-          result[#result + 1] = { time = t, text = lyricText }
-        end
-      end
-    else
-      local trimmedLine = trim(line)
-      if not (lyricText == "" or isMetadataLine(trimmedLine) or looksLikeMalformedTimestamp(trimmedLine)) then
-        result[#result + 1] = { time = -1.0, text = lyricText }
-      end
-    end
-  end
-
-  -- stable sort: synced lines first (by time), unsynced after, preserving order
-  local function keyed(t)
-    for i, v in ipairs(result) do
-      if v == t then return i end
-    end
-    return 0
-  end
-  table.sort(result, function(a, b)
-    local at, bt = a.time >= 0, b.time >= 0
-    if at ~= bt then return at end
-    if at and bt then
-      if a.time ~= b.time then return a.time < b.time end
-      return keyed(a) < keyed(b) -- stability
-    end
-    return false
-  end)
-  return result
-end
+-- Implementations live in lyrics_lib.luau (require'd above) so they can be
+-- unit-tested without the host; these are thin re-exports for call sites that
+-- reference the old local names.
+local fractionalSeconds = lyrics_lib.fractionalSeconds
+local isMetadataLine = lyrics_lib.isMetadataLine
+local looksLikeMalformedTimestamp = lyrics_lib.looksLikeMalformedTimestamp
+local parseLrc = lyrics_lib.parseLrc
 
 local function indexForTime(lyrics, positionSeconds)
   if not snapshot.synced or positionSeconds == nil or positionSeconds < 0 then return -1 end
@@ -170,7 +122,7 @@ end
 -- ============================= cache / local lyrics =============================
 
 local function sanitizePart(s)
-  return trim((s or ""):gsub('[%c/\\]', "_"))
+  return lyrics_lib.sanitizePart(s)
 end
 
 local function cachePath(artist, title)
@@ -273,25 +225,8 @@ end
 -- (e.g. "[00:00.000] 纯音乐，请欣赏" = "instrumental music, enjoy", or
 -- "暂无歌词" = "no lyrics yet"). Those are NOT lyrics: treat the text as
 -- empty so the chain keeps hunting / ends with a clean "no lyrics".
-local NETEASE_PLACEHOLDERS = { "纯音乐请欣赏", "纯音乐版", "暂无歌词",
-  "此歌曲为没有填词的纯音乐", "此歌曲为纯音乐请欣赏", "纯音乐" }
-local function isPlaceholderLyrics(raw)
-  -- Byte-safe sanitize: multibyte chars must NOT live inside a Lua character
-  -- class together with ASCII punctuation — it corrupts UTF-8 bytes. Strip
-  -- timestamps + ASCII punctuation first, then full-width chars literally.
-  local cleaned = (raw or ""):gsub("%[%d+:%d+%.?%d*%]", "")
-  cleaned = cleaned:gsub("[%s,.!?]", "")
-  cleaned = cleaned:gsub("，", ""):gsub("。", ""):gsub("．", "")
-  cleaned = cleaned:gsub("！", ""):gsub("？", "")
-  if cleaned == "" then return false end
-  for _, p in ipairs(NETEASE_PLACEHOLDERS) do
-    if cleaned == p then return true end
-  end
-  -- variant lines appended after the phrase (e.g. "...请欣赏，谢谢");
-  -- compare CHARACTER length (utf8), not bytes
-  local clen = utf8.len(cleaned) or #cleaned
-  return clen <= 16 and cleaned:find("纯音乐", 1, true) ~= nil
-end
+-- Implementation in lyrics_lib.luau (unit-tested).
+local isPlaceholderLyrics = lyrics_lib.isPlaceholderLyrics
 
 -- chain: local dir -> embedded (xesam:asText) -> cache -> LRCLIB exact ->
 -- LRCLIB search -> NetEase fallback
@@ -367,84 +302,18 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key, embedd
 
   -- ── NetEase Cloud Music fallback (last resort, no auth) ──────────────────
   -- NetEase LRCs open with metadata credit lines (作词/作曲/编曲/Artist: …)
-  -- that would render as lyric rows; drop them before parsing.
-  local NETEASE_META = {
-    "^%s*作词%s*[:：]", "^%s*作曲%s*[:：]", "^%s*编曲%s*[:：]",
-    "^%s*制作人%s*[:：]", "^%s*混音%s*[:：]", "^%s*母带%s*[:：]",
-    "^%s*录音%s*[:：]", "^%s*监制%s*[:：]", "^%s*和声%s*[:：]",
-    "^%s*出品%s*[:：]", "^%s*发行%s*[:：]", "^%s*企划%s*[:：]",
-    "^%s*统筹%s*[:：]", "^%s*OP%s*[:：]", "^%s*SP%s*[:：]",
-    "^%s*Artist%s*[:：]", "^%s*Album%s*[:：]", "^%s*Producer%s*[:：]",
-    "^%s*Composer%s*[:：]", "^%s*Lyricist%s*[:：]",
-  }
-  local function stripNetEaseMeta(raw)
-    local out = {}
-    for line in (raw .. "\n"):gmatch("(.-)\n") do
-      local text = trim(line)
-      if text ~= "" then
-        local body = text:gsub("^%[%d+:%d+%.?%d*%]%s*", "")
-        local isMeta = false
-        for _, p in ipairs(NETEASE_META) do
-          if body:match(p) then isMeta = true break end
-        end
-        if not isMeta then out[#out + 1] = text end
-      end
-    end
-    return table.concat(out, "\n")
-  end
-
-  local function ciEq(a, b)
-    return trim(a or ""):lower() == trim(b or ""):lower()
-  end
-  local function ciHas(hay, needle)
-    return trim(hay or ""):lower():find(trim(needle or ""):lower(), 1, true) ~= nil
-  end
+  -- that would render as lyric rows; drop them before parsing. The list and
+  -- strip live in lyrics_lib.luau (unit-tested).
+  local stripNetEaseMeta = lyrics_lib.stripNetEaseMeta
 
   -- Rank cloudsearch hits: exact/contains matches on title (3/1) and artist
   -- (2/1), plus a duration bonus (2/1) when cloudsearch `dt` (ms) matches the
   -- playing track's length — the timed version of a song is the one whose
-  -- timestamps line up. Returns score>0 candidates sorted desc {id, score}.
-  local function rankNetEaseSongs(songs, artist, title, durSec)
-    local ranked = {}
-    for _, s in ipairs(songs) do
-      local sname = trim(s.name or "")
-      local artists = ""
-      local arr = type(s.ar) == "table" and s.ar or type(s.artists) == "table" and s.artists or nil
-      if arr then
-        local names = {}
-        for _, a in ipairs(arr) do names[#names + 1] = a.name or "" end
-        artists = table.concat(names, ", ")
-      end
-      -- Eligibility: when we know the artist, the candidate MUST overlap on
-      -- the artist too — a title-only hit for "DNA" happily returns some
-      -- Chinese song with the same name (wrong-language lyrics, 2026-09-03).
-      -- An empty metadata artist (dirty sources) keeps title-based matching.
-      local artistKnown = trim(artist or "") ~= ""
-      local titleOk = ciEq(sname, title) or ciHas(sname, title)
-      local artistOk = (not artistKnown) or ciEq(artists, artist) or ciHas(artists, artist)
-      if titleOk and artistOk then
-        local score = 0
-      if ciEq(sname, title) then score = score + 3 end
-      if ciHas(sname, title) then score = score + 1 end
-      if ciEq(artists, artist) then score = score + 2 end
-      if ciHas(artists, artist) then score = score + 1 end
-      if type(s.dt) == "number" and durSec and durSec > 0 then
-        local d = math.abs(s.dt / 1000 - durSec)
-        if d < 2 then score = score + 2
-        elseif d < 6 then score = score + 1 end
-      end
-        if score > 0 and type(s.id) == "number" then
-          ranked[#ranked + 1] = { id = s.id, score = score }
-        end
-      end
-    end
-    table.sort(ranked, function(a, b) return a.score > b.score end)
-    return ranked
-  end
+  -- timestamps line up. Lives in lyrics_lib.luau (unit-tested).
+  local rankNetEaseSongs = lyrics_lib.rankNetEaseSongs
 
-  -- True when the text carries [mm:ss.xx] timestamps (karaoke-capable).
   local function lrcIsSynced(text)
-    return text:match("%[%d+:%d+%.?%d*%]") ~= nil
+    return lyrics_lib.lrcIsSynced(text)
   end
 
   -- Accept a candidate and cache it on success. Returns success.
@@ -605,29 +474,58 @@ local function loadLyricsForTrack(artist, title, album, durationSec, key, embedd
       if resp2.ok and resp2.status == 200 and type(resp2.body) == "string" then
         local list = noctalia.json.decode(resp2.body)
         if type(list) == "table" and #list > 0 then
+          -- Score every candidate; keep the top-scoring ones. If exactly one
+          -- wins, accept it directly. If several tie, surface them in the
+          -- snapshot so the panel can offer a "choose lyrics" selector.
           local best, bestScore = nil, -1
+          local ties = {}
           for _, cand in ipairs(list) do
             local score = 0
             if trim(cand.artistName or "") == artist then score = score + 2 end
             if trim(cand.trackName or "") == title then score = score + 2 end
             if trim(cand.syncedLyrics or "") ~= "" then score = score + 1 end
-            if score > bestScore then best, bestScore = cand, score end
+            if score > bestScore then best, bestScore, ties = cand, score, { cand }
+            elseif score == bestScore then ties[#ties + 1] = cand end
           end
           if best then
-            local synced = trim(best.syncedLyrics or "")
-            local plain = trim(best.plainLyrics or "")
-            if synced ~= "" then
-              if not acceptAndCache("LRCLIB", synced, plain) then
-                -- parsed but unusable (instrumental): try NetEase
-                fetchNetEaseFallback(artist, title, key, plain ~= "" and
-                  { provider = "LRCLIB", synced = "", plain = plain } or nil)
+            if #ties == 1 or bestScore == 0 then
+              -- Single winner, or NO candidate matched artist/title (score 0):
+              -- accept the single best directly. A score-0 tie would otherwise
+              -- dump the whole search list into the selector and blow the
+              -- panel's CPU budget rendering hundreds of buttons.
+              local synced = trim(best.syncedLyrics or "")
+              local plain = trim(best.plainLyrics or "")
+              if synced ~= "" then
+                if not acceptAndCache("LRCLIB", synced, plain) then
+                  fetchNetEaseFallback(artist, title, key, plain ~= "" and
+                    { provider = "LRCLIB", synced = "", plain = plain } or nil)
+                end
+              elseif plain ~= "" then
+                fetchNetEaseFallback(artist, title, key,
+                  { provider = "LRCLIB", synced = "", plain = plain })
+              else
+                fetchNetEaseFallback(artist, title, key)
               end
-            elseif plain ~= "" then
-              -- plain-only LRCLIB hit: prefer a synced NetEase copy
-              fetchNetEaseFallback(artist, title, key,
-                { provider = "LRCLIB", synced = "", plain = plain })
             else
-              fetchNetEaseFallback(artist, title, key)
+              -- Multiple top candidates: offer a manual choice. Cap the list
+              -- at 8 so the selector stays cheap to render.
+              local cands = {}
+              local cap = math.min(#ties, 8)
+              for i = 1, cap do
+                local c = ties[i]
+                cands[#cands + 1] = {
+                  title = c.trackName or "",
+                  artist = c.artistName or "",
+                  album = c.albumName or "",
+                  duration = c.duration or 0,
+                  synced = trim(c.syncedLyrics or ""),
+                  plain = trim(c.plainLyrics or ""),
+                }
+              end
+              snapshot.lyricsCandidates = cands
+              snapshot.lyricsStatus = "choose"
+              snapshot.lyricsProvider = "LRCLIB"
+              publish()
             end
             return
           end
@@ -647,12 +545,115 @@ local function invalidateLyrics()
   snapshot.lyricsProvider = ""
   snapshot.synced = false
   snapshot.lyricsError = ""
+  -- variant picker state is per-track: drop the list and the active marker.
+  snapshot.lyricsCandidates = {}
+  snapshot.lyricsVariantIndex = 0
+end
+
+-- ===================== lyric variant picker (on the fly) =====================
+
+-- Candidate list for the "lyrics variants" selector, kept in the snapshot so
+-- the user can re-open the list and switch again WITHOUT re-running the fetch
+-- chain. The currently playing lyrics are never touched by opening the list;
+-- lyricsVariantIndex (0 = the automatic chain, N = picked candidate) marks the
+-- active row so the panel can highlight it.
+function publishVariantList(cands)
+  snapshot.lyricsCandidates = cands
+  snapshot.lyricsStatus = "choose"
+  publish()
+end
+
+-- Build the selector list on demand: the automatic chain picks ONE source
+-- (local / embedded / cache / LRCLIB exact / NetEase) and stops, so the full
+-- LRCLIB search result is fetched only when the user opens the picker. The
+-- "Default" row (restore automatic chain) is rendered by the panel from
+-- lyricsProvider; here we only deliver real alternatives.
+local variantPickGeneration = 0
+
+function openLyricChoices()
+  -- Need an actual track to search for.
+  local artist, title = snapshot.artist, snapshot.title
+  if trim(title) == "" then return end
+
+  local pickGen = variantPickGeneration + 1
+  variantPickGeneration = pickGen
+
+  local searchUrl = "https://lrclib.net/api/search?track_name=" .. noctalia.string.urlEncode(title)
+    .. "&artist_name=" .. noctalia.string.urlEncode(artist)
+  noctalia.runAsync({ "curl", "-sSf", "-m", "8", "-4", "-H", "User-Agent: " .. LRCLIB_UA, searchUrl },
+    function(result)
+      if pickGen ~= variantPickGeneration then return end
+      local cands = {}
+      if result.exitCode == 0 and type(result.stdout) == "string" then
+        local list = noctalia.json.decode(result.stdout)
+        if type(list) == "table" then
+          local seen = {}
+          for _, c in ipairs(list) do
+            local synced = trim(c.syncedLyrics or "")
+            local plain = trim(c.plainLyrics or "")
+            if synced ~= "" or plain ~= "" then
+              -- dedupe identical texts (same lyrics re-listed per album)
+              local sig = (synced ~= "") and synced or ("P:" .. plain)
+              if not seen[sig] then
+                seen[sig] = true
+                cands[#cands + 1] = {
+                  title = c.trackName or "", artist = c.artistName or "",
+                  album = c.albumName or "", duration = c.duration or 0,
+                  synced = synced, plain = plain,
+                }
+              end
+            end
+          end
+        end
+      end
+      -- Cap the list so the selector stays cheap to render.
+      while #cands > 8 do cands[#cands] = nil end
+      publishVariantList(cands)
+    end)
+end
+
+-- Apply a picked variant WITHOUT clearing the list, so the user can switch
+-- again immediately. Index 0 = "Default" row: re-run the automatic chain
+-- (same as the reload button). NOTE: acceptAndCache is a closure inside
+-- loadLyricsForTrack and is NOT visible here — use file-level acceptLyrics
+-- + cacheLyrics with the current track key instead.
+function applyLyricVariant(idx)
+  if idx == 0 then
+    -- "Default": re-run the automatic chain for this track.
+    local key = snapshot.playerName .. "|" .. snapshot.title .. "|" .. snapshot.artist
+      .. "|" .. tostring(math.floor(snapshot.lengthSec * 1e6 + 0.5))
+    snapshot.lyricsVariantIndex = 0
+    loadLyricsForTrack(snapshot.artist, snapshot.title, snapshot.album, snapshot.lengthSec, key,
+      (embeddedCacheKey == key) and embeddedCache or "")
+    return
+  end
+  local cand = (snapshot.lyricsCandidates or {})[idx]
+  if not cand then return end
+  local synced, plain = trim(cand.synced or ""), trim(cand.plain or "")
+  if synced == "" and plain == "" then return end -- nothing to apply
+  -- Same key format as refreshPlayer (lengthUs integer), so the 150 ms poll
+  -- keeps treating this track as UNCHANGED and does not restart the chain.
+  local key = snapshot.playerName .. "|" .. snapshot.title .. "|" .. snapshot.artist
+    .. "|" .. tostring(math.floor(snapshot.lengthSec * 1e6 + 0.5))
+  local body, extra = synced, plain
+  if synced == "" then body, extra = plain, "" end
+  if acceptLyrics("LRCLIB", body, extra, key) then
+    snapshot.lyricsVariantIndex = idx
+    cacheLyrics(snapshot.artist, snapshot.title, body, extra)
+  end
+  -- keep snapshot.lyricsCandidates intact: the picker can be re-opened and
+  -- the user can switch to another variant at any time.
 end
 
 -- ============================= MPRIS via busctl =============================
 
 local GET_ACTIVE = { "busctl", "--user", "--json=short", "call", "dev.noctalia.Mpris",
   "/dev/noctalia/Mpris", "dev.noctalia.Mpris", "GetActivePlayer" }
+
+-- All players (aa{sv}): used to fall back to the next allowed player when the
+-- active one is filtered out by the allowlist/blocklist.
+local GET_PLAYERS = { "busctl", "--user", "--json=short", "call", "dev.noctalia.Mpris",
+  "/dev/noctalia/Mpris", "dev.noctalia.Mpris", "GetPlayers" }
 
 -- Some MPRIS players expose lyrics via xesam:asText in their own Metadata;
 -- the Noctalia aggregator does not forward that field, so ask the player bus
@@ -699,30 +700,13 @@ end
 
 local refreshInFlight = false
 
-local function refreshPlayer()
-  if refreshInFlight then return end
-  refreshInFlight = true
-  noctalia.runAsync(GET_ACTIVE, function(result)
-    refreshInFlight = false
-    if result.exitCode ~= 0 or trim(result.stdout or "") == "" then
-      clearPlayer()
-      return
-    end
-
-    -- busctl --json=short wraps the reply: { type = "ba{sv}", data = [ found, fields ] }
-    local payload = noctalia.json.decode(result.stdout)
-    local body = payload and payload.data
-    if type(body) ~= "table" or type(body[1]) ~= "boolean" then return end
-    if not body[1] or type(body[2]) ~= "table" then
-      clearPlayer()
-      return
-    end
-
-    local f = body[2]
+-- Apply a single player's fields to the snapshot and (on track change) load
+-- lyrics. Shared by the active-player path and the allowlist fallback.
+-- Declared BEFORE refreshPlayer so it is a visible upvalue there.
+local function applyPlayer(f)
     local title = parseBusctlVariant(f.title) or ""
     local artist = parseBusctlVariant(f.artists) or ""
     local album = parseBusctlVariant(f.album) or ""
-    -- art_url comes as file:// URI; ui.image expects a filesystem path
     local artUrl = parseBusctlVariant(f.art_url) or ""
     artUrl = artUrl:gsub("^file://", "")
     local playing = (parseBusctlVariant(f.playback_status) == "Playing")
@@ -730,6 +714,7 @@ local function refreshPlayer()
     local posUs = tonumber(parseBusctlVariant(f.position_us)) or 0
     local ident = parseBusctlVariant(f.identity) or parseBusctlVariant(f.bus_name) or ""
     local busName = parseBusctlVariant(f.bus_name) or ""
+
     local canSeek = parseBusctlVariant(f.can_seek) == true
     local canNext = parseBusctlVariant(f.can_go_next) == true
     local canPrev = parseBusctlVariant(f.can_go_previous) == true
@@ -771,6 +756,64 @@ local function refreshPlayer()
     else
       publish()
     end
+end
+
+local function refreshPlayer()
+  if refreshInFlight then return end
+  refreshInFlight = true
+  noctalia.runAsync(GET_ACTIVE, function(result)
+    refreshInFlight = false
+    if result.exitCode ~= 0 or trim(result.stdout or "") == "" then
+      clearPlayer()
+      return
+    end
+
+    -- busctl --json=short wraps the reply: { type = "ba{sv}", data = [ found, fields ] }
+    local payload = noctalia.json.decode(result.stdout)
+    local body = payload and payload.data
+    if type(body) ~= "table" or type(body[1]) ~= "boolean" then return end
+    if not body[1] or type(body[2]) ~= "table" then
+      clearPlayer()
+      return
+    end
+
+    local f = body[2]
+    local title = parseBusctlVariant(f.title) or ""
+    local artist = parseBusctlVariant(f.artists) or ""
+    local album = parseBusctlVariant(f.album) or ""
+    -- art_url comes as file:// URI; ui.image expects a filesystem path
+    local artUrl = parseBusctlVariant(f.art_url) or ""
+    artUrl = artUrl:gsub("^file://", "")
+    local playing = (parseBusctlVariant(f.playback_status) == "Playing")
+    local lengthUs = tonumber(parseBusctlVariant(f.length_us)) or 0
+    local posUs = tonumber(parseBusctlVariant(f.position_us)) or 0
+    local ident = parseBusctlVariant(f.identity) or parseBusctlVariant(f.bus_name) or ""
+    local busName = parseBusctlVariant(f.bus_name) or ""
+
+    -- Player allowlist/blocklist: if the active player is filtered out, fall
+    -- back to the first allowed player from the full list (e.g. Yandex is
+    -- blocked but zen is running). If none is allowed, show the empty state.
+    if not playerAllowed(ident, busName) then
+      noctalia.runAsync(GET_PLAYERS, function(res)
+        if res.exitCode ~= 0 then clearPlayer() return end
+        local pl = noctalia.json.decode(res.stdout or "")
+        -- GetPlayers returns aa{sv} wrapped as data = [ [player1, player2, ...] ]
+        local list = pl and pl.data and pl.data[1]
+        if type(list) ~= "table" then clearPlayer() return end
+        for _, p in ipairs(list) do
+          local pIdent = parseBusctlVariant(p.identity) or parseBusctlVariant(p.bus_name) or ""
+          local pBus = parseBusctlVariant(p.bus_name) or ""
+          if playerAllowed(pIdent, pBus) then
+            applyPlayer(p)
+            return
+          end
+        end
+        clearPlayer()
+      end)
+      return
+    end
+
+    applyPlayer(f)
   end)
 end
 
@@ -779,13 +822,40 @@ end
 local function busctlCall(method, argType, argValue)
   local argv = { "busctl", "--user", "call", "dev.noctalia.Mpris", "/dev/noctalia/Mpris",
     "dev.noctalia.Mpris", method }
+  local withResult = argType == nil and
+    (method == "NextActive" or method == "PreviousActive" or method == "PlayPauseActive")
   -- busctl requires the D-Bus signature for typed arguments ("Too few
   -- parameters for signature" otherwise); methods without args need none.
   if argType then
     argv[#argv + 1] = argType
     argv[#argv + 1] = tostring(argValue)
   end
-  noctalia.runAsync(argv)
+  local cb = nil
+  if withResult then
+    cb = function(result)
+      -- no-op: we refresh state after the call elsewhere; result is a boolean
+      -- handled flag we intentionally do not wire here
+    end
+  end
+  noctalia.runAsync(argv, cb)
+end
+
+-- Track navigation is a thin wrapper over the busctl command: the return value
+-- is a boolean the player reports (true = handled). MPRIS spec: Next()/Previous()
+-- are optional; some players (e.g. Spotify) reject them, so we update the
+-- snapshot's can_go_next/can_go_prev AFTER the call rather than trusting the
+-- initial metadata. This keeps the transport buttons honest across players and
+-- systems. (PlayPauseActive is nearly universal and rarely rejected; we refresh
+-- state afterward anyway.)
+local function navigate(direction)
+  local method = (direction == "prev") and "PreviousActive" or "NextActive"
+  busctlCall(method)
+  -- after a navigation the player's caps may have changed (e.g. reached the
+  -- start/end of a shuffled queue): refresh promptly so buttons re-enable.
+  local gen = fetchGeneration
+  noctalia.runAsync({ "sleep", "0.5" }, function()
+    if gen == fetchGeneration then refreshPlayer() end
+  end)
 end
 
 noctalia.state.watch("panel_cmd", function(value)
@@ -794,9 +864,9 @@ noctalia.state.watch("panel_cmd", function(value)
   if a == "toggle" then
     busctlCall("PlayPauseActive")
   elseif a == "next" then
-    busctlCall("NextActive")
+    navigate("next")
   elseif a == "prev" then
-    busctlCall("PreviousActive")
+    navigate("prev")
   elseif a == "shuffle" then
     busctlCall("SetShuffleActive", "b", tostring(not snapshot.shuffle))
   elseif a == "loop" then
@@ -828,6 +898,16 @@ noctalia.state.watch("panel_req", function(value)
       .. "|" .. tostring(math.floor(snapshot.lengthSec * 1e6 + 0.5))
     loadLyricsForTrack(snapshot.artist, snapshot.title, snapshot.album, snapshot.lengthSec, key,
       (embeddedCacheKey == key) and embeddedCache or "")
+  elseif value.action == "openLyricChoices" then
+    -- User opened the lyrics-variant picker: fetch LRCLIB search candidates
+    -- on demand and publish the list without touching the playing lyrics.
+    openLyricChoices()
+  elseif value.action == "chooseLyrics" then
+    -- User picked a variant from the "choose lyrics" selector. index 0 =
+    -- "Default" (restore the automatic chain); 1-based into
+    -- snapshot.lyricsCandidates otherwise. The list is kept so the picker
+    -- can be re-opened and the variant switched again at any time.
+    applyLyricVariant(tonumber(value.index) or 0)
   end
 end)
 

--- a/media-lyrics/shortcut.luau
+++ b/media-lyrics/shortcut.luau
@@ -3,6 +3,7 @@
 -- panel_size setting: compact / medium / large).
 local function panelIdForSize()
   local sz = noctalia.getConfig("panel_size")
+  if sz == "mini" then return "panel-mini" end
   if sz == "compact" then return "panel-compact" end
   if sz == "large" then return "panel-large" end
   return "panel"

--- a/media-lyrics/translations/en.json
+++ b/media-lyrics/translations/en.json
@@ -3,6 +3,14 @@
     "no-title": "(no title)",
     "unknown-artist": "Unknown artist"
   },
+  "provider": {
+    "local": "Local",
+    "cache": "Cache",
+    "embedded": "Embedded"
+  },
+  "service": {
+    "lyrics-unreachable": "Lyrics services unreachable (network error)"
+  },
   "panel": {
     "loading-lyrics": "Loading lyrics…",
     "lyrics-error": "Lyrics error: ",
@@ -10,83 +18,87 @@
     "no-media-player": "No media player",
     "now-playing": "NOW PLAYING",
     "reload-lyrics": "Reload lyrics",
+    "choose-lyrics": "Lyrics variants",
+    "variant-default": "Default",
+    "no-variants": "No alternative lyrics found",
     "synced": "synced",
     "unsynced": "unsynced"
   },
-  "provider": {
-    "cache": "Cache",
-    "embedded": "Embedded",
-    "local": "Local"
-  },
-  "service": {
-    "lyrics-unreachable": "LRCLIB unreachable (network error)"
-  },
   "settings": {
     "album_art_only": {
-      "description": "Show only the album artwork (no text).",
-      "label": "Album art only"
-    },
-    "art_size": {
-      "description": "Album artwork size in pixels.",
-      "label": "Art size"
-    },
-    "artist_first": {
-      "description": "Show \"Artist - Title\" instead of \"Title - Artist\".",
-      "label": "Artist first"
+      "label": "Album art only",
+      "description": "Show only the album artwork (no text)."
     },
     "hide_album_art": {
-      "description": "Hide the artwork and its fallback icon.",
-      "label": "Hide album art"
+      "label": "Hide album art",
+      "description": "Hide the artwork and its fallback icon."
     },
     "hide_artist": {
-      "description": "Show only the track title.",
-      "label": "Hide artist"
+      "label": "Hide artist",
+      "description": "Show only the track title."
     },
-    "hide_when_no_media": {
-      "description": "Hide the widget when no MPRIS player is active.",
-      "label": "Hide when no media"
+    "artist_first": {
+      "label": "Artist first",
+      "description": "Show \"Artist - Title\" instead of \"Title - Artist\"."
     },
-    "local_lyrics_dir": {
-      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB.",
-      "label": "Local lyrics folder"
+    "player_allowlist": {
+      "label": "Player allowlist",
+      "description": "Comma-separated player names (identity or bus name). When set, only matching players are shown. Empty = show any player."
     },
-    "max_length": {
-      "description": "Maximum widget length in pixels — the text area width (long titles scroll or truncate to fit it).",
-      "label": "Max length"
+    "player_blocklist": {
+      "label": "Player blocklist",
+      "description": "Comma-separated player names (identity or bus name) to hide. Empty = hide none."
     },
     "min_length": {
-      "description": "Minimum widget length in pixels.",
-      "label": "Min length"
+      "label": "Min length",
+      "description": "Minimum widget length in pixels."
     },
-    "offset_ms": {
-      "description": "Shift lyric timing: positive values show lines earlier, negative later.",
-      "label": "Lyrics offset (ms)"
+    "max_length": {
+      "label": "Max length",
+      "description": "Maximum widget length in pixels — the text area width (long titles scroll or truncate to fit it)."
     },
-    "panel_size": {
-      "description": "Size preset of the lyrics panel: compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
-      "label": "Panel size",
-      "options": {
-        "compact": "Compact (440)",
-        "large": "Large (640)",
-        "medium": "Medium (520)"
-      }
-    },
-    "show_lyric_line": {
-      "description": "Show the current synced lyric line in the chip instead of the artist (title stays).",
-      "label": "Show current lyric line"
+    "art_size": {
+      "label": "Art size",
+      "description": "Album artwork size in pixels."
     },
     "title_scroll": {
-      "description": "Scroll long titles that exceed the max length.",
       "label": "Title scroll",
+      "description": "Scroll long titles that exceed the max length.",
       "options": {
-        "always": "Always",
         "none": "None",
+        "always": "Always",
         "on_hover": "On hover"
       }
     },
+    "hide_when_no_media": {
+      "label": "Hide when no media",
+      "description": "Hide the widget when no MPRIS player is active."
+    },
+    "offset_ms": {
+      "label": "Lyrics offset (ms)",
+      "description": "Shift lyric timing: positive values show lines earlier, negative later."
+    },
+    "panel_size": {
+      "label": "Panel size",
+      "description": "Size preset of the lyrics panel: mini (360), compact (440), medium (520), large (640). The bar widget and control-center tile open this preset.",
+      "options": {
+        "mini": "Mini",
+        "compact": "Compact",
+        "medium": "Medium",
+        "large": "Large"
+      }
+    },
     "use_cache": {
-      "description": "Store fetched lyrics in the plugin data directory for offline reuse.",
-      "label": "Cache lyrics"
+      "label": "Cache lyrics",
+      "description": "Store fetched lyrics in the plugin data directory for offline reuse."
+    },
+    "local_lyrics_dir": {
+      "label": "Local lyrics folder",
+      "description": "Folder with local .lrc files named 'Artist - Title.lrc'; searched before LRCLIB."
+    },
+    "show_lyric_line": {
+      "label": "Show current lyric line",
+      "description": "Show the current synced lyric line in the chip instead of the artist (title stays)."
     }
   }
 }

--- a/media-lyrics/widget.luau
+++ b/media-lyrics/widget.luau
@@ -32,6 +32,7 @@ local SCROLL_TICKS = 2             -- advance one char every N update ticks
 -- Which panel preset to open (panel_size plugin setting).
 local function panelIdForSize()
   local sz = noctalia.getConfig("panel_size")
+  if sz == "mini" then return "panel-mini" end
   if sz == "compact" then return "panel-compact" end
   if sz == "large" then return "panel-large" end
   return "panel"
@@ -125,7 +126,11 @@ local function activeLyricLine(m)
   -- timestamp <= posSec. Falls back to the first line before the first
   -- timestamp (karaoke convention). posSec in the snapshot is ≤150 ms stale
   -- (service polls), fine for a subtitle.
-  if m == nil or m.lyricsStatus ~= "ready" or not m.synced then return nil end
+  -- lyricsStatus "choose" = the variant picker published a list; lyrics may
+  -- still be live (a picked variant or default kept), so accept it too.
+  if m == nil then return nil end
+  if m.lyricsStatus ~= "ready" and m.lyricsStatus ~= "choose" then return nil end
+  if not m.synced then return nil end
   local lines = m.lyrics
   if type(lines) ~= "table" or #lines == 0 then return nil end
   local pos = tonumber(m.posSec) or 0
@@ -308,9 +313,18 @@ local function renderFrom(m, force)
   local children = {}
   local icon = iconChild()
   if icon then children[#children + 1] = icon end
-  -- Wrap the label in a row owning onHover (ui.label takes no hover handler);
-  -- the row passes clicks through to the widget-level onClick.
-  children[#children + 1] = ui.row({
+
+  -- Text block: a single centered label. (A playback-progress bar was
+  -- considered here but dropped — see ROADMAP "show_progress in bar widget".)
+  local label = ui.label({
+    key = "title",
+    text = shown,
+    fontSize = FONT_PX,
+    opacity = dim,
+    maxLines = 1,
+  })
+
+  local textNode = ui.row({
     key = "textwrap",
     align = "center",
     onHover = function(state)
@@ -320,15 +334,8 @@ local function renderFrom(m, force)
         renderFrom(media(), true)
       end
     end,
-  }, {
-    ui.label({
-      key = "title",
-      text = shown,
-      fontSize = FONT_PX,
-      opacity = dim,
-      maxLines = 1,
-    }),
-  })
+  }, { label })
+  children[#children + 1] = textNode
 
   barWidget.render(ui.row({ gap = GAP, align = "center" }, children))
 end


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `tranzem/media-lyrics`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

A media player panel with time-synced lyrics (karaoke carousel, transport, marquee titles, LRCLIB + NetEase + embedded sources). Update **0.9.3 → 0.9.4**:

- **Lyrics variants picker (switch on the fly)** — the panel header "list" button is now always visible while a track plays (it previously appeared only in the rare case where LRCLIB search returned several equally-scored candidates, i.e. it vanished as soon as lyrics loaded normally). Clicking it fetches the full LRCLIB `/api/search` result on demand and lists alternative lyric versions: picking one switches instantly without interrupting the playing lyrics; a **Default** row restores the automatic chain; the candidate list is kept per track so variants can be switched again at any time.
- **New `panel-mini` panel preset** — a 360×120 always-on surface (cover + current lyric line) intended for pinning to the desktop (`dismiss_on_outside_click = false`); the `panel_size` setting gains a `mini` option and opens it from the bar widget / control-center tile.
- **Player allowlist/blocklist settings** — comma-separated identity/bus-name substrings to filter which MPRIS players the plugin follows (e.g. ignore a browser's MPRIS).
- **Marquee stable-key fix (#649)** — long titles/artists no longer recreate the text node every frame (per-frame surface re-blur caused visible text blink under compositor blur on some GPUs).
- Lyric-row hover highlight, cover fallback disc glyph, pure-Luau logic extracted to `lyrics_lib.luau` with 22 host-independent unit tests.
- Fix: the `chooseLyrics` request handler called `acceptAndCache`, a closure private to `loadLyricsForTrack` (nil at module scope) — applying a picked candidate errored; it now uses the file-level accept/cache path.

The canonical repository also declares `layer = "overlay"` on the panel entries (0.9.3+); this store copy keeps omitting the field until the validator supports it (unchanged from the merged 0.9.3 update).

## External dependencies

- `busctl` — MPRIS polling and transport commands via Noctalia's D-Bus aggregator (unchanged).
- `curl` — HTTPS lyric fetches: LRCLIB (`https://lrclib.net`) primary, NetEase fallback (`https://music.163.com`); the variants picker adds LRCLIB `/api/search` calls, same host as the existing search fallback (unchanged).
- `sleep` (coreutils) — short refresh delay after transport commands (unchanged).

Both are declared in `dependencies` in plugin.toml. Nothing new in 0.9.4.

## Testing

Tested on my own setup (Arch Linux, Niri 26.04, Noctalia 5.0.1):

- `plugin.toml` passes `validate-plugins.py` locally; all Luau entries pass `luac -p`; `tests/run_lib_tests.lua` 22/22 pass.
- Live host: plugin disable/enable clean (no log errors, no "ui tree node is not a table"), all panel presets open.
- Variants picker live: with a playing Firefox/MPRIS track the header button opens the selector, LRCLIB search returns candidates (live HTTP 200), picking a variant applies it, "Default" restores the chain, the picker can be re-opened and switched repeatedly; track change resets it.
- Unit tests for the extracted lyric logic (LRC parsing, placeholders, NetEase ranking) run with plain `lua5.4`, no host needed.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.1
- **Plugin API level:** 30

## Screenshots / Videos

Visual layout is unchanged from 0.9.3 (same panel chrome; the variants list reuses the existing lyrics body area, the mini preset is a small cover+line surface). Screenshots in the repo (`media-lyrics/screenshots/`) still reflect the current UI.

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.