### PR TITLE
fix(screen-toolkit): pass logical geometry to recording backends

### DIFF
--- a/screen-toolkit/plugin.toml
+++ b/screen-toolkit/plugin.toml
@@ -8,7 +8,7 @@
 
 id = "alexander/screen-toolkit"
 name = "Screen Toolkit"
-version = "1.4.0"
+version = "1.4.1"
 plugin_api = 13
 author = "alexander"
 license = "MIT"

--- a/screen-toolkit/service.luau
+++ b/screen-toolkit/service.luau
@@ -88,31 +88,28 @@ local function publish(key, value)
   noctalia.state.set(key, value)
 end
 
--- `noctalia.outputs()` reports logical geometry + a scale; grim wants physical
--- pixels, so multiply every axis by the output scale.
+-- `noctalia.outputs()` reports logical geometry; grim, gpu-screen-recorder, wl_screenrec and wf-recorder want logical geometry. Except for gpu-screen-recorder, they all take geometry as formated by this function.
 local function focusedGeometry()
   local outputs = noctalia.outputs()
   for _, o in ipairs(outputs) do
     if o.focused then
-      local scale = o.scale or 1
       return string.format(
         "%d,%d %dx%d",
-        math.floor(o.x * scale),
-        math.floor(o.y * scale),
-        math.round(o.width * scale),
-        math.round(o.height * scale)
+        o.x,
+        o.y,
+        o.width,
+        o.height
       )
     end
   end
   if outputs and #outputs > 0 then
     local o = outputs[1]
-    local scale = o.scale or 1
     return string.format(
       "%d,%d %dx%d",
-      math.floor(o.x * scale),
-      math.floor(o.y * scale),
-      math.round(o.width * scale),
-      math.round(o.height * scale)
+      o.x,
+      o.y,
+      o.width,
+      o.height
     )
   end
   return nil


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `alexander/screen-toolkit`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Fixes full screen recording on displays with scaling (#688).
The plugin previously passed physical geometry to the recording backend, but all of them expect logical geometry.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
Nothing new

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
I starting a recording using the "Rec FS" button while only one of each backend (gpu-screen-recorder, wl-screenrec, wf-recorder) is installed and with a video with audio running. I ended the recording using `noctalia msg plugin alexander/screen-toolkit:service all recordStop` and saved it. I then checked whether the full screen and audio was recorded.
This worked for gpu-screen-recorder and wl-screenrec. For wf-recorder, the command was partially fixed, but another potential bug still prevents recording with audio (already didn't work before).
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.0.0
- **Plugin API level:** 13 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
