### PR TITLE
fix(phone-operate): prevent panel crash with ADB devices

### DIFF
--- a/phone-operate/panel.luau
+++ b/phone-operate/panel.luau
@@ -103,7 +103,11 @@ local function deviceSidebar(visibleOrder, devices, sel)
 	local paired, available = {}, {}
 	for _, id in ipairs(visibleOrder) do
 		local d = devices[id]
-		if d then table.insert(d.source == "adb" or d.isPaired == true and paired or available, id) end
+		if d then
+			local target = paired
+			if d.source ~= "adb" and d.isPaired ~= true then target = available end
+			table.insert(target, id)
+		end
 	end
 
 	local items = {}

--- a/phone-operate/plugin.toml
+++ b/phone-operate/plugin.toml
@@ -1,6 +1,6 @@
 id = "icefish/phone-operate"
 name = "Phone Operate"
-version = "1.0.0"
+version = "1.0.1"
 plugin_api = 22
 author = "icefish"
 license = "MIT"


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `icefish/phone-operate`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Fixes the Phone Operate panel crashing when an authorized ADB device is present.

The previous device-grouping expression returned the boolean `true` for ADB devices because of Lua operator precedence, then passed that boolean to `table.insert`. The new code selects the destination table explicitly: ADB and paired KDE Connect devices go into `paired`, while unpaired KDE Connect devices go into `available`.

Fixes #706.

## External dependencies

This fix adds no dependencies and does not introduce new commands, network access, filesystem writes, or processes.

The existing plugin uses:

- `adb` from `android-tools` for device discovery, USB/Wi-Fi connection, pairing, and disconnection.
- `scrcpy` for Android screen mirroring, control, and optional recording.
- `kdeconnectd`, `kdeconnect-cli`, and `gdbus` for KDE Connect discovery and device actions.
- `sshfs` and `xdg-open` for browsing device files.
- `pgrep` and `pkill` to inspect and stop plugin-launched `scrcpy` processes.

## Testing

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- **Noctalia version tested against:** 5.1.0
- **Plugin API level:** 22

Test procedure:

1. Connected and authorized an Android device over USB; `adb devices -l` reported it as `device`.
2. Confirmed version 1.0.0 failed when opening `icefish/phone-operate:main` with `table.insert` receiving a boolean, after which Noctalia disabled the panel.
3. Loaded the patched plugin from a local path source and opened the same panel with the same device connected.
4. Left the panel open across repeated device-state polling cycles and checked the Noctalia service journal.
5. Confirmed the original `table expected, got boolean` error did not recur and the panel was not disabled.
6. Ran `git diff --check` and `.github/workflows/scripts/validate-plugins.py`; all 169 plugin manifests passed validation.

Journal output before the fix (sanitized; hostname, PID, and home path replaced):

```text
Sep 11 19:11:19 <host> noctalia[<pid>]: 19:11:19.407 [ERR] [luau] plugin icefish/phone-operate:main: call to 'onOpen' failed: [string "<state-dir>/plugins/materialized/community/phone-operate/panel.luau"]:106: invalid argument #1 to 'insert' (table expected, got boolean)
Sep 11 19:11:20 <host> noctalia[<pid>]: 19:11:20.635 [ERR] [luau] plugin icefish/phone-operate:main: call to 'state watch callback' failed: [string "<state-dir>/plugins/materialized/community/phone-operate/panel.luau"]:106: invalid argument #1 to 'insert' (table expected, got boolean)
Sep 11 19:11:20 <host> noctalia[<pid>]: 19:11:20.668 [WRN] [plugin-panel] plugin panel 'icefish/phone-operate:main' disabled after repeated timeouts
```

Journal output during the patched run (sanitized; hostname and PID replaced):

```text
2026-09-11T19:20:02+08:00 <host> noctalia[<pid>]: 19:20:02.072 [WRN] [plugin-bindings] plugin icefish/phone-operate:main: ui tree node is not a table
2026-09-11T19:20:05+08:00 <host> noctalia[<pid>]: 19:20:05.848 [WRN] [plugin-bindings] plugin icefish/phone-operate:main: ui tree node is not a table
2026-09-11T19:20:08+08:00 <host> noctalia[<pid>]: 19:20:08.845 [WRN] [plugin-bindings] plugin icefish/phone-operate:main: ui tree node is not a table
```

The following query returned no matches for the patched test window:

```sh
journalctl --user -u noctalia.service \
  --since '2026-09-11 19:19:58' --until '2026-09-11 19:20:09' \
  | rg "invalid argument #1|call to 'onOpen' failed|call to 'state watch callback' failed|plugin panel 'icefish/phone-operate:main' disabled"
```

The remaining `ui tree node is not a table` warnings predate this patch and are outside its scope.

## Screenshots / Videos

Not applicable. This change does not alter the UI; it fixes a Luau runtime error triggered while grouping an authorized ADB device. The before/after behavior is covered by the reproduction steps and Noctalia journal results above.

## Checklist

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.