### PR TITLE
feat(special-workspaces): add callback to toggle special workspaces

### DIFF
--- a/special-workspaces/README.md
+++ b/special-workspaces/README.md
@@ -21,9 +21,10 @@ chips in the Noctalia bar.
 Enable `jamesfeeder/special-workspaces` in **Settings → Plugins**, then add
 **Special Workspaces** to the bar from **Settings → Bar**.
 
-The widget shows special workspaces in alphabetical order. Active workspaces
-remain visible when empty. Inactive workspaces appear only while populated and
-can be hidden with `hide_inactive`.
+The widget shows special workspaces in alphabetical order.
+Click on a workspace capsule to toggle the workspace.
+Active workspaces remain visible when empty.
+Inactive workspaces appear only while populated and can be hidden with `hide_inactive`.
 
 ## Settings
 

--- a/special-workspaces/plugin.toml
+++ b/special-workspaces/plugin.toml
@@ -1,6 +1,6 @@
 id = "jamesfeeder/special-workspaces"
 name = "Special Workspaces"
-version = "1.5.0"
+version = "1.6.0"
 plugin_api = 3
 author = "jamesfeeder"
 license = "MIT"

--- a/special-workspaces/widget.luau
+++ b/special-workspaces/widget.luau
@@ -37,6 +37,18 @@ local function verticalName(name)
   return table.concat(characters, "\n")
 end
 
+local function toggleWorkspace(workspaceName)
+  noctalia.log("Toggling special:" .. workspaceName .. " workspace.")
+  local command = "hyprctl dispatch 'hl.dsp.workspace.toggle_special(\""
+  .. workspaceName .. "\")'"
+  noctalia.runAsync(command, function(result) 
+    if result.exitCode ~= 0 then
+      noctalia.log("hyprctl failed while toggling special:" .. workspaceName
+      .. " with error:\n" .. result.stderr)
+    end
+  end)
+end
+
 local function render(vertical)
   renderedVertical = vertical
   local container = vertical and ui.column or ui.row
@@ -60,6 +72,7 @@ local function render(vertical)
         justify = "center",
         fill = fill,
         radius = capsuleRadius,
+        onClick = function() toggleWorkspace(name) end
       }
       if vertical then
         capsuleProps.width = PILL_HEIGHT
@@ -70,7 +83,6 @@ local function render(vertical)
         capsuleProps.minWidth = capsuleMinWidth
         capsuleProps.paddingH = capsulePadding
       end
-
       local label = displayName(name)
       table.insert(chips, capsule(capsuleProps, {
         ui.label({


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `jamesfeeder/special-workspaces`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

<!-- A short description, and what a user gets out of it. -->
Added a callback to special workspace capsules in bar, to toggle the workspaces.

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->
The new feature calls `hyprctl dispatch 'hl.dsp.workspace.toggle_special(special_name)'` ([docs](https://wiki.hypr.land/0.56.0/Configuring/Basics/Dispatchers/#workspace-1)) using the _lua_ syntax to toggle the workspace upon user request. Hyprland 0.55.0 or newer required.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->
Testing opening several special workspaces and toggling them.

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** noctalia v5.0.0 (5.0.0_beta.10-1-dirty)
- **Plugin API level:** 3

## Screenshots / Videos

<!-- Show the plugin running. Required for anything with a visual surface. -->

> [!NOTE]
> Screen was cropped for privacy reasons 

https://github.com/user-attachments/assets/3085fb33-9a2e-42b2-bd56-540b099026c5


## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
