### PR TITLE
feat(web-search): Add configurable search provider

### DIFF
--- a/web-search/README.md
+++ b/web-search/README.md
@@ -1,6 +1,6 @@
 # Web Search
 
-Open a configurable set of websites or search Google directly from the Noctalia launcher. Frequently opened configured sites are promoted automatically.
+Open a configurable set of websites or search the web directly from the Noctalia launcher. Frequently opened configured sites are promoted automatically.
 
 ## Plugin
 
@@ -14,12 +14,11 @@ Open a configurable set of websites or search Google directly from the Noctalia 
 
 Install these commands on `PATH`:
 
-- `python3` — URL-encodes Google search queries.
 - `xdg-open` — opens selected websites and searches in the system's default browser.
 
 ## Usage
 
-Open the Noctalia launcher and type `/web` to browse the configured websites. Type text after `/web` to filter those sites and add a **Search Google** result. Activating a website opens its configured URL in the default browser; activating **Search Google** opens a Google search for the entered text.
+Open the Noctalia launcher and type `/web` to browse the configured websites. Type text after `/web` to filter those sites and add a **Search `<Provider>`** result. Activating a website opens its configured URL in the default browser; activating the search result opens a search for the entered text using the configured **Search provider**.
 
 Configured sites are ordered by most recent activation. Sites that have never been opened retain the order in **Websites** settings.
 
@@ -27,10 +26,11 @@ Configured sites are ordered by most recent activation. Sites that have never be
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
+| `provider` | `select` | `google` | Search engine used for the Search result: `google`, `duckduckgo`, `ecosia`, `bing`, `brave`, or `mojeek`. |
 | `links` | `string_list` | `GitHub|https://github.com`, `GitLab|https://gitlab.com`, `Codeberg|https://codeberg.org`, `Reddit|https://reddit.com`, `YouTube|https://youtube.com`, `Gmail|https://mail.google.com` | Websites displayed by `/web`. Each entry must be `Name|https://example.com`; entries without a non-empty name or an `http://`/`https://` URL are ignored. |
 
 ## Notes
 
-- The plugin fetches missing 64px favicons over HTTPS from `https://www.google.com/s2/favicons` for every valid configured website domain whenever launcher results refresh, even if that site does not match the current filter; it also fetches `www.google.com` when a non-empty search is entered. Favicon PNGs are cached in the plugin's `cache/` directory and are reused while present.
+- The plugin fetches missing 64px favicons over HTTPS from `https://www.google.com/s2/favicons` for every valid configured website domain whenever launcher results refresh, even if that site does not match the current filter; it also fetches the configured search provider's favicon domain when a non-empty search is entered. Favicon PNGs are cached in the plugin's `cache/` directory and are reused while present.
 - Each activated configured website updates `cache/mru.txt`. It is a local last-use ledger containing one `used <sequence>|<url>` line for each opened configured URL; higher sequence numbers are more recent.
-- Website activation asynchronously runs `xdg-open '<configured URL>' >/dev/null 2>&1`. Google search activation asynchronously runs `python3` to percent-encode the entered query, then opens the resulting `https://www.google.com/search?q=...` URL with `xdg-open`; both command outputs are discarded.
+- Website activation asynchronously runs `xdg-open '<configured URL>' >/dev/null 2>&1`. Search activation percent-encodes the entered query and opens it with the configured provider's search URL (`https://www.google.com/search?q=...`, `https://duckduckgo.com/?q=...`, `https://www.ecosia.org/search?q=...`, `https://www.bing.com/search?q=...`, `https://search.brave.com/search?q=...`, or `https://www.mojeek.com/search?q=...`) via `xdg-open`; command output is discarded.

--- a/web-search/launcher.luau
+++ b/web-search/launcher.luau
@@ -1,5 +1,22 @@
 --!nonstrict
 
+local PROVIDERS = {
+    google = { label = "Google", domain = "www.google.com", searchUrl = "https://www.google.com/search?q=%s" },
+    duckduckgo = { label = "DuckDuckGo", domain = "duckduckgo.com", searchUrl = "https://duckduckgo.com/?q=%s" },
+    ecosia = { label = "Ecosia", domain = "www.ecosia.org", searchUrl = "https://www.ecosia.org/search?q=%s" },
+    bing = { label = "Bing", domain = "www.bing.com", searchUrl = "https://www.bing.com/search?q=%s" },
+    brave = { label = "Brave", domain = "search.brave.com", searchUrl = "https://search.brave.com/search?q=%s" },
+    mojeek = { label = "Mojeek", domain = "www.mojeek.com", searchUrl = "https://www.mojeek.com/search?q=%s" },
+}
+
+local function currentProvider()
+    local id = noctalia.getConfig("provider")
+    if type(id) ~= "string" or PROVIDERS[id] == nil then
+        id = "google"
+    end
+    return PROVIDERS[id]
+end
+
 local function trim(value)
     return (value:gsub("^%s+", ""):gsub("%s+$", ""))
 end
@@ -145,10 +162,11 @@ local function makeResults(query)
 
     local results = websiteResults(text, query, refresh)
     if text ~= "" then
-        local icon = loadIcon("www.google.com", query, refresh)
+        local provider = currentProvider()
+        local icon = loadIcon(provider.domain, query, refresh)
         table.insert(results, 1, {
             id = "search:" .. text,
-            title = "Search Google",
+            title = "Search " .. provider.label,
             subtitle = text,
             glyph = icon and nil or "world-search",
             icon = icon,
@@ -174,8 +192,7 @@ function onActivate(id)
     if query == nil or query == "" then
         return
     end
-    local command = "xdg-open \"$(python3 -c 'import sys, urllib.parse; print(\"https://www.google.com/search?q=\" + urllib.parse.quote_plus(sys.argv[1]))' "
-        .. shellQuote(query)
-        .. ")\" >/dev/null 2>&1"
-    noctalia.runAsync(command)
+    local provider = currentProvider()
+    local url = provider.searchUrl:format(noctalia.string.urlEncode(query))
+    noctalia.runAsync("xdg-open " .. shellQuote(url) .. " >/dev/null 2>&1")
 end

--- a/web-search/plugin.toml
+++ b/web-search/plugin.toml
@@ -1,13 +1,13 @@
 id = "notfinaldev/web-search"
 name = "Web Search"
-version = "1.3.0"
+version = "1.4.0"
 plugin_api = 18
 author = "notfinaldev"
 license = "MIT"
 icon = "world"
-description = "Open favourite websites or search Google from the Noctalia launcher."
+description = "Open favourite websites or search the web from the Noctalia launcher."
 tags = ["launcher", "network", "utility"]
-dependencies = ["python3", "xdg-open"]
+dependencies = ["xdg-open"]
 
 [[launcher_provider]]
 id = "search"
@@ -16,6 +16,21 @@ prefix = "web"
 glyph = "world-search"
 include_in_global_search = true
 
+
+[[setting]]
+key = "provider"
+type = "select"
+label_key = "settings.provider.label"
+description_key = "settings.provider.description"
+default = "google"
+options = [
+    { value = "google", label_key = "settings.provider.options.google" },
+    { value = "duckduckgo", label_key = "settings.provider.options.duckduckgo" },
+    { value = "ecosia", label_key = "settings.provider.options.ecosia" },
+    { value = "bing", label_key = "settings.provider.options.bing" },
+    { value = "brave", label_key = "settings.provider.options.brave" },
+    { value = "mojeek", label_key = "settings.provider.options.mojeek" },
+]
 
 [[setting]]
 key = "links"

--- a/web-search/translations/en.json
+++ b/web-search/translations/en.json
@@ -1,5 +1,17 @@
 {
   "settings": {
+    "provider": {
+      "description": "Search engine used for the Search result and by activating it.",
+      "label": "Search provider",
+      "options": {
+        "google": "Google",
+        "duckduckgo": "DuckDuckGo",
+        "ecosia": "Ecosia",
+        "bing": "Bing",
+        "brave": "Brave",
+        "mojeek": "Mojeek"
+      }
+    },
     "links": {
       "description": "Websites shown by /web, formatted as Name|https://example.com.",
       "label": "Websites"

--- a/web-search/translations/en.json
+++ b/web-search/translations/en.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "provider": {
-      "description": "Search engine used for the Search result and by activating it.",
+      "description": "Search engine used for the Search result when activated.",
       "label": "Search provider",
       "options": {
         "google": "Google",


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->
<!-- ^ Keep the marker line above this comment.

     A bot checks this description and converts an invalid ready pull request back to
     Draft. It never closes the pull request.

     Draft pull requests may leave checkboxes incomplete. Before marking a pull request
     ready for review:
     - check exactly one plugin type;
     - check at least one compositor under Testing; and
     - check every item under Checklist and Code review attestation.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft.

     Everything else, including every one of these guidance comments, is yours to delete. -->

## Plugin

<!-- The canonical id. The part after the "/" is the plugin's directory in this repo. -->

- **Id:** `notfinaldev/web-search`
<!-- Check exactly one plugin type. -->
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds configurable provider to the Web Search plugin with support for google (previous default), duckduckgo, ecosia, bing, brave, mojeek.

<!-- A short description, and what a user gets out of it. -->

## External dependencies

<!-- Any command or service the plugin shells out to, and why. List them in `dependencies` in plugin.toml too.
     Write "None" if it is self-contained. -->

The plugin still relies on `xdg-open`. However this PR removes the Python dependency in favor of using`noctalia.string.urlEncode`.

## Testing

<!-- How you exercised it: entries opened, IPC messages sent, settings toggled. -->
<!-- Check every compositor on which you actually tested the plugin. At least one is required before review. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.1.0-1-dirty)
- **Plugin API level:** 18 <!-- must match plugin_api in plugin.toml -->

## Screenshots / Videos

<img width="1631" height="651" alt="image" src="https://github.com/user-attachments/assets/7671df86-8529-495d-ad36-ab02b458dbdc" />

<!-- Show the plugin running. Required for anything with a visual surface. -->

## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.
