### PR TITLE
feat(): add advanced mango display settings.

### DIFF
--- a/mango-displays/README.md
+++ b/mango-displays/README.md
@@ -32,10 +32,11 @@ type = "prponkshe/mango-displays:bar"
 ```
 
 Left-click the tile to open the panel, right-click to open `wdisplays`. The
-panel also opens over IPC:
+panels also open over IPC:
 
 ```sh
 noctalia msg panel-toggle prponkshe/mango-displays:panel
+noctalia msg panel-toggle prponkshe/mango-displays:advanced
 ```
 
 The panel carries three cards for the selected output - **Monitor** (picker plus
@@ -53,7 +54,7 @@ panel being open.
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `auto_save` | `bool` | `true` | Let the watcher write `monitorrule=` lines when the layout changes on its own, such as a drag in `wdisplays`. With this off, only the panel writes. |
-| `monitor_rules_path` | `string` | `~/.config/mango/monitors.conf` | The mango config the rules are written into. It has to be a file mango sources. |
+| `monitor_rules_path` | `string` | `~/.config/mango/monitors.conf` | The mango config the rules are written into. It has to be a file mango sources. If it contains other config, the panels ask before overwriting it with generated `monitorrule=` lines only. |
 | `glyph` | `glyph` | `device-desktop` | Bar tile icon. |
 
 ## IPC

--- a/mango-displays/README.md
+++ b/mango-displays/README.md
@@ -10,7 +10,7 @@ change lands and survives a reboot in one step.
 | Field | Value |
 | --- | --- |
 | ID | `prponkshe/mango-displays` |
-| Entries | Bar widget: `bar`; panel: `panel`; services: `watcher`, `mirror` |
+| Entries | Bar widget: `bar`; panels: `panel`, `advanced`; services: `watcher`, `mirror` |
 
 ## Requirements
 
@@ -40,11 +40,13 @@ noctalia msg panel-toggle prponkshe/mango-displays:panel
 
 The panel carries three cards for the selected output - **Monitor** (picker plus
 an on/off toggle), **Mode** (resolution and refresh rate) and **Scale** - and a
-**Mirror** card for the layout as a whole. There is no Apply button: picking a
-value writes the rules and reloads mango straight away, and the last thing that
-happened is reported along the bottom of the panel. With `auto_save` on, a
-change made anywhere else (a drag in `wdisplays`, a monitor unplugged) is
-written by the watcher without the panel being open.
+**Mirror** card for the layout as a whole. The settings button opens advanced
+`monitorrule` fields: rotation, VRR, custom modes, HDR metadata and ICC profile.
+There is no Apply button on the main cards: picking a value writes the rules and
+reloads mango straight away, and the last thing that happened is reported along
+the bottom of the panel. With `auto_save` on, a change made anywhere else (a
+drag in `wdisplays`, a monitor unplugged) is written by the watcher without the
+panel being open.
 
 ## Settings
 

--- a/mango-displays/advanced.luau
+++ b/mango-displays/advanced.luau
@@ -1,0 +1,229 @@
+--!nonstrict
+
+local layout = require("./layout.luau")
+local controls = require("./controls.luau")
+
+local TRANSFORMS = { "normal", "90", "180", "270", "flipped", "flipped-90", "flipped-180", "flipped-270" }
+local HDR_INPUTS = { "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum" }
+local DRAFT_FIELDS = { "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "icc" }
+
+local outputs = {}
+local selectedName = ""
+local status = ""
+local statusIsError = false
+local busy = false
+local drafts = {}
+local render
+
+local function tr(key, subst)
+  return noctalia.tr(key, subst)
+end
+
+local function selectedOutput()
+  for _, output in ipairs(outputs) do
+    if output.name == selectedName then
+      return output
+    end
+  end
+  return nil
+end
+
+local function draftKey(output, key)
+  return output.name .. ":" .. key
+end
+
+local function advancedValue(output, key)
+  local extra = type(output.ruleFields) == "table" and output.ruleFields or {}
+  return extra[key] or ""
+end
+
+local function syncDraft(output, key)
+  drafts[draftKey(output, key)] = advancedValue(output, key)
+end
+
+local function loadOutputs()
+  layout.query(function(found)
+    if found == nil then
+      outputs = {}
+      status = tr("status.query_failed")
+      statusIsError = true
+      render()
+      return
+    end
+
+    outputs = found
+    layout.attachRuleFields(outputs)
+    for _, output in ipairs(outputs) do
+      for _, key in ipairs(DRAFT_FIELDS) do
+        syncDraft(output, key)
+      end
+    end
+    if selectedOutput() == nil then
+      selectedName = outputs[1] and outputs[1].name or ""
+    end
+    render()
+  end)
+end
+
+local function save()
+  if layout.rulesPath() == nil then
+    busy = false
+    status = tr("status.no_profile_path")
+    statusIsError = true
+    render()
+    return
+  end
+
+  local ok, err = layout.save(outputs, function()
+    busy = false
+    status = tr("status.saved")
+    statusIsError = false
+    loadOutputs()
+  end)
+  if not ok then
+    busy = false
+    status = tr("status.save_failed", { error = tostring(err) })
+    statusIsError = true
+    render()
+  end
+end
+
+local function commit(output, changes)
+  if busy then
+    return
+  end
+  output.ruleFields = type(output.ruleFields) == "table" and output.ruleFields or {}
+  for key, value in pairs(changes) do
+    if key == "transform" then
+      output.transform = value
+    elseif key == "vrr" then
+      output.adaptiveSync = value == "1"
+    else
+      output.ruleFields[key] = value ~= "" and value or nil
+    end
+  end
+
+  busy = true
+  status = ""
+  render()
+  save()
+end
+
+local function boolControl(output, key, checked)
+  return controls.toggleRow(tr("field." .. key), checked, function(on)
+    commit(output, { [key] = on and "1" or "0" })
+  end, key, not busy)
+end
+
+local function inputControl(output, key)
+  local id = draftKey(output, key)
+  return controls.control(tr("field." .. key), ui.row({ gap = 8, align = "center" }, {
+    ui.input({
+      key = id,
+      value = drafts[id] or "",
+      placeholder = tr("advanced.unset"),
+      controlSize = "sm",
+      flexGrow = 1,
+      onChange = function(value)
+        drafts[id] = value or ""
+      end,
+    }),
+    ui.button({
+      text = tr("action.apply"),
+      controlSize = "sm",
+      enabled = not busy,
+      onClick = function()
+        commit(output, { [key] = noctalia.string.trim(drafts[id] or "") })
+      end,
+    }),
+  }))
+end
+
+local function transformControl(output)
+  return controls.control(tr("field.rr"), controls.chips(TRANSFORMS, output.transform or "normal", function(label)
+    commit(output, { transform = label })
+  end))
+end
+
+local function statusLine()
+  if status == "" then
+    return nil
+  end
+  return ui.label({
+    text = status,
+    fontSize = 11,
+    color = statusIsError and "error" or "on_surface_variant",
+    maxLines = 2,
+  })
+end
+
+render = function()
+  local output = selectedOutput()
+  local nodes = {
+    controls.header(tr("advanced.title"), {
+      ui.button({ glyph = "refresh", variant = "ghost", controlSize = "sm", tooltip = tr("rescan"), enabled = not busy, onClick = "onRefresh" }),
+      ui.button({ glyph = "x", variant = "ghost", controlSize = "sm", onClick = "onCloseClick" }),
+    }),
+  }
+
+  if output == nil then
+    table.insert(nodes, controls.message(status ~= "" and status or tr("status.no_outputs")))
+    panel.render(ui.column({ flexGrow = 1, gap = 12, align = "stretch" }, nodes))
+    return
+  end
+
+  local picture = { controls.heading(tr("advanced.picture")), transformControl(output) }
+  table.insert(picture, boolControl(output, "vrr", output.adaptiveSync == true))
+  table.insert(picture, boolControl(output, "custom", advancedValue(output, "custom") == "1"))
+
+  local hdr = {
+    controls.heading(tr("advanced.hdr")),
+    boolControl(output, "hdr", advancedValue(output, "hdr") == "1"),
+    boolControl(output, "hdr_force", advancedValue(output, "hdr_force") == "1"),
+  }
+  for _, key in ipairs(HDR_INPUTS) do
+    table.insert(hdr, inputControl(output, key))
+  end
+
+  local body = {
+    controls.tiles(outputs, selectedName, function(name)
+      selectedName = name
+      status = ""
+      render()
+    end),
+    controls.card(picture),
+    controls.card(hdr),
+    controls.card({ controls.heading(tr("advanced.color")), inputControl(output, "icc") }),
+  }
+  local note = statusLine()
+  if note ~= nil then
+    table.insert(body, note)
+  end
+  table.insert(nodes, ui.scroll({ flexGrow = 1, gap = 10 }, body))
+  panel.render(ui.column({ flexGrow = 1, gap = 12, align = "stretch" }, nodes))
+end
+
+function onOpen(_context)
+  status = ""
+  statusIsError = false
+  busy = false
+  render()
+  loadOutputs()
+end
+
+function onRefresh()
+  status = ""
+  statusIsError = false
+  loadOutputs()
+end
+
+function onCloseClick()
+  panel.close()
+end
+
+function onKey(chord, pressed)
+  if pressed and chord == "escape" then
+    panel.close()
+    noctalia.togglePanel("prponkshe/mango-displays:panel")
+  end
+end

--- a/mango-displays/advanced.luau
+++ b/mango-displays/advanced.luau
@@ -5,18 +5,26 @@ local controls = require("./controls.luau")
 
 local TRANSFORMS = { "normal", "90", "180", "270", "flipped", "flipped-90", "flipped-180", "flipped-270" }
 local HDR_INPUTS = { "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum" }
-local DRAFT_FIELDS = { "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "icc" }
+local MODE_INPUTS = { "width", "height", "refresh" }
+local DRAFT_FIELDS = { "width", "height", "refresh", "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "icc" }
 
 local outputs = {}
 local selectedName = ""
 local status = ""
 local statusIsError = false
 local busy = false
+local overwriteNeeded = false
 local drafts = {}
 local render
 
 local function tr(key, subst)
   return noctalia.tr(key, subst)
+end
+
+local function clearStatus()
+  status = ""
+  statusIsError = false
+  overwriteNeeded = false
 end
 
 local function selectedOutput()
@@ -37,8 +45,26 @@ local function advancedValue(output, key)
   return extra[key] or ""
 end
 
+local function modeValue(output, key)
+  local mode = output.currentMode
+  if mode == nil then
+    return ""
+  end
+  if key == "refresh" then
+    return tostring(layout.roundHz(mode.refresh))
+  end
+  return tostring(mode[key] or "")
+end
+
+local function draftValue(output, key)
+  if key == "width" or key == "height" or key == "refresh" then
+    return modeValue(output, key)
+  end
+  return advancedValue(output, key)
+end
+
 local function syncDraft(output, key)
-  drafts[draftKey(output, key)] = advancedValue(output, key)
+  drafts[draftKey(output, key)] = draftValue(output, key)
 end
 
 local function loadOutputs()
@@ -65,7 +91,7 @@ local function loadOutputs()
   end)
 end
 
-local function save()
+local function save(overwrite)
   if layout.rulesPath() == nil then
     busy = false
     status = tr("status.no_profile_path")
@@ -76,13 +102,15 @@ local function save()
 
   local ok, err = layout.save(outputs, function()
     busy = false
+    overwriteNeeded = false
     status = tr("status.saved")
     statusIsError = false
     loadOutputs()
-  end)
+  end, overwrite)
   if not ok then
     busy = false
-    status = tr("status.save_failed", { error = tostring(err) })
+    overwriteNeeded = err == layout.NON_MONITOR_RULES
+    status = overwriteNeeded and tr("status.overwrite_required") or tr("status.save_failed", { error = tostring(err) })
     statusIsError = true
     render()
   end
@@ -96,17 +124,37 @@ local function commit(output, changes)
   for key, value in pairs(changes) do
     if key == "transform" then
       output.transform = value
-    elseif key == "vrr" then
-      output.adaptiveSync = value == "1"
     else
       output.ruleFields[key] = value ~= "" and value or nil
     end
   end
 
   busy = true
+  overwriteNeeded = false
   status = ""
   render()
   save()
+end
+
+local function validCustomMode(width, height, refresh)
+  return width ~= nil and height ~= nil and refresh ~= nil
+    and width >= 1 and width <= 9999 and width % 1 == 0
+    and height >= 1 and height <= 9999 and height % 1 == 0
+    and refresh >= 0.001 and refresh <= 9999
+end
+
+local function commitCustomMode(output)
+  local width = tonumber(noctalia.string.trim(drafts[draftKey(output, "width")] or ""))
+  local height = tonumber(noctalia.string.trim(drafts[draftKey(output, "height")] or ""))
+  local refresh = tonumber(noctalia.string.trim(drafts[draftKey(output, "refresh")] or ""))
+  if not validCustomMode(width, height, refresh) then
+    status = tr("status.invalid_mode")
+    statusIsError = true
+    render()
+    return
+  end
+  output.currentMode = { width = width, height = height, refresh = refresh, current = true }
+  commit(output, { custom = "1" })
 end
 
 local function boolControl(output, key, checked)
@@ -115,25 +163,48 @@ local function boolControl(output, key, checked)
   end, key, not busy)
 end
 
-local function inputControl(output, key)
+local function validateInput(key, value)
+  if value == "" or key == "icc" then
+    return true
+  end
+  local number = tonumber(value)
+  return number ~= nil and number >= 0 and number <= 10000
+end
+
+local function draftInput(output, key)
   local id = draftKey(output, key)
+  return ui.input({
+    key = id,
+    value = drafts[id] or "",
+    placeholder = tr("advanced.unset"),
+    controlSize = "sm",
+    flexGrow = 1,
+    onChange = function(value)
+      drafts[id] = value or ""
+    end,
+  })
+end
+
+local function modeInput(output, key)
+  return controls.control(tr("field." .. key), draftInput(output, key))
+end
+
+local function inputControl(output, key)
   return controls.control(tr("field." .. key), ui.row({ gap = 8, align = "center" }, {
-    ui.input({
-      key = id,
-      value = drafts[id] or "",
-      placeholder = tr("advanced.unset"),
-      controlSize = "sm",
-      flexGrow = 1,
-      onChange = function(value)
-        drafts[id] = value or ""
-      end,
-    }),
+    draftInput(output, key),
     ui.button({
       text = tr("action.apply"),
       controlSize = "sm",
       enabled = not busy,
       onClick = function()
-        commit(output, { [key] = noctalia.string.trim(drafts[id] or "") })
+        local value = noctalia.string.trim(drafts[draftKey(output, key)] or "")
+        if not validateInput(key, value) then
+          status = tr("status.invalid_value", { field = tr("field." .. key) })
+          statusIsError = true
+          render()
+          return
+        end
+        commit(output, { [key] = value })
       end,
     }),
   }))
@@ -143,18 +214,6 @@ local function transformControl(output)
   return controls.control(tr("field.rr"), controls.chips(TRANSFORMS, output.transform or "normal", function(label)
     commit(output, { transform = label })
   end))
-end
-
-local function statusLine()
-  if status == "" then
-    return nil
-  end
-  return ui.label({
-    text = status,
-    fontSize = 11,
-    color = statusIsError and "error" or "on_surface_variant",
-    maxLines = 2,
-  })
 end
 
 render = function()
@@ -173,8 +232,19 @@ render = function()
   end
 
   local picture = { controls.heading(tr("advanced.picture")), transformControl(output) }
-  table.insert(picture, boolControl(output, "vrr", output.adaptiveSync == true))
+  table.insert(picture, boolControl(output, "vrr", advancedValue(output, "vrr") == "1"))
   table.insert(picture, boolControl(output, "custom", advancedValue(output, "custom") == "1"))
+  for _, key in ipairs(MODE_INPUTS) do
+    table.insert(picture, modeInput(output, key))
+  end
+  table.insert(picture, ui.button({
+    text = tr("action.apply_custom_mode"),
+    controlSize = "sm",
+    enabled = not busy,
+    onClick = function()
+      commitCustomMode(output)
+    end,
+  }))
 
   local hdr = {
     controls.heading(tr("advanced.hdr")),
@@ -195,7 +265,7 @@ render = function()
     controls.card(hdr),
     controls.card({ controls.heading(tr("advanced.color")), inputControl(output, "icc") }),
   }
-  local note = statusLine()
+  local note = controls.status(status, statusIsError, overwriteNeeded)
   if note ~= nil then
     table.insert(body, note)
   end
@@ -204,21 +274,36 @@ render = function()
 end
 
 function onOpen(_context)
-  status = ""
-  statusIsError = false
+  clearStatus()
   busy = false
   render()
   loadOutputs()
 end
 
 function onRefresh()
-  status = ""
-  statusIsError = false
+  clearStatus()
   loadOutputs()
 end
 
 function onCloseClick()
   panel.close()
+end
+
+function onCancelOverwrite()
+  overwriteNeeded = false
+  status = ""
+  busy = false
+  loadOutputs()
+end
+
+function onOverwrite()
+  if busy then
+    return
+  end
+  busy = true
+  status = ""
+  render()
+  save(true)
 end
 
 function onKey(chord, pressed)

--- a/mango-displays/controls.luau
+++ b/mango-displays/controls.luau
@@ -1,0 +1,125 @@
+--!nonstrict
+
+local M = {}
+
+M.PADDING = 16
+M.RADIUS = 14
+
+function M.card(children)
+  return ui.column({ gap = 14, padding = M.PADDING, radius = M.RADIUS, fill = "surface_variant" }, children)
+end
+
+function M.heading(text)
+  return ui.label({ text = text, fontSize = 15, fontWeight = "bold", flexGrow = 1 })
+end
+
+function M.control(caption, node, reading)
+  local head = { ui.label({ text = caption, fontSize = 13, fontWeight = "bold", flexGrow = 1 }) }
+  if reading ~= nil then
+    table.insert(head, ui.label({ text = reading, fontSize = 13, fontWeight = "bold", color = "primary" }))
+  end
+  return ui.column({ gap = 6 }, {
+    ui.row({ align = "center", gap = 8 }, head),
+    node,
+  })
+end
+
+function M.chips(labels, current, onPick)
+  local widest = 0
+  for _, label in ipairs(labels) do
+    widest = math.max(widest, #label)
+  end
+  local perRow = widest > 6 and 3 or 4
+
+  local rows, row = {}, {}
+  for _, label in ipairs(labels) do
+    if #row == perRow then
+      table.insert(rows, ui.row({ gap = 8 }, row))
+      row = {}
+    end
+    local picked = label == current
+    table.insert(row, ui.button({
+      key = "chip-" .. label,
+      text = label,
+      controlSize = "sm",
+      flexGrow = 1,
+      variant = picked and "primary" or "outline",
+      selected = picked,
+      onClick = function()
+        onPick(label)
+      end,
+    }))
+  end
+  if #row > 0 then
+    for _ = #row + 1, perRow do
+      table.insert(row, ui.spacer({ flexGrow = 1 }))
+    end
+    table.insert(rows, ui.row({ gap = 8 }, row))
+  end
+  return ui.column({ gap = 8 }, rows)
+end
+
+function M.toggleRow(caption, checked, onSet, key, enabled)
+  return ui.row({ align = "center", gap = 10 }, {
+    ui.label({ text = caption, fontSize = 13, fontWeight = "bold", flexGrow = 1 }),
+    ui.toggle({
+      key = key,
+      checked = checked,
+      enabled = enabled ~= false,
+      onChange = function(value)
+        onSet(value == "true")
+      end,
+    }),
+  })
+end
+
+function M.tiles(outputs, selectedName, onPick)
+  local tiles = {}
+  for _, entry in ipairs(outputs) do
+    local active = entry.name == selectedName
+    local name = entry.name
+    table.insert(tiles, ui.row({
+      key = "pick-" .. name,
+      gap = 6,
+      align = "center",
+      justify = "center",
+      paddingV = 9,
+      radius = M.RADIUS,
+      flexGrow = 1,
+      fill = active and "primary" or "surface_variant",
+      onClick = function()
+        onPick(name)
+      end,
+    }, {
+      ui.glyph({
+        name = entry.enabled and "device-desktop" or "device-desktop-off",
+        size = 15,
+        color = active and "on_primary" or "on_surface_variant",
+      }),
+      ui.label({
+        text = name,
+        fontSize = 12,
+        fontWeight = "medium",
+        color = active and "on_primary" or "on_surface",
+      }),
+    }))
+  end
+  return ui.row({ gap = 8 }, tiles)
+end
+
+function M.message(text)
+  return ui.column({ flexGrow = 1, gap = 10, align = "center", justify = "center" }, {
+    ui.glyph({ name = "device-desktop-off", size = 26, color = "on_surface_variant" }),
+    ui.label({ text = text, fontSize = 13, color = "on_surface_variant", textAlign = "center" }),
+  })
+end
+
+function M.header(title, buttons)
+  local children = { ui.label({ text = title, fontSize = 15, fontWeight = "semibold", color = "primary", flexGrow = 1 }) }
+  for _, button in ipairs(buttons) do
+    table.insert(children, button)
+  end
+  return ui.row({ align = "center", gap = 6 }, children)
+end
+
+return M

--- a/mango-displays/controls.luau
+++ b/mango-displays/controls.luau
@@ -107,6 +107,31 @@ function M.tiles(outputs, selectedName, onPick)
   return ui.row({ gap = 8 }, tiles)
 end
 
+function M.status(text, isError, overwriteNeeded)
+  if text == "" then
+    return nil
+  end
+  local row = {
+    ui.glyph({
+      name = isError and "alert-triangle" or "circle-check",
+      size = 14,
+      color = isError and "error" or "primary",
+    }),
+    ui.label({
+      text = text,
+      fontSize = 11,
+      color = isError and "error" or "on_surface_variant",
+      maxLines = 2,
+      flexGrow = 1,
+    }),
+  }
+  if overwriteNeeded then
+    table.insert(row, ui.button({ text = noctalia.tr("action.cancel"), variant = "outline", controlSize = "sm", onClick = "onCancelOverwrite" }))
+    table.insert(row, ui.button({ text = noctalia.tr("action.overwrite"), variant = "primary", controlSize = "sm", onClick = "onOverwrite" }))
+  end
+  return ui.row({ gap = 6, align = "center" }, row)
+end
+
 function M.message(text)
   return ui.column({ flexGrow = 1, gap = 10, align = "center", justify = "center" }, {
     ui.glyph({ name = "device-desktop-off", size = 26, color = "on_surface_variant" }),

--- a/mango-displays/layout.luau
+++ b/mango-displays/layout.luau
@@ -22,7 +22,7 @@ local TRANSFORMS = {
   ["flipped-180"] = 6,
   ["flipped-270"] = 7,
 }
-local ADVANCED_FIELDS = { "hdr", "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "hdr_force", "icc", "custom" }
+local ADVANCED_FIELDS = { "vrr", "hdr", "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "hdr_force", "icc", "custom" }
 local MANAGED_FIELDS = {
   name = true,
   make = true,
@@ -36,10 +36,11 @@ local MANAGED_FIELDS = {
   y = true,
   scale = true,
   rr = true,
-  vrr = true,
 }
 
 local M = {}
+
+M.NON_MONITOR_RULES = "non-monitorrule lines"
 
 function M.shellQuote(s)
   return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
@@ -193,7 +194,6 @@ local function ruleFor(output, originX, originY)
   table.insert(fields, "y:" .. (output.y - originY))
   table.insert(fields, string.format("scale:%.4f", output.scale))
   table.insert(fields, "rr:" .. (TRANSFORMS[output.transform] or 0))
-  table.insert(fields, "vrr:" .. (output.adaptiveSync and 1 or 0))
   appendAdvanced(fields, output)
   return "monitorrule=" .. table.concat(fields, ",")
 end
@@ -231,7 +231,7 @@ local function ruleKeyForOutput(output)
 end
 
 local function readRuleData(path)
-  local data = { lines = {}, fields = {} }
+  local data = { lines = {}, fields = {}, raw = nil, writable = true }
   if path == nil or not noctalia.fileExists(path) then
     return data
   end
@@ -239,21 +239,21 @@ local function readRuleData(path)
   if raw == nil then
     return data
   end
+  data.raw = raw
   for line in (raw .. "\n"):gmatch("(.-)\n") do
-    local fields = parseRule(line)
+    local trimmed = noctalia.string.trim(line)
+    local fields = parseRule(trimmed)
     if fields ~= nil then
       local key = keyForFields(fields)
       if key ~= "" then
         data.lines[key] = line
         data.fields[key] = fields
       end
+    elseif trimmed ~= "" and trimmed:sub(1, 1) ~= "#" then
+      data.writable = false
     end
   end
   return data
-end
-
-function M.readRuleFields()
-  return readRuleData(M.rulesPath()).fields
 end
 
 local function advancedFields(output, sections)
@@ -267,12 +267,8 @@ local function advancedFields(output, sections)
   return advanced
 end
 
-function M.advancedFields(output)
-  return advancedFields(output, M.readRuleFields())
-end
-
 function M.attachRuleFields(outputs)
-  local sections = M.readRuleFields()
+  local sections = readRuleData(M.rulesPath()).fields
   for _, output in ipairs(outputs) do
     output.ruleFields = advancedFields(output, sections)
   end
@@ -280,10 +276,14 @@ end
 
 -- Returns ok, error, changed. onApplied fires once mango has reloaded, so a
 -- caller can re-read state that the reload changed.
-function M.save(outputs, onApplied)
+function M.save(outputs, onApplied, overwrite)
   local path = M.rulesPath()
   if path == nil then
     return false, "no monitor rules path configured", false
+  end
+  local data = readRuleData(path)
+  if overwrite ~= true and not data.writable then
+    return false, M.NON_MONITOR_RULES, false
   end
 
   -- Rebase on the layout's top-left: XWayland maps clicks into a leading gap,
@@ -302,7 +302,6 @@ function M.save(outputs, onApplied)
     return false, "refusing to save a config with every monitor disabled", false
   end
 
-  local data = readRuleData(path)
   local rules = data.lines
   local sections = data.fields
   for _, output in ipairs(outputs) do
@@ -327,7 +326,7 @@ function M.save(outputs, onApplied)
   end
   local body = table.concat(lines, "\n") .. "\n"
 
-  if noctalia.fileExists(path) and noctalia.readFile(path) == body then
+  if data.raw == body then
     if onApplied ~= nil then
       onApplied()
     end

--- a/mango-displays/layout.luau
+++ b/mango-displays/layout.luau
@@ -22,6 +22,22 @@ local TRANSFORMS = {
   ["flipped-180"] = 6,
   ["flipped-270"] = 7,
 }
+local ADVANCED_FIELDS = { "hdr", "hdr_min_lum", "hdr_max_lum", "hdr_max_avg_lum", "hdr_force", "icc", "custom" }
+local MANAGED_FIELDS = {
+  name = true,
+  make = true,
+  model = true,
+  serial = true,
+  disable = true,
+  width = true,
+  height = true,
+  refresh = true,
+  x = true,
+  y = true,
+  scale = true,
+  rr = true,
+  vrr = true,
+}
 
 local M = {}
 
@@ -135,21 +151,33 @@ end
 
 -- ── monitorrule persistence ────────────────────────────────────────────────
 
-local function ruleFor(output, originX, originY)
-  local fields = {}
+local function appendAdvanced(fields, output)
+  local extra = type(output.ruleFields) == "table" and output.ruleFields or {}
+  for _, key in ipairs(ADVANCED_FIELDS) do
+    local value = extra[key]
+    if type(value) == "string" and value ~= "" then
+      table.insert(fields, key .. ":" .. value)
+    end
+  end
+end
+
+local function identityFields(output)
   if output.make ~= "" and output.model ~= "" then
-    table.insert(fields, "make:" .. output.make)
-    table.insert(fields, "model:" .. output.model)
+    local fields = { "make:" .. output.make, "model:" .. output.model }
     if output.serial ~= "" then
       table.insert(fields, "serial:" .. output.serial)
     end
-  else
-    -- name is a regex, so anchor it or eDP-1 would also match eDP-11.
-    table.insert(fields, "name:^" .. output.name .. "$")
+    return fields
   end
+  return { "name:^" .. output.name .. "$" } -- name is a regex.
+end
+
+local function ruleFor(output, originX, originY)
+  local fields = identityFields(output)
 
   if not output.enabled then
     table.insert(fields, "disable:1")
+    appendAdvanced(fields, output)
     return "monitorrule=" .. table.concat(fields, ",")
   end
 
@@ -166,29 +194,88 @@ local function ruleFor(output, originX, originY)
   table.insert(fields, string.format("scale:%.4f", output.scale))
   table.insert(fields, "rr:" .. (TRANSFORMS[output.transform] or 0))
   table.insert(fields, "vrr:" .. (output.adaptiveSync and 1 or 0))
+  appendAdvanced(fields, output)
   return "monitorrule=" .. table.concat(fields, ",")
 end
 
--- Rules are keyed on identity rather than grouped per output set, because that
--- is all mango offers. Re-read what is already there so a display that is not
--- plugged in right now keeps its rule.
-local function readRules(path)
-  local rules = {}
-  if not noctalia.fileExists(path) then
-    return rules
+local function parseRule(line)
+  local fields = {}
+  local body = line:match("^monitorrule=(.*)$")
+  if body == nil then
+    return nil
+  end
+  for item in body:gmatch("([^,]+)") do
+    local key, value = item:match("^([^:]+):(.*)$")
+    if key ~= nil then
+      fields[key] = value
+    end
+  end
+  return fields
+end
+
+local function keyForFields(fields)
+  local keys = {}
+  for _, key in ipairs({ "name", "make", "model", "serial" }) do
+    if fields[key] ~= nil then
+      table.insert(keys, key .. ":" .. fields[key])
+    end
+  end
+  table.sort(keys)
+  return table.concat(keys, ",")
+end
+
+local function ruleKeyForOutput(output)
+  local fields = identityFields(output)
+  table.sort(fields)
+  return table.concat(fields, ",")
+end
+
+local function readRuleData(path)
+  local data = { lines = {}, fields = {} }
+  if path == nil or not noctalia.fileExists(path) then
+    return data
   end
   local raw = noctalia.readFile(path)
   if raw == nil then
-    return rules
+    return data
   end
   for line in (raw .. "\n"):gmatch("(.-)\n") do
-    if line:match("^monitorrule=") then
-      -- Key on the identity fields so a rewrite replaces rather than duplicates.
-      local key = line:match("^monitorrule=(.-),disable:") or line:match("^monitorrule=(.*)$")
-      rules[key] = line
+    local fields = parseRule(line)
+    if fields ~= nil then
+      local key = keyForFields(fields)
+      if key ~= "" then
+        data.lines[key] = line
+        data.fields[key] = fields
+      end
     end
   end
-  return rules
+  return data
+end
+
+function M.readRuleFields()
+  return readRuleData(M.rulesPath()).fields
+end
+
+local function advancedFields(output, sections)
+  local fields = sections[ruleKeyForOutput(output)] or {}
+  local advanced = {}
+  for key, value in pairs(fields) do
+    if not MANAGED_FIELDS[key] then
+      advanced[key] = value
+    end
+  end
+  return advanced
+end
+
+function M.advancedFields(output)
+  return advancedFields(output, M.readRuleFields())
+end
+
+function M.attachRuleFields(outputs)
+  local sections = M.readRuleFields()
+  for _, output in ipairs(outputs) do
+    output.ruleFields = advancedFields(output, sections)
+  end
 end
 
 -- Returns ok, error, changed. onApplied fires once mango has reloaded, so a
@@ -215,12 +302,16 @@ function M.save(outputs, onApplied)
     return false, "refusing to save a config with every monitor disabled", false
   end
 
-  local rules = readRules(path)
+  local data = readRuleData(path)
+  local rules = data.lines
+  local sections = data.fields
   for _, output in ipairs(outputs) do
+    if output.ruleFields == nil then
+      output.ruleFields = advancedFields(output, sections)
+    end
     local rule = ruleFor(output, originX, originY)
     if rule ~= nil then
-      local key = rule:match("^monitorrule=(.-),disable:") or rule
-      rules[key] = rule
+      rules[keyForFields(parseRule(rule))] = rule
     end
   end
 

--- a/mango-displays/panel.luau
+++ b/mango-displays/panel.luau
@@ -8,6 +8,7 @@
 -- without anyone opening this panel.
 
 local layout = require("./layout.luau")
+local controls = require("./controls.luau")
 
 -- wlroots takes any positive scale, but fractional factors off this ladder
 -- produce blurry integer-scaled clients more often than they help.
@@ -24,6 +25,7 @@ local status = ""
 local statusIsError = false
 local mirrorErrorShown = false
 local busy = false
+local overwriteNeeded = false
 local mirrorRequestSerial = 0
 local mirrorFrom = ""
 local mirrorTo = ""
@@ -39,6 +41,12 @@ local render
 
 local function tr(key, subst)
   return noctalia.tr(key, subst)
+end
+
+local function clearStatus()
+  status = ""
+  statusIsError = false
+  overwriteNeeded = false
 end
 
 -- ── Model ──────────────────────────────────────────────────────────────────
@@ -173,6 +181,8 @@ local function loadOutputs(onLoaded)
     outputs = found
     if selectedOutput() == nil then
       selectOutput(outputs[1] and outputs[1].name or "")
+    else
+      adoptCurrent(selectedOutput())
     end
     syncMirrorPair()
     if onLoaded ~= nil then
@@ -182,7 +192,7 @@ local function loadOutputs(onLoaded)
   end)
 end
 
-local function persistCurrent()
+local function persistCurrent(overwrite)
   if layout.rulesPath() == nil then
     status = tr("status.no_profile_path")
     statusIsError = true
@@ -192,15 +202,18 @@ local function persistCurrent()
   end
   local ok, err = layout.save(outputs, function()
     busy = false
+    overwriteNeeded = false
     loadOutputs()
-  end)
+  end, overwrite)
   if not ok then
     busy = false
-    status = tr("status.save_failed", { error = tostring(err) })
+    overwriteNeeded = err == layout.NON_MONITOR_RULES
+    status = overwriteNeeded and tr("status.overwrite_required") or tr("status.save_failed", { error = tostring(err) })
     statusIsError = true
     render()
     return
   end
+  overwriteNeeded = false
   status = tr("status.saved")
   statusIsError = false
   render()
@@ -232,6 +245,7 @@ local function applyPending()
   end
 
   busy = true
+  overwriteNeeded = false
   status = ""
   render()
   persistCurrent()
@@ -253,6 +267,7 @@ local function setEnabled(name, on)
   end
 
   busy = true
+  overwriteNeeded = false
   status = ""
   render()
 
@@ -644,26 +659,6 @@ local function header()
   })
 end
 
-local function statusLine()
-  if status == "" then
-    return nil
-  end
-  return ui.row({ gap = 6, align = "center" }, {
-    ui.glyph({
-      name = statusIsError and "alert-triangle" or "circle-check",
-      size = 14,
-      color = statusIsError and "error" or "primary",
-    }),
-    ui.label({
-      text = status,
-      fontSize = 11,
-      color = statusIsError and "error" or "on_surface_variant",
-      maxLines = 2,
-      flexGrow = 1,
-    }),
-  })
-end
-
 local function message(glyph, text, color)
   return ui.column({ flexGrow = 1, gap = 12, align = "center", justify = "center" }, {
     ui.glyph({ name = glyph, size = 48, color = "on_surface_variant" }),
@@ -695,7 +690,7 @@ render = function()
   -- The header and the status line stay pinned and the cards scroll, so the
   -- last thing that happened is readable whatever the content does.
   local nodes = { header(), ui.scroll({ flexGrow = 1, gap = 12 }, cards(output)) }
-  local note = statusLine()
+  local note = controls.status(status, statusIsError, overwriteNeeded)
   if note ~= nil then
     table.insert(nodes, note)
   end
@@ -713,8 +708,7 @@ end)
 
 function onOpen(_context)
   opened = true
-  status = ""
-  statusIsError = false
+  clearStatus()
   mirrorErrorShown = false
   busy = false
   adoptMirrorStatus(noctalia.state.get("mirror_status"))
@@ -727,14 +721,30 @@ function onClose()
 end
 
 function onRescan()
-  status = ""
-  statusIsError = false
+  clearStatus()
   selectedName = ""
   loadOutputs()
 end
 
 function onCloseClick()
   panel.close()
+end
+
+function onCancelOverwrite()
+  overwriteNeeded = false
+  status = ""
+  busy = false
+  loadOutputs()
+end
+
+function onOverwrite()
+  if busy then
+    return
+  end
+  busy = true
+  status = ""
+  render()
+  persistCurrent(true)
 end
 
 function onAdvanced()

--- a/mango-displays/panel.luau
+++ b/mango-displays/panel.luau
@@ -638,6 +638,7 @@ end
 local function header()
   return ui.row({ align = "center", justify = "space_between", gap = 8 }, {
     ui.label({ text = tr("title"), fontSize = 18, fontWeight = "bold", color = "primary", flexGrow = 1 }),
+    ui.button({ glyph = "settings", variant = "outline", controlSize = "sm", tooltip = tr("advanced.title"), enabled = not busy, onClick = "onAdvanced" }),
     ui.button({ glyph = "refresh", variant = "outline", controlSize = "sm", tooltip = tr("rescan"), enabled = not busy, onClick = "onRescan" }),
     ui.button({ glyph = "x", variant = "outline", controlSize = "sm", onClick = "onCloseClick" }),
   })
@@ -734,4 +735,9 @@ end
 
 function onCloseClick()
   panel.close()
+end
+
+function onAdvanced()
+  panel.close()
+  noctalia.togglePanel("prponkshe/mango-displays:advanced")
 end

--- a/mango-displays/plugin.toml
+++ b/mango-displays/plugin.toml
@@ -3,7 +3,7 @@
 
 id = "prponkshe/mango-displays"
 name = "Mango Displays"
-version = "1.2.0"
+version = "1.3.0"
 plugin_api = 22
 author = "prponkshe"
 license = "MIT"
@@ -34,6 +34,17 @@ height = 580
 placement = "attached"
 position = "auto"
 open_near_click = true
+
+[[panel]]
+id = "advanced"
+entry = "advanced.luau"
+width = 470
+height = 600
+placement = "floating"
+position = "center"
+keyboard_focus = "exclusive"
+dismiss_on_outside_click = true
+capture_keys = ["escape"]
 
 [[service]]
 id = "watcher"

--- a/mango-displays/translations/en.json
+++ b/mango-displays/translations/en.json
@@ -18,7 +18,9 @@
     "hdr_min_lum": "Minimum luminance",
     "icc": "ICC profile",
     "rr": "Rotation",
-    "vrr": "Variable refresh rate"
+    "vrr": "Variable refresh rate",
+    "width": "Width",
+    "height": "Height"
   },
   "mirror": {
     "explain": "{source} is copied onto {destination}",
@@ -71,14 +73,20 @@
     "query_failed": "wlr-randr could not list outputs.",
     "save_failed": "Applied, but not saved: {error}",
     "saved": "Applied and saved to mango.",
-    "toggle_failed": "mango could not toggle the monitor."
+    "toggle_failed": "mango could not toggle the monitor.",
+    "invalid_mode": "Custom mode must be width 1-9999, height 1-9999 and refresh 0.001-9999.",
+    "invalid_value": "{field} must be a number from 0 to 10000.",
+    "overwrite_required": "Monitor rules file contains other config. Overwrite it with generated monitor rules only?"
   },
   "title": "Display",
   "widget": {
     "tooltip": "Display (right-click to arrange)"
   },
   "action": {
-    "apply": "Apply"
+    "apply": "Apply",
+    "apply_custom_mode": "Apply custom mode",
+    "cancel": "No",
+    "overwrite": "Overwrite"
   },
   "advanced": {
     "color": "Color profile",

--- a/mango-displays/translations/en.json
+++ b/mango-displays/translations/en.json
@@ -9,7 +9,16 @@
     "enabled": "On",
     "last_output": "Last output",
     "refresh": "Refresh rate",
-    "resolution": "Resolution"
+    "resolution": "Resolution",
+    "custom": "Custom mode",
+    "hdr": "HDR",
+    "hdr_force": "Force HDR",
+    "hdr_max_avg_lum": "Max average luminance",
+    "hdr_max_lum": "Peak luminance",
+    "hdr_min_lum": "Minimum luminance",
+    "icc": "ICC profile",
+    "rr": "Rotation",
+    "vrr": "Variable refresh rate"
   },
   "mirror": {
     "explain": "{source} is copied onto {destination}",
@@ -67,5 +76,15 @@
   "title": "Display",
   "widget": {
     "tooltip": "Display (right-click to arrange)"
+  },
+  "action": {
+    "apply": "Apply"
+  },
+  "advanced": {
+    "color": "Color profile",
+    "hdr": "HDR",
+    "picture": "Picture",
+    "title": "Advanced display",
+    "unset": "Unset"
   }
 }


### PR DESCRIPTION
<!-- noctalia-pr-template:v1 -->

## Plugin

- **Id:** `prponkshe/mango-displays`
- [ ] New plugin
- [x] Update to an existing plugin (version bumped in `plugin.toml`)

## What it does

Adds an advanced settings panel to Mango Displays, with Mango `monitorrule` options that were not exposed in the main panel: rotation, VRR, custom mode, HDR, HDR metadata, HDR force and ICC profile.

The normal panel and watcher now preserve these advanced `monitorrule` fields when rewriting monitor rules.

Closes #711

## External dependencies

- `mmsg`: applies Mango monitor changes, reloads config, watches monitor changes and controls the mirror window.
- `wlr-randr`: lists outputs, modes and monitor identity metadata.
- `wdisplays`: used for monitor arrangement from the widget right-click flow.
- `wl-mirror`: used by the Mirror card and mirror service.

## Testing

Opened the Mango Displays panel and advanced panel, switched between connected outputs, changed advanced monitorrule values, verified the generated monitors config preserves advanced fields after normal panel writes and watcher rewrites, and verified Escape returns from the advanced panel to the main panel.

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: MangoWC
- **Noctalia version tested against:** v5.0.1
- **Plugin API level:** 22

## Screenshots / Videos
<img width="617" height="788" alt="image" src="https://github.com/user-attachments/assets/8a0f850f-4ec8-4dcd-b0a9-7fe3458b8a75" />


## Checklist
**Ready-for-review requirement:** Every box in this section must be checked. If any statement is not true, keep the
pull request as Draft. An explanation does not replace a required check.

- [x] The directory name matches the part of `id` after the `/` in `plugin.toml` exactly.
- [x] It ships `plugin.toml`, `README.md`, `thumbnail.webp`, and `translations/en.json`.
- [x] `README.md` follows the
      [README template](https://github.com/noctalia-dev/community-plugins/blob/main/README_TEMPLATE.md), documents
      every entry id and dependency, and includes exact panel IPC commands and launcher prefixes where applicable.
- [x] `thumbnail.webp` is present and relevant; for a new plugin I created it with the [thumbnail generator](https://assets.noctalia.dev/plugins/thumbnail-generator.html), and for an update I regenerated it with the generator if the visual identity or user-facing appearance changed.
- [x] `version` follows semver and is bumped in this PR; `plugin_api` is the oldest API level this plugin requires.
- [x] Every non-English translation in this PR uses a locale supported by Noctalia core, and I can read, write, and
      understand that language well enough to review and maintain it (no unreviewed machine/LLM translations).
- [x] I did not edit `catalog.toml`; CI generates it.
- [x] This PR touches exactly one plugin directory.

## Code review attestation

Plugins run as trusted, unsandboxed Luau in the user's session. Confirm:
**Ready-for-review requirement:** Every attestation below must be checked.

- [x] The code is readable and not obfuscated, minified, or generated.
- [x] It does not download and execute remote code.
- [x] Every network call, filesystem write, and spawned process is something the description above accounts for.
- [x] I have the right to publish this code under the `license` declared in `plugin.toml`.